### PR TITLE
Conditionally set the STD_CELL_LIBRARY

### DIFF
--- a/configuration/general.tcl
+++ b/configuration/general.tcl
@@ -14,7 +14,11 @@
 
 # default pdk
 set ::env(PDK) "sky130A"
-set ::env(STD_CELL_LIBRARY) "sky130_fd_sc_hd"
+if { ! [info exists ::env(STD_CELL_LIBRARY)] } {
+    set ::env(STD_CELL_LIBRARY) "sky130_fd_sc_hd"
+} else {
+    puts_info "Standard Cell Library: $::env(STD_CELL_LIBRARY)"
+}
 set ::env(USE_GPIO_PADS) 0
 
 # Flow control defaults


### PR DESCRIPTION
Fixes issue #279 

> Describe the bug
> If you set STD_CELL_LIBRARY, it is supposed to use that library. However, it will always use sky130_fd_sc_hd.
> 
> To Reproduce
> Steps to reproduce the behavior:
> 
> export STD_CELL_LIBRARY="sky130_fd_sc_ls"
> make pdk
> make mount
> echo $STD_CELL_LIBRARY
> export STD_CELL_LIBRARY="sky130_fd_sc_ls"
> ./flow.tcl -design spm
> Expected behavior
> It should create a design using sky130_fd_sc_ls, but instead it tries to use sky130_fd_sc_hd.
> 
> Screenshots
> `ash-4.2$ ./flow.tcl -design spm
> [INFO]:
> ___ ____ ___ ____ _ ____ ____ ___
> / \ | \ / ]| \ | | / || \ / ]
> | || o ) [ | _ || | | o || _ | / [
> | O || / ]| | || |_ | || | || ]
> | || | | [ | | || || _ || | || [_
> _/ || ||||||||||||||_____|
> 
> [INFO]: Version: v0.12-1-ga95f56d
> [INFO]: Running non-interactively
> [INFO]: Using design configuration at /openLANE_flow/designs/spm/config.tcl
> sky130_fd_sc_ls
> /openLANE_flow/configuration/checkers.tcl /openLANE_flow/configuration/routing.tcl /openLANE_flow/configuration/floorplan.tcl /openLANE_flow/configuration/synthesis.tcl /openLANE_flow/configuration/lvs.tcl /openLANE_flow/configuration/placement.tcl /openLANE_flow/configuration/general.tcl /openLANE_flow/configuration/cts.tcl
> sky130_fd_sc_hd
> [INFO]: Sourcing Configurations from /openLANE_flow/designs/spm/config.tcl
> [INFO]: PDKs root directory: /home/mrg/openlane/pdks
> [INFO]: PDK: sky130A
> [INFO]: Setting PDKPATH to /home/mrg/openlane/pdks/sky130A
> [INFO]: Standard Cell Library: sky130_fd_sc_hd
> [INFO]: Sourcing Configurations from /openLANE_flow/designs/spm/config.tcl
> [INFO]: Current run directory is /openLANE_flow/designs/spm/runs/05-04_18-31
> [INFO]: Preparing LEF Files
> [INFO]: Extracting the number of available metal layers from /home/mrg/openlane/pdks/sky130A/libs.ref/sky130_fd_sc_hd/techlef/sky130_fd_sc_hd.tlef
> [ERROR]: during executing: "python3 /openLANE_flow/scripts/extract_metal_layers.py -t /home/mrg/openlane/pdks/sky130A/libs.ref/sky130_fd_sc_hd/techlef/sky130_fd_sc_hd.tlef -o /openLANE_flow/designs/spm/runs/05-04_18-31/tmp/met_layers_list.txt"
> [ERROR]: Exit code: 1
> [ERROR]: Last 10 lines:
> Traceback (most recent call last):
> File "/openLANE_flow/scripts/extract_metal_layers.py", line 37, in 
> with open(techlef_name, "r") as f:
> FileNotFoundError: [Errno 2] No such file or directory: '/home/mrg/openlane/pdks/sky130A/libs.ref/sky130_fd_sc_hd/techlef/sky130_fd_sc_hd.tlef'
> `
> 
> Desktop (please complete the following information):
> 
> OS: Ubuntu 20.04
> Openlane Version 0.12-1-ga95f56d
> open_pdks Version: b9ffc1fd1cfc26cbca85a61c287ac799721f6e6a
> skywater-pdk Version: db2e06709dc3d876aa6b74a5f3893fa5f1bc2a6e