### PR TITLE
Enable using different std cell library when doing resizer optimizations

### DIFF
--- a/configuration/README.md
+++ b/configuration/README.md
@@ -185,6 +185,7 @@ These variables are optional that can be specified in the design configuration f
 |---------------|---------------------------------------------------------------|
 | `PDK` | Specifies the process design kit (PDK). <br> (Default: `sky130A` )|
 | `STD_CELL_LIBRARY` | Specifies the standard cell library to be used under the specified PDK. <br> (Default: `sky130_fd_sc_hd` )|
+| `STD_CELL_LIBRARY_OPT` | Specifies the standard cell library to be used during resizer optimizations. <br> (Default: `$STD_CELL_LIBRARY` )|
 | `PDK_ROOT` | Specifies the folder path of the PDK. It searches for a `config.tcl` in `$PDK_ROOT/$PDK/libs.tech/openlane/` directory and at least have one standard cell library config defined in `$PDK_ROOT/$PDK/libs.tech/openlane/$STD_CELL_LIBRARY`. |
 | `CELL_PAD` | Cell padding; increases the width of cells. <br> (Default: `4` microns -- 4 sites)|
 | `DIODE_PADDING` | Diode cell padding; increases the width of diode cells during placement checks. <br> (Default: `2` microns -- 2 sites)|

--- a/dependencies/tool_metadata.yml
+++ b/dependencies/tool_metadata.yml
@@ -74,7 +74,7 @@
   in_install: false
 - name: open_pdks
   repo: https://github.com/rtimothyedwards/open_pdks
-  commit: 1d93a6bd9d6e481acfdf88f26aa3bb0600303d98
+  commit: de95d784746c0a727a3e66765c76c605c5512179
   build: ''
   in_install: false
   in_container: false

--- a/scripts/tcl_commands/all.tcl
+++ b/scripts/tcl_commands/all.tcl
@@ -88,6 +88,12 @@ proc prep_lefs {args} {
         try_catch $::env(SCRIPTS_DIR)/mergeLef.py -i $::env(MERGED_LEF_UNPADDED) {*}$::env(EXTRA_LEFS) -o $::env(MERGED_LEF_UNPADDED) |& tee $::env(TERMINAL_OUTPUT)
         puts_info "Merging the following extra LEFs: $::env(EXTRA_LEFS)"
     }
+    
+    # merge optimization library lef if it is different from the STD_CELL_LIBRARY
+    if { [info exist ::env(STD_CELL_LIBRARY_OPT)] && $::env(STD_CELL_LIBRARY_OPT) != $::env(STD_CELL_LIBRARY) } {
+        try_catch $::env(SCRIPTS_DIR)/mergeLef.py -i $::env(MERGED_LEF_UNPADDED) $::env(TECH_LEF_OPT) {*}$::env(CELLS_LEF_OPT) -o $::env(MERGED_LEF_UNPADDED) |& tee $::env(TERMINAL_OUTPUT) 
+        puts_info "Merging the optimization library LEFs: $::env(TECH_LEF_OPT) $::env(CELLS_LEF_OPT)"
+    }
 
     file copy -force $::env(CELLS_LEF_UNPADDED) $::env(TMP_DIR)/merged.lef
     set ::env(CELLS_LEF) $::env(TMP_DIR)/merged.lef
@@ -117,6 +123,9 @@ proc gen_exclude_list {args} {
     puts_info "Generating Exclude List..."
     set options {
         {-lib required}
+        {-drc_exclude_list optional}
+        {-synth_exclude_list optional}
+        {-output optional}
     }
     set flags {
         -drc_exclude_only
@@ -124,32 +133,34 @@ proc gen_exclude_list {args} {
     }
     parse_key_args "gen_exclude_list" args arg_values $options flags_map $flags
 
-    # Set if unset for the two env vars:
-    if {![info exists ::env(NO_SYNTH_CELL_LIST)]} {
-        set ::env(NO_SYNTH_CELL_LIST) $::env(PDK_ROOT)/$::env(PDK)/libs.tech/openlane/$::env(STD_CELL_LIBRARY)/no_synth.cells
-    }
-
-    if {![info exists ::env(DRC_EXCLUDE_CELL_LIST)]} {
-        set ::env(DRC_EXCLUDE_CELL_LIST) $::env(PDK_ROOT)/$::env(PDK)/libs.tech/openlane/$::env(STD_CELL_LIBRARY)/drc_exclude.cells
-    }
+    set_if_unset arg_values(-drc_exclude_list) $::env(DRC_EXCLUDE_CELL_LIST)
+    set_if_unset arg_values(-synth_exclude_list) $::env(NO_SYNTH_CELL_LIST) 
+    set_if_unset arg_values(-output) $arg_values(-lib).exclude.list 
 
     # Copy the drc exclude list into the run directory, if it exists.
-    if { [file exists $::env(DRC_EXCLUDE_CELL_LIST)] } {
-        file copy -force $::env(DRC_EXCLUDE_CELL_LIST) $arg_values(-lib).exclude.list
+    foreach list_file $arg_values(-drc_exclude_list) {
+        puts $list_file
+        set out  [open $arg_values(-output) a]
+        if { [file exists $list_file] } {
+            set in [open $list_file]
+            fcopy $in $out
+            close $in 
+        }
+        close $out 
     }
-
+   
     # If you're not told to only use the drc exclude list, and if the no_synth.cells exists, merge the two lists
-    if { (![info exists flags_map(-drc_exclude_only)]) && [file exists $::env(NO_SYNTH_CELL_LIST)] } {
-        set out [open $arg_values(-lib).exclude.list a]
-        set in [open $::env(NO_SYNTH_CELL_LIST)]
+    if { (![info exists flags_map(-drc_exclude_only)]) && [file exists $arg_values(-synth_exclude_list)] } {
+        set out [open $arg_values(-output) a]
+        set in [open $arg_values(-synth_exclude_list)]
         fcopy $in $out
         close $in
         close $out
     }
 
-    if { [file exists $arg_values(-lib).exclude.list] && [info exists flags_map(-create_dont_use_list)] } {
+    if { [file exists $arg_values(-output)] && [info exists flags_map(-create_dont_use_list)] } {
         puts_info "Creating ::env(DONT_USE_CELLS)..."
-        set fp [open "$arg_values(-lib).exclude.list" r]
+        set fp [open "$arg_values(-output)" r]
         set x [read $fp]
         set y [split $x]
         set ::env(DONT_USE_CELLS) [join $y " "]
@@ -340,6 +351,12 @@ proc prep {args} {
         puts_info "Standard Cell Library: $::env(STD_CELL_LIBRARY)"
     }
 
+    if { ! [info exists ::env(STD_CELL_LIBRARY_OPT)] } {
+        set ::env(STD_CELL_LIBRARY_OPT) $::env(STD_CELL_LIBRARY)
+        puts_info "Optimization Standard Cell Library is set to: $::env(STD_CELL_LIBRARY_OPT)"
+    } else {
+        puts_info "Optimization Standard Cell Library: $::env(STD_CELL_LIBRARY_OPT)"
+    }
 
     # source PDK and SCL specific configurations
     set pdk_config $::env(PDK_ROOT)/$::env(PDK)/libs.tech/openlane/config.tcl

--- a/scripts/tcl_commands/cvc.tcl
+++ b/scripts/tcl_commands/cvc.tcl
@@ -61,11 +61,24 @@ BEGIN {  # Print power and standard_input definitions
 	    # TODO: Remove in later versions
 	    if { ! [info exists ::env(STD_CELL_LIBRARY_CDL)] } {
                 set ::env(STD_CELL_LIBRARY_CDL) $::env(PDK_ROOT)/$::env(PDK)/libs.ref/$::env(STD_CELL_LIBRARY)/cdl/$::env(STD_CELL_LIBRARY).cdl
-            }
+        }
+        
+        # merge cdl views of the optimization library and the base library if they are different
+        if { $::env(STD_CELL_LIBRARY_OPT) != $::env(STD_CELL_LIBRARY)} {
+            set lib_cdl $::env(TMP_DIR)/cvc/merged.cdl
+            file copy -force $::env(STD_CELL_LIBRARY_CDL) $lib_cdl
+            set out [open $lib_cdl a]
+            set in [open $::env(STD_CELL_LIBRARY_OPT_CDL)]
+            fcopy $in $out
+            close $in
+            close $out
+        } else {
+            set lib_cdl $::env(STD_CELL_LIBRARY_CDL)
+        }
             # Create power file
             try_catch awk $cvc_power_awk $::env(CURRENT_NETLIST) > $::env(cvc_result_file_tag).power
             # Create cdl file by combining cdl library with lef spice
-	    try_catch awk $cvc_cdl_awk $::env(STD_CELL_LIBRARY_CDL) $::env(magic_result_file_tag).lef.spice \
+	    try_catch awk $cvc_cdl_awk $lib_cdl $::env(magic_result_file_tag).lef.spice \
                 > $::env(cvc_result_file_tag).cdl
             try_catch cvc $::env(SCRIPTS_DIR)/cvc/$::env(PDK)/cvcrc.$::env(PDK) \
                 |& tee $::env(TERMINAL_OUTPUT) [index_file $::env(cvc_log_file_tag)_screen.log]

--- a/scripts/tcl_commands/klayout.tcl
+++ b/scripts/tcl_commands/klayout.tcl
@@ -23,7 +23,12 @@ proc run_klayout {args} {
 			if {  [info exist ::env(EXTRA_GDS_FILES)] } {
 				set gds_files_in $::env(EXTRA_GDS_FILES)
 			}
-			try_catch bash $::env(SCRIPTS_DIR)/klayout/def2gds.sh $::env(KLAYOUT_TECH) $::env(CURRENT_DEF) $::env(DESIGN_NAME) $::env(klayout_result_file_tag).gds "$::env(GDS_FILES) $gds_files_in" |& tee $::env(TERMINAL_OUTPUT) [index_file $::env(klayout_log_file_tag).log]
+			if { $::env(STD_CELL_LIBRARY_OPT) != $::env(STD_CELL_LIBRARY) } {
+				set cells_gds "$::env(GDS_FILES) $::env(GDS_FILES_OPT)"
+			} else {
+				set cells_gds $::env(GDS_FILES)
+			}
+			try_catch bash $::env(SCRIPTS_DIR)/klayout/def2gds.sh $::env(KLAYOUT_TECH) $::env(CURRENT_DEF) $::env(DESIGN_NAME) $::env(klayout_result_file_tag).gds "$cells_gds $gds_files_in" |& tee $::env(TERMINAL_OUTPUT) [index_file $::env(klayout_log_file_tag).log]
 			if {[info exists ::env(KLAYOUT_PROPERTIES)]} {
 				file copy -force $::env(KLAYOUT_PROPERTIES) $::env(klayout_result_file_tag).lyp
 			} else {

--- a/scripts/tcl_commands/placement.tcl
+++ b/scripts/tcl_commands/placement.tcl
@@ -171,7 +171,12 @@ proc run_resizer_timing {args} {
             }
         } 
         if { ! [info exists ::env(DONT_USE_CELLS)] } {
-            gen_exclude_list -lib resizer_timing_opt -drc_exclude_list "$::env(DRC_EXCLUDE_CELL_LIST_OPT) $::env(DRC_EXCLUDE_CELL_LIST)" -output $::env(TMP_DIR)/resizer_timing_opt.exclude.list -drc_exclude_only -create_dont_use_list
+            if { $::env(STD_CELL_LIBRARY_OPT) != $::env(STD_CELL_LIBRARY) } {
+                set drc_exclude_list "$::env(DRC_EXCLUDE_CELL_LIST) $::env(DRC_EXCLUDE_CELL_LIST_OPT)"
+            } else {
+                set drc_exclude_list "$::env(DRC_EXCLUDE_CELL_LIST)"
+            }
+            gen_exclude_list -lib resizer_timing_opt -drc_exclude_list $drc_exclude_list -output $::env(TMP_DIR)/resizer_timing_opt.exclude.list -drc_exclude_only -create_dont_use_list
         }
         set ::env(SAVE_DEF) [index_file $::env(resizer_tmp_file_tag)_timing.def 0]
         try_catch $::env(OPENROAD_BIN) -exit $::env(SCRIPTS_DIR)/openroad/or_resizer_timing.tcl |& tee $::env(TERMINAL_OUTPUT) [index_file $::env(resizer_log_file_tag)_timing.log 0]
@@ -214,7 +219,12 @@ proc run_resizer_design {args} {
             }
         } 
         if { ! [info exists ::env(DONT_USE_CELLS)] } {
-            gen_exclude_list -lib resizer_opt -drc_exclude_list "$::env(DRC_EXCLUDE_CELL_LIST_OPT) $::env(DRC_EXCLUDE_CELL_LIST)" -output $::env(TMP_DIR)/resizer_opt.exclude.list -drc_exclude_only -create_dont_use_list
+            if { $::env(STD_CELL_LIBRARY_OPT) != $::env(STD_CELL_LIBRARY) } {
+                set drc_exclude_list "$::env(DRC_EXCLUDE_CELL_LIST) $::env(DRC_EXCLUDE_CELL_LIST_OPT)"
+            } else {
+                set drc_exclude_list "$::env(DRC_EXCLUDE_CELL_LIST)"
+            }
+            gen_exclude_list -lib resizer_opt -drc_exclude_list $drc_exclude_list -output $::env(TMP_DIR)/resizer_opt.exclude.list -drc_exclude_only -create_dont_use_list
         }
         set ::env(SAVE_DEF) [index_file $::env(resizer_tmp_file_tag).def 0]
         try_catch $::env(OPENROAD_BIN) -exit $::env(SCRIPTS_DIR)/openroad/or_resizer.tcl |& tee $::env(TERMINAL_OUTPUT) [index_file $::env(resizer_log_file_tag).log 0]

--- a/scripts/tcl_commands/placement.tcl
+++ b/scripts/tcl_commands/placement.tcl
@@ -163,9 +163,15 @@ proc run_resizer_timing {args} {
         if { ! [info exists ::env(LIB_RESIZER_OPT) ] } {
             set ::env(LIB_RESIZER_OPT) $::env(TMP_DIR)/resizer.lib
             file copy -force $::env(LIB_SLOWEST) $::env(LIB_RESIZER_OPT)
-        }
+            # if optimization library is different from the base library
+            if { $::env(STD_CELL_LIBRARY_OPT) != $::env(STD_CELL_LIBRARY) } {
+                set opt_lib $::env(TMP_DIR)/resizer_optlib.lib
+                file copy -force $::env(LIB_SLOWEST_OPT) $opt_lib
+                lappend $::env(LIB_RESIZER_OPT) $::env(LIB_SLOWEST_OPT)
+            }
+        } 
         if { ! [info exists ::env(DONT_USE_CELLS)] } {
-            gen_exclude_list -lib $::env(LIB_RESIZER_OPT) -drc_exclude_only -create_dont_use_list
+            gen_exclude_list -lib resizer_timing_opt -drc_exclude_list "$::env(DRC_EXCLUDE_CELL_LIST_OPT) $::env(DRC_EXCLUDE_CELL_LIST)" -output $::env(TMP_DIR)/resizer_timing_opt.exclude.list -drc_exclude_only -create_dont_use_list
         }
         set ::env(SAVE_DEF) [index_file $::env(resizer_tmp_file_tag)_timing.def 0]
         try_catch $::env(OPENROAD_BIN) -exit $::env(SCRIPTS_DIR)/openroad/or_resizer_timing.tcl |& tee $::env(TERMINAL_OUTPUT) [index_file $::env(resizer_log_file_tag)_timing.log 0]
@@ -201,9 +207,14 @@ proc run_resizer_design {args} {
         if { ! [info exists ::env(LIB_RESIZER_OPT) ] } {
             set ::env(LIB_RESIZER_OPT) $::env(TMP_DIR)/resizer.lib
             file copy -force $::env(LIB_SLOWEST) $::env(LIB_RESIZER_OPT)
-        }
+            if { $::env(STD_CELL_LIBRARY_OPT) != $::env(STD_CELL_LIBRARY) } {
+                set opt_lib $::env(TMP_DIR)/resizer_optlib.lib
+                file copy -force $::env(LIB_SLOWEST_OPT) $opt_lib
+                lappend $::env(LIB_RESIZER_OPT) $::env(LIB_SLOWEST_OPT)
+            }
+        } 
         if { ! [info exists ::env(DONT_USE_CELLS)] } {
-            gen_exclude_list -lib $::env(LIB_RESIZER_OPT) -drc_exclude_only -create_dont_use_list
+            gen_exclude_list -lib resizer_opt -drc_exclude_list "$::env(DRC_EXCLUDE_CELL_LIST_OPT) $::env(DRC_EXCLUDE_CELL_LIST)" -output $::env(TMP_DIR)/resizer_opt.exclude.list -drc_exclude_only -create_dont_use_list
         }
         set ::env(SAVE_DEF) [index_file $::env(resizer_tmp_file_tag).def 0]
         try_catch $::env(OPENROAD_BIN) -exit $::env(SCRIPTS_DIR)/openroad/or_resizer.tcl |& tee $::env(TERMINAL_OUTPUT) [index_file $::env(resizer_log_file_tag).log 0]


### PR DESCRIPTION
- Added a new variable `STD_CELL_LIBRARY_OPT` for using a different standard cell library (that is compatible with the base library) when doing resizer optimizations.

