### PR TITLE
Allow IR Drop Calculation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,13 @@ ifeq (, $(strip $(NPROC)))
 
 endif
 
+DOCKER_MEMORY_OPTIONS := 
+ifneq (,$(DOCKER_MEMORY))
+DOCKER_MEMORY_OPTIONS := --memory=$(DOCKER_MEMORY)
+endif
+
 DOCKER_UID_OPTIONS = $(shell python3 ./get_docker_config.py)
+DOCKER_OPTIONS = $(DOCKER_UID_OPTIONS) $(DOCKER_MEMORY_OPTIONS)
 
 
 THREADS ?= $(NPROC)
@@ -57,7 +63,7 @@ PRINT_REM_DESIGNS_TIME ?= 0
 SKYWATER_COMMIT ?= $(shell python3 ./dependencies/tool.py sky130 -f commit)
 OPEN_PDKS_COMMIT ?= $(shell python3 ./dependencies/tool.py open_pdks -f commit)
 
-ENV_COMMAND ?= docker run --rm -v $(OPENLANE_DIR):/openLANE_flow -v $(PDK_ROOT):$(PDK_ROOT) -e PDK_ROOT=$(PDK_ROOT) $(DOCKER_UID_OPTIONS) $(IMAGE_NAME)
+ENV_COMMAND ?= docker run --rm -v $(OPENLANE_DIR):/openLANE_flow -v $(PDK_ROOT):$(PDK_ROOT) -e PDK_ROOT=$(PDK_ROOT) $(DOCKER_OPTIONS) $(IMAGE_NAME)
 
 ifndef PDK_ROOT
 $(error PDK_ROOT is undefined, please export it before running make)
@@ -171,7 +177,7 @@ openlane:
 .PHONY: mount
 mount:
 	cd $(OPENLANE_DIR) && \
-		docker run -it --rm -v $(OPENLANE_DIR):/openLANE_flow -v $(PDK_ROOT):$(PDK_ROOT) -e PDK_ROOT=$(PDK_ROOT) $(DOCKER_UID_OPTIONS) $(IMAGE_NAME)
+		docker run -it --rm -v $(OPENLANE_DIR):/openLANE_flow -v $(PDK_ROOT):$(PDK_ROOT) -e PDK_ROOT=$(PDK_ROOT) $(DOCKER_OPTIONS) $(IMAGE_NAME)
 
 MISC_REGRESSION_ARGS=
 .PHONY: regression regression_test

--- a/configuration/floorplan.tcl
+++ b/configuration/floorplan.tcl
@@ -32,6 +32,7 @@ set ::env(FP_PDN_CORE_RING) 0
 set ::env(FP_PDN_ENABLE_RAILS) 1
 
 set ::env(FP_PDN_CHECK_NODES) 1
+set ::env(FP_PDN_IRDROP) 0
 
 set ::env(FP_IO_MODE) 1; # 0 matching mode - 1 random equidistant mode
 set ::env(FP_IO_HLENGTH) 4

--- a/designs/APU/config.tcl
+++ b/designs/APU/config.tcl
@@ -8,10 +8,10 @@ set ::env(CLOCK_PORT) "clk"
 set ::env(CLOCK_NET) $::env(CLOCK_PORT)
 
 set ::env(FP_PDN_IRDROP) 1
-set ::env(FP_PDN_RCFILE) $::env(OPENLANE_ROOT)/designs/$::env(DESIGN_NAME)/rc.tcl
+set ::env(FP_PDN_RCFILE) $::env(DESIGN_DIR)/rc.tcl
 
 
-set filename $::env(OPENLANE_ROOT)/designs/$::env(DESIGN_NAME)/$::env(PDK)_$::env(STD_CELL_LIBRARY)_config.tcl
+set filename $::env(DESIGN_DIR)/$::env(PDK)_$::env(STD_CELL_LIBRARY)_config.tcl
 if { [file exists $filename] == 1} {
 	source $filename
 }

--- a/designs/APU/config.tcl
+++ b/designs/APU/config.tcl
@@ -7,6 +7,9 @@ set ::env(CLOCK_PORT) "clk"
 
 set ::env(CLOCK_NET) $::env(CLOCK_PORT)
 
+set ::env(FP_PDN_IRDROP) 1
+set ::env(FP_PDN_RCFILE) $::env(OPENLANE_ROOT)/designs/$::env(DESIGN_NAME)/rc.tcl
+
 
 set filename $::env(OPENLANE_ROOT)/designs/$::env(DESIGN_NAME)/$::env(PDK)_$::env(STD_CELL_LIBRARY)_config.tcl
 if { [file exists $filename] == 1} {

--- a/designs/APU/rc.tcl
+++ b/designs/APU/rc.tcl
@@ -1,0 +1,48 @@
+# From OpenROAD Flow Scripts
+
+# BSD 3-Clause License
+
+# Copyright (c) 2018, The Regents of the University of California
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# sync from openroad repo test/sky130hd/sky130hd.rc
+set_layer_rc -layer li1 -capacitance 1.499e-04 -resistance 7.176e-02
+set_layer_rc -layer met1 -capacitance 1.449e-04 -resistance 8.929e-04
+set_layer_rc -layer met2 -capacitance 1.331e-04 -resistance 8.929e-04
+set_layer_rc -layer met3 -capacitance 1.464e-04 -resistance 1.567e-04
+set_layer_rc -layer met4 -capacitance 1.297e-04 -resistance 1.567e-04
+set_layer_rc -layer met5 -capacitance 1.501e-04 -resistance 1.781e-05
+# end sync
+
+set_layer_rc -via mcon -resistance 9.249146E-3
+set_layer_rc -via via -resistance 4.5E-3
+set_layer_rc -via via2 -resistance 3.368786E-3
+set_layer_rc -via via3 -resistance 0.376635E-3
+set_layer_rc -via via4 -resistance 0.00580E-3
+
+set_wire_rc -signal -layer met2
+set_wire_rc -clock -layer met5

--- a/docker_build/Makefile
+++ b/docker_build/Makefile
@@ -41,7 +41,7 @@ tar/openroad_tools.tar.gz: $(TOOL_EXPORT_TARGETS_REAL)
 	cd tar && tar -czf openroad_tools.tar.gz ../build
 
 tar/openLANE_flow.tar.gz: FORCE
-	cd tar && tar --exclude='../../.git' --exclude='../../docker_build' --exclude="../../designs" --exclude="../../pdks/" --exclude="../../logs/*" -czf openLANE_flow.tar.gz ../../
+	cd tar && tar --exclude='../../.git' --exclude='../../docker_build' --exclude="../../designs" --exclude="../../pdks" --exclude="../../logs/*" -czf openLANE_flow.tar.gz ../../
 
 FORCE:
 

--- a/scripts/openroad/or_pdn.tcl
+++ b/scripts/openroad/or_pdn.tcl
@@ -26,7 +26,6 @@ if {[catch {read_def $::env(CURRENT_DEF)} errmsg]} {
     exit 1
 }
 
-
 if {[catch {pdngen $::env(PDN_CFG) -verbose} errmsg]} {
     puts stderr $errmsg
     exit 1
@@ -36,6 +35,21 @@ if {[catch {pdngen $::env(PDN_CFG) -verbose} errmsg]} {
 if { $::env(FP_PDN_CHECK_NODES) } {
     check_power_grid -net $::env(VDD_NET)
     check_power_grid -net $::env(GND_NET)
+}
+
+if { $::env(FP_PDN_IRDROP) } {
+    if { ! [ info exists ::env(FP_PDN_RCFILE) ] } {
+        puts stderr "To calculate the IR Drop, you should add an RC file to your config.tcl."
+        puts stderr "set ::env(FP_PDN_RCFILE) /path/to/rcfile"
+        exit 1
+    }
+    if {[catch {source $::env(FP_PDN_RCFILE)} errmsg]} {
+        puts stderr "Invalid PDN RC file $::env(FP_PDN_RCFILE)."
+        puts stderr $errmsg
+        exit 1
+    }
+    
+    analyze_power_grid -net $::env(VDD_NET)
 }
 
 write_def $::env(SAVE_DEF)

--- a/scripts/tcl_commands/all.tcl
+++ b/scripts/tcl_commands/all.tcl
@@ -358,6 +358,10 @@ proc prep {args} {
         puts_info "Optimization Standard Cell Library: $::env(STD_CELL_LIBRARY_OPT)"
     }
 
+    if {![info exists ::env(PDN_CFG)]} {
+        set ::env(PDN_CFG) $::env(PDKPATH)/libs.tech/openlane/common_pdn.tcl
+    }
+    
     # source PDK and SCL specific configurations
     set pdk_config $::env(PDK_ROOT)/$::env(PDK)/libs.tech/openlane/config.tcl
     set scl_config $::env(PDK_ROOT)/$::env(PDK)/libs.tech/openlane/$::env(STD_CELL_LIBRARY)/config.tcl

--- a/scripts/tcl_commands/routing.tcl
+++ b/scripts/tcl_commands/routing.tcl
@@ -221,9 +221,6 @@ proc power_routing {args} {
 proc gen_pdn {args} {
     puts_info "Generating PDN..."
     TIMER::timer_start
-    if {![info exists ::env(PDN_CFG)]} {
-	set ::env(PDN_CFG) $::env(PDK_ROOT)/$::env(PDK)/libs.tech/openlane/common_pdn.tcl
-    }
     set ::env(SAVE_DEF) [index_file $::env(pdn_tmp_file_tag).def]
     try_catch $::env(OPENROAD_BIN) -exit $::env(SCRIPTS_DIR)/openroad/or_pdn.tcl \
 	|& tee $::env(TERMINAL_OUTPUT) [index_file $::env(pdn_log_file_tag).log 0]


### PR DESCRIPTION
Addressing #535.

--
 
Adds ability to optionally calculate IR drop (user must provide file with rc values).
* A discussion should be held in the near future on if RC values should be calculated as part of open_pdks.

* Change PDN_CFG so it's included in the generated config.tcl file (for or_issue.py)

* Fix The-OpenROAD-Project#495

The **APU** design gives an example of how to enable IR drop calculation.
