### PR TITLE
Add include paths when processing top-level and blackbox verilog files

### DIFF
--- a/scripts/synth.tcl
+++ b/scripts/synth.tcl
@@ -30,6 +30,14 @@ if { [info exists ::env(SYNTH_DEFINES) ] } {
 	}
 }
 
+set vIdirsArgs ""
+if {[info exist ::env(VERILOG_INCLUDE_DIRS)]} {
+	foreach dir $::env(VERILOG_INCLUDE_DIRS) {
+		lappend vIdirsArgs "-I$dir"
+	}
+	set vIdirsArgs [join $vIdirsArgs]
+}
+
 if { $::env(SYNTH_READ_BLACKBOX_LIB) } {
 	log "Reading $::env(LIB_SYNTH_COMPLETE_NO_PG) as a blackbox"
 	foreach lib $::env(LIB_SYNTH_COMPLETE_NO_PG) {
@@ -45,7 +53,7 @@ if { [info exists ::env(EXTRA_LIBS) ] } {
 
 if { [info exists ::env(VERILOG_FILES_BLACKBOX)] } {
 	foreach verilog_file $::env(VERILOG_FILES_BLACKBOX) {
-		read_verilog -sv -lib $verilog_file
+		read_verilog -sv -lib {*}$vIdirsArgs $verilog_file
 	}
 }
 
@@ -195,14 +203,6 @@ if { !($adder_type in [list "YOSYS" "FA" "RCA" "CSA"]) } {
 	log -stderr "\[ERROR] Misformatted SYNTH_ADDER_TYPE (\"$::env(SYNTH_ADDER_TYPE)\")."
 	log -stderr "\[ERROR] Correct format is \"YOSYS|FA|RCA|CSA\"."
 	exit 1
-}
-
-set vIdirsArgs ""
-if {[info exist ::env(VERILOG_INCLUDE_DIRS)]} {
-	foreach dir $::env(VERILOG_INCLUDE_DIRS) {
-		lappend vIdirsArgs "-I$dir"
-	}
-	set vIdirsArgs [join $vIdirsArgs]
 }
 
 for { set i 0 } { $i < [llength $::env(VERILOG_FILES)] } { incr i } {

--- a/scripts/synth_top.tcl
+++ b/scripts/synth_top.tcl
@@ -42,15 +42,23 @@ if { [info exists ::env(SYNTH_DEFINES) ] } {
 	}
 }
 
+set vIdirsArgs ""
+if {[info exist ::env(VERILOG_INCLUDE_DIRS)]} {
+	foreach dir $::env(VERILOG_INCLUDE_DIRS) {
+		lappend vIdirsArgs "-I$dir"
+	}
+	set vIdirsArgs [join $vIdirsArgs]
+}
+
 if { [info exists ::env(VERILOG_FILES_BLACKBOX)] } {
 	foreach verilog_file $::env(VERILOG_FILES_BLACKBOX) {
-		read_verilog -lib $verilog_file
+		read_verilog -lib {*}$vIdirsArgs $verilog_file
 	}
 }
 
 
 for { set i 0 } { $i < [llength $::env(VERILOG_FILES)] } { incr i } {
-  read_verilog  [lindex $::env(VERILOG_FILES) $i]
+  read_verilog {*}$vIdirsArgs [lindex $::env(VERILOG_FILES) $i]
 }
 
 select -module $vtop


### PR DESCRIPTION
Some of the IPs in my design define ports using macros declared inside include files. For example:

```
`include "wishbone_tag_macros.svh"
`include "wishbone_amo_defines.svh"
  
module fwrisc_rv32imca_wb #(
		parameter VENDORID 	= 0,
		parameter ARCHID 	= 0,
		parameter IMPID 	= 0
		) (
		input				clock,
		input				reset,
		input[31:0]			hartid,
		`WB_INITIATOR_TAG_PORT( , 32, 32, 1, 1, 4),
		input				irq
		);
```
This PR passes include paths to the processing of black-box and top-level verilog files, allowing these included files to be found.

Signed-off-by: Matthew Ballance <matt.ballance@gmail.com>