### PR TITLE
Patch for save_state function: crash due to environment variables wit…

### DIFF
--- a/scripts/tcl_commands/all.tcl
+++ b/scripts/tcl_commands/all.tcl
@@ -22,7 +22,7 @@ proc save_state {args} {
     set_log ::env(PDK_ROOT) $::env(PDK_ROOT) $::env(GLB_CFG_FILE) 1
     foreach index [lsort [array names ::env]] {
         if { $index != "INIT_ENV_VAR_ARRAY" && $index != "PS1" } {
-            set_log ::env($index) $::env($index) $::env(GLB_CFG_FILE) 1
+            set_log ::env($index) [string map {\" \\\"} $::env($index)] $::env(GLB_CFG_FILE) 1
         }
     }
 }


### PR DESCRIPTION
…h double quotes

'save_state' function crashes when trying to save environment variables that contain double quotes

Example definition (.bashrc) that causes a crash:

function vcs() { command vcs -full64 "$@"; }; export -f vcs

Fix for issue: https://github.com/The-OpenROAD-Project/OpenLane/issues/493