### PR TITLE
fix for GitHub Issue #501 on adding propagation clock

### DIFF
--- a/scripts/openroad/or_cts.tcl
+++ b/scripts/openroad/or_cts.tcl
@@ -68,6 +68,7 @@ if { [info exists ::env(PL_OPTIMIZE_MIRRORING)] && $::env(PL_OPTIMIZE_MIRRORING)
     optimize_mirroring
 }
 write_def $::env(SAVE_DEF)
+write_sdc $::env(cts_result_file_tag).sdc
 if { [check_placement -verbose] } {
 	exit 1
 }

--- a/scripts/openroad/or_groute.tcl
+++ b/scripts/openroad/or_groute.tcl
@@ -75,7 +75,13 @@ if {[info exists ::env(CLOCK_PORT)]} {
     if { $::env(GLB_RT_ESTIMATE_PARASITICS) == 1 } {
         read_liberty -max $::env(LIB_SLOWEST)
         read_liberty -min $::env(LIB_FASTEST)
-        read_sdc -echo $::env(BASE_SDC_FILE)
+        #read_sdc -echo $::env(BASE_SDC_FILE)
+	if {$::env(CLOCK_TREE_SYNTH)} {
+	   read_sdc -echo $::env(cts_result_file_tag)_1.sdc
+	} else {
+	   puts "INFO:Skipped CTS Stage so reading base SDC file"
+	   read_sdc -echo $::env(BASE_SDC_FILE)
+	}
 
         set_wire_rc -layer $::env(WIRE_RC_LAYER)
         estimate_parasitics -global_routing

--- a/scripts/openroad/or_resizer_timing.tcl
+++ b/scripts/openroad/or_resizer_timing.tcl
@@ -24,7 +24,13 @@ if {[catch {read_def $::env(CURRENT_DEF)} errmsg]} {
     puts stderr $errmsg
     exit 1
 }
-read_sdc -echo $::env(BASE_SDC_FILE)
+#read_sdc -echo $::env(BASE_SDC_FILE)
+if {$::env(CLOCK_TREE_SYNTH)} {
+	read_sdc -echo $::env(cts_result_file_tag).sdc
+} else {
+puts "INFO:Skipped CTS Stage so reading base SDC file"
+	read_sdc -echo $::env(BASE_SDC_FILE)
+}
 # Resize
 # estimate wire rc parasitics
 set_wire_rc -signal -layer $::env(WIRE_RC_LAYER)
@@ -49,3 +55,4 @@ if { [info exists ::env(PL_OPTIMIZE_MIRRORING)] && $::env(PL_OPTIMIZE_MIRRORING)
 check_placement -verbose
 
 write_def $::env(SAVE_DEF)
+write_sdc $::env(cts_result_file_tag)_1.sdc


### PR DESCRIPTION
I have updated or scripts to write sdc file at CTS stage to use the updated sdc file for timing check post CTS with propagated delay. This is part of #501 fix. I checked #make fastest_test_set flow completed without fail.