### PR TITLE
Report generation patches to avoid crashing with "-to <step>" parameter

### DIFF
--- a/scripts/report/get_file_name.py
+++ b/scripts/report/get_file_name.py
@@ -18,15 +18,23 @@ import argparse
 import os
 
 def get_name(run_path, output_file, include_only=False):
-    try:
-        neededfile=[]
-        if not include_only:
-            neededfile = sorted([(int(f.split('-',1)[0]),f.split('-',1)[1]) for f in os.listdir(run_path) if os.path.isfile(os.path.join(run_path, f)) and len(f.split('-',1)) > 1 and f.split('-',1)[1] == output_file], reverse=True)[0]
-        else:
-            neededfile = sorted([(int(f.split('-',1)[0]),f.split('-',1)[1]) for f in os.listdir(run_path) if os.path.isfile(os.path.join(run_path, f)) and len(f.split('-',1)) > 1 and str(output_file) in str(f.split('-',1)[1])], reverse=True)[0]
-        return str(run_path)+'/'+str(neededfile[0])+'-'+str(neededfile[1])
-    except Exception:
-        return str(run_path)+'/'+str(output_file)
+    candidates = [
+        filename.split('-', 1) for filename in os.listdir(run_path)
+        if os.path.isfile(os.path.join(run_path, filename))
+    ]
+    candidates = filter(lambda name_pair: len(name_pair) > 1 and str(output_file) in name_pair[1], candidates)
+    if not include_only:
+        candidates = filter(lambda name_pair: name_pair[1] == output_file, candidates)
+
+    candidates = sorted(candidates, reverse=True, key=lambda name_parts: int(name_parts[0]))
+    if len(candidates) > 0:
+        neededfile = '-'.join(candidates[0])
+    elif os.path.isfile(os.path.join(run_path, output_file)):
+        neededfile = output_file
+    else:
+        raise FileNotFoundError(f"Cannot find any file with name matching '{output_file}'")
+
+    return os.path.join(run_path, neededfile)
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(

--- a/scripts/report/report.py
+++ b/scripts/report/report.py
@@ -109,7 +109,7 @@ class Report:
         return header
 
     def run_script(self):
-        return subprocess.check_output(self.report_command.split()).decode(sys.getfilesystemencoding())
+        return subprocess.check_output(self.report_command.split(), stderr=subprocess.DEVNULL).decode(sys.getfilesystemencoding())
 
     def format_report(self):
         prefixIdx = self.values.index('config')+1

--- a/scripts/report/report.sh
+++ b/scripts/report/report.sh
@@ -22,61 +22,157 @@ scriptDir=$3
 export SCRIPT_PATH=$3
 
 # This assumes that all these files exist
-tritonRoute_log=$(python3 $3/get_file_name.py -p ${path}/logs/routing/ -o tritonRoute.log 2>&1)
+tritonRoute_log=$(python3 $3/get_file_name.py -p ${path}/logs/routing/ -o tritonRoute.log)
 
-cts_log=$(python3 $3/get_file_name.py -p ${path}/logs/cts/ -o cts.log 2>&1)
-routing_log=$(python3 $3/get_file_name.py -p ${path}/logs/routing/ -o fastroute.log 2>&1)
-placement_log=$(python3 $3/get_file_name.py -p ${path}/logs/placement/ -o replace.log 2>&1)
-sta_log=$(python3 $3/get_file_name.py -p ${path}/logs/synthesis/ -o opensta 2>&1)
-sta_post_resizer_log=$(python3 $3/get_file_name.py -p ${path}/logs/synthesis/ -o opensta_post_resizer 2>&1)
-sta_post_resizer_timing_log=$(python3 $3/get_file_name.py -p ${path}/logs/synthesis/ -o opensta_post_resizer_timing 2>&1)
-sta_spef_log=$(python3 $3/get_file_name.py -p ${path}/logs/synthesis/ -o opensta_spef 2>&1)
+cts_log=$(python3 $3/get_file_name.py -p ${path}/logs/cts/ -o cts.log)
+routing_log=$(python3 $3/get_file_name.py -p ${path}/logs/routing/ -o fastroute.log)
+placement_log=$(python3 $3/get_file_name.py -p ${path}/logs/placement/ -o replace.log)
+sta_log=$(python3 $3/get_file_name.py -p ${path}/logs/synthesis/ -o opensta)
+sta_post_resizer_log=$(python3 $3/get_file_name.py -p ${path}/logs/synthesis/ -o opensta_post_resizer)
+sta_post_resizer_timing_log=$(python3 $3/get_file_name.py -p ${path}/logs/synthesis/ -o opensta_post_resizer_timing)
+sta_spef_log=$(python3 $3/get_file_name.py -p ${path}/logs/synthesis/ -o opensta_spef)
 
-tritonRoute_drc=$(python3 $3/get_file_name.py -p ${path}/reports/routing/ -o tritonRoute.drc 2>&1)
-yosys_rprt=$(python3 $3/get_file_name.py -p ${path}/reports/synthesis/ -o .stat.rpt -io 2>&1)
+tritonRoute_drc=$(python3 $3/get_file_name.py -p ${path}/reports/routing/ -o tritonRoute.drc)
+yosys_rprt=$(python3 $3/get_file_name.py -p ${path}/reports/synthesis/ -o .stat.rpt -io)
 routed_runtime_rpt=${path}/reports/routed_runtime.txt
 total_runtime_rpt=${path}/reports/total_runtime.txt
-wns_rpt=$(python3 $3/get_file_name.py -p ${path}/reports/synthesis/ -o opensta_wns.rpt 2>&1)
-pl_wns_rpt=$(python3 $3/get_file_name.py -p ${path}/reports/placement/ -o replace.log 2>&1)
-opt_wns_rpt=$(python3 $3/get_file_name.py -p ${path}/reports/synthesis/ -o opensta_post_resizer_timing_wns.rpt 2>&1)
-fr_wns_rpt=$(python3 $3/get_file_name.py -p ${path}/logs/routing/ -o fastroute.log 2>&1)
-spef_wns_rpt=$(python3 $3/get_file_name.py -p ${path}/reports/synthesis/ -o opensta_spef_wns.rpt 2>&1)
-tns_rpt=$(python3 $3/get_file_name.py -p ${path}/reports/synthesis/ -o opensta_tns.rpt 2>&1)
-pl_tns_rpt=$(python3 $3/get_file_name.py -p ${path}/reports/placement/ -o replace.log 2>&1)
-opt_tns_rpt=$(python3 $3/get_file_name.py -p ${path}/reports/synthesis/ -o opensta_post_resizer_timing_tns.rpt 2>&1)
-fr_tns_rpt=$(python3 $3/get_file_name.py -p  ${path}/reports/routing/ -o fastroute.log 2>&1)
-spef_tns_rpt=$(python3 $3/get_file_name.py -p ${path}/reports/synthesis/ -o opensta_spef_tns.rpt 2>&1)
-HPWL_rpt=$(python3 $3/get_file_name.py -p ${path}/logs/placement/ -o replace.log 2>&1)
-yosys_log=$(python3 $3/get_file_name.py -p ${path}/logs/synthesis/ -o yosys.log 2>&1)
-magic_drc=$(python3 $3/get_file_name.py -p ${path}/reports/magic/ -o magic.drc 2>&1)
-klayout_drc=$(python3 $3/get_file_name.py -p ${path}/reports/klayout/ -o magic.lydrc -io 2>&1)
-tapcell_log=$(python3 $3/get_file_name.py -p ${path}/logs/floorplan/ -o tapcell.log 2>&1)
-diodes_log=$(python3 $3/get_file_name.py -p ${path}/logs/placement/ -o diodes.log 2>&1)
-magic_antenna_report=$(python3 $3/get_file_name.py -p ${path}/reports/magic/ -o magic.antenna_violators.rpt 2>&1)
-arc_antenna_report=$(python3 $3/get_file_name.py -p ${path}/reports/routing/ -o antenna.rpt 2>&1)
+wns_rpt=$(python3 $3/get_file_name.py -p ${path}/reports/synthesis/ -o opensta_wns.rpt)
+pl_wns_rpt=$(python3 $3/get_file_name.py -p ${path}/reports/placement/ -o replace.log)
+opt_wns_rpt=$(python3 $3/get_file_name.py -p ${path}/reports/synthesis/ -o opensta_post_resizer_timing_wns.rpt)
+fr_wns_rpt=$(python3 $3/get_file_name.py -p ${path}/logs/routing/ -o fastroute.log)
+spef_wns_rpt=$(python3 $3/get_file_name.py -p ${path}/reports/synthesis/ -o opensta_spef_wns.rpt)
+tns_rpt=$(python3 $3/get_file_name.py -p ${path}/reports/synthesis/ -o opensta_tns.rpt)
+pl_tns_rpt=$(python3 $3/get_file_name.py -p ${path}/reports/placement/ -o replace.log)
+opt_tns_rpt=$(python3 $3/get_file_name.py -p ${path}/reports/synthesis/ -o opensta_post_resizer_timing_tns.rpt)
+fr_tns_rpt=$(python3 $3/get_file_name.py -p  ${path}/reports/routing/ -o fastroute.log)
+spef_tns_rpt=$(python3 $3/get_file_name.py -p ${path}/reports/synthesis/ -o opensta_spef_tns.rpt)
+HPWL_rpt=$(python3 $3/get_file_name.py -p ${path}/logs/placement/ -o replace.log)
+yosys_log=$(python3 $3/get_file_name.py -p ${path}/logs/synthesis/ -o yosys.log)
+magic_drc=$(python3 $3/get_file_name.py -p ${path}/reports/magic/ -o magic.drc)
+klayout_drc=$(python3 $3/get_file_name.py -p ${path}/reports/klayout/ -o magic.lydrc -io)
+tapcell_log=$(python3 $3/get_file_name.py -p ${path}/logs/floorplan/ -o tapcell.log)
+diodes_log=$(python3 $3/get_file_name.py -p ${path}/logs/placement/ -o diodes.log)
+magic_antenna_report=$(python3 $3/get_file_name.py -p ${path}/reports/magic/ -o magic.antenna_violators.rpt)
+arc_antenna_report=$(python3 $3/get_file_name.py -p ${path}/reports/routing/ -o antenna.rpt)
 fr_log=${path}/logs/routing/fastroute.log
-cvc_log=$(python3 $3/get_file_name.py -p ${path}/logs/cvc/ -o cvc_screen.log 2>&1)
+cvc_log=$(python3 $3/get_file_name.py -p ${path}/logs/cvc/ -o cvc_screen.log)
 tritonRoute_def="${path}/results/routing/${designName}.def"
-replace_log=$(python3 $3/get_file_name.py -p ${path}/logs/placement/ -o replace.log 2>&1)
+replace_log=$(python3 $3/get_file_name.py -p ${path}/logs/placement/ -o replace.log)
 lvs_report=${path}/results/lvs/${designName}.lvs_parsed.*.log
+
+test_file() {
+        # Tests if a log file exists and is greater than 10 bytes
+        find "$1" -type f -size +10c 2> /dev/null
+}
+
+parse_to_report() {
+        export LOG="$1"
+        export REPORT_PATH="$2"
+        export REPORT="$3"
+        export FROM="$4"
+        export TO="$5"
+        python3 "$SCRIPT_PATH/report_parser.py" "$LOG" $(python3 "$SCRIPT_PATH/get_file_name.py" -p "${REPORT_PATH}" -o "${REPORT}") "$FROM" "$TO"
+}
+
+REPORT_PATH="${path}/reports/cts/"
+if [[ $(test_file "$cts_log") ]]; then
+        parse_to_report "$cts_log" "$REPORT_PATH" cts.timing.rpt timing_report timing_report_end
+        parse_to_report "$cts_log" "$REPORT_PATH" cts.timing.rpt timing_report timing_report_end
+        parse_to_report "$cts_log" "$REPORT_PATH" cts.min_max.rpt min_max_report min_max_report_end
+        parse_to_report "$cts_log" "$REPORT_PATH" cts.rpt check_report check_report_end
+        parse_to_report "$cts_log" "$REPORT_PATH" cts_wns.rpt wns_report wns_report_end
+        parse_to_report "$cts_log" "$REPORT_PATH" cts_tns.rpt tns_report tns_report_end
+        parse_to_report "$cts_log" "$REPORT_PATH" cts_clock_skew.rpt clock_skew_report clock_skew_report_end
+else
+	echo "CTS log not found or empty." > "$REPORT_PATH/cts.rpt"
+fi
+
+REPORT_PATH="${path}/reports/routing/"
+if [[ $(test_file "$routing_log") ]]; then
+        parse_to_report "$routing_log" "$REPORT_PATH" fastroute.timing.rpt timing_report timing_report_end
+        parse_to_report "$routing_log" "$REPORT_PATH" fastroute.min_max.rpt min_max_report min_max_report_end
+        parse_to_report "$routing_log" "$REPORT_PATH" fastroute.rpt check_report check_report_end
+        parse_to_report "$routing_log" "$REPORT_PATH" fastroute_wns.rpt wns_report wns_report_end
+        parse_to_report "$routing_log" "$REPORT_PATH" fastroute_tns.rpt tns_report tns_report_end
+else
+	echo "Routing log not found or empty." > "$REPORT_PATH/fastroute.rpt"
+fi
+
+REPORT_PATH="${path}/reports/placement/"
+if [[ $(test_file "$placement_log") ]]; then
+        parse_to_report "$placement_log" "$REPORT_PATH" replace.timing.rpt timing_report timing_report_end
+        parse_to_report "$placement_log" "$REPORT_PATH" replace.min_max.rpt min_max_report min_max_report_end
+        parse_to_report "$placement_log" "$REPORT_PATH" replace.rpt check_report check_report_end
+        parse_to_report "$placement_log" "$REPORT_PATH" replace_wns.rpt wns_report wns_report_end
+        parse_to_report "$placement_log" "$REPORT_PATH" replace_tns.rpt tns_report tns_report_end
+else
+	echo "Placement log not found or empty." > "$REPORT_PATH/replace.rpt"
+fi
+
+REPORT_PATH="${path}/reports/synthesis/"
+if [[ $(test_file "$sta_log") ]]; then
+	parse_to_report "$sta_log" "$REPORT_PATH" opensta.timing.rpt timing_report timing_report_end
+	parse_to_report "$sta_log" "$REPORT_PATH" opensta.min_max.rpt min_max_report min_max_report_end
+	parse_to_report "$sta_log" "$REPORT_PATH" opensta.rpt check_report check_report_end
+	parse_to_report "$sta_log" "$REPORT_PATH" opensta_wns.rpt wns_report wns_report_end
+	parse_to_report "$sta_log" "$REPORT_PATH" opensta_tns.rpt tns_report tns_report_end
+	parse_to_report "$sta_log" "$REPORT_PATH" opensta.slew.rpt check_slew check_slew_end
+else
+	echo "Static Timing Analysis log not found or empty." > "$REPORT_PATH/opensta.rpt"
+fi
+
+if [[ $(test_file "$sta_post_resizer_log") ]]; then
+	parse_to_report "$sta_post_resizer_log" "$REPORT_PATH" opensta_post_resizer.timing.rpt timing_report timing_report_end
+	parse_to_report "$sta_post_resizer_log" "$REPORT_PATH" opensta_post_resizer.min_max.rpt min_max_report min_max_report_end
+	parse_to_report "$sta_post_resizer_log" "$REPORT_PATH" opensta_post_resizer.rpt check_report check_report_end
+	parse_to_report "$sta_post_resizer_log" "$REPORT_PATH" opensta_post_resizer_wns.rpt wns_report wns_report_end
+	parse_to_report "$sta_post_resizer_log" "$REPORT_PATH" opensta_post_resizer_tns.rpt tns_report tns_report_end
+	parse_to_report "$sta_post_resizer_log" "$REPORT_PATH" opensta_post_resizer.slew.rpt check_slew check_slew_end
+else
+	echo "Static Timing Analysis Post Resizer log not found or empty." > "$REPORT_PATH/opensta_post_resizer.rpt"
+fi
+
+if [[ $(find "$sta_post_resizer_timing_log" -type f -size +10c 2> /dev/null) ]]; then
+	parse_to_report "$sta_post_resizer_timing_log" "$REPORT_PATH" opensta_post_resizer_timing.timing.rpt timing_report timing_report_end
+	parse_to_report "$sta_post_resizer_timing_log" "$REPORT_PATH" opensta_post_resizer_timing.min_max.rpt min_max_report min_max_report_end
+	parse_to_report "$sta_post_resizer_timing_log" "$REPORT_PATH" opensta_post_resizer_timing.rpt check_report check_report_end
+	parse_to_report "$sta_post_resizer_timing_log" "$REPORT_PATH" opensta_post_resizer_timing_wns.rpt wns_report wns_report_end
+	parse_to_report "$sta_post_resizer_timing_log" "$REPORT_PATH" opensta_post_resizer_timing_tns.rpt tns_report tns_report_end
+	parse_to_report "$sta_post_resizer_timing_log" "$REPORT_PATH" opensta_post_resizer_timing.slew.rpt check_slew check_slew_end
+else
+	echo "Static Timing Analysis Post Resizer Timing log not found or empty." > "$REPORT_PATH/opensta_post_resizer_timing.rpt"
+fi
+
+if [[ $(test_file "$sta_spef_log") ]]; then
+	parse_to_report "$sta_spef_log" "$REPORT_PATH" opensta_spef.timing.rpt timing_report timing_report_end
+	parse_to_report "$sta_spef_log" "$REPORT_PATH" opensta_spef.min_max.rpt min_max_report min_max_report_end
+	parse_to_report "$sta_spef_log" "$REPORT_PATH" opensta_spef.rpt check_report check_report_end
+	parse_to_report "$sta_spef_log" "$REPORT_PATH" opensta_spef_wns.rpt wns_report wns_report_end
+	parse_to_report "$sta_spef_log" "$REPORT_PATH" opensta_spef_tns.rpt tns_report tns_report_end
+	parse_to_report "$sta_spef_log" "$REPORT_PATH" opensta_spef.slew.rpt check_slew check_slew_end
+else
+	echo "Static Timing Analysis SPEF log not found or empty." > "$REPORT_PATH/opensta_spef.rpt"
+fi
+
+
 # Extracting info from Yosys
-cell_count=$(grep "cells" $yosys_rprt -s | tail -1 | sed -r 's/.*[^0-9]//')
-if ! [[ $cell_count ]]; then cell_count=-1; fi
+cell_count=$(grep "cells" "$yosys_rprt" -s | tail -1 | sed -r 's/.*[^0-9]//')
+if ! [[ "$cell_count" ]]; then cell_count=-1; fi
 
 #Extracting routed_runtime info
-if [ -f $routed_runtime_rpt ]; then
-        routed_runtime=$(sed 's/.*in //' $routed_runtime_rpt)
-        if ! [[ $routed_runtime ]]; then routed_runtime=-1; fi
+if [ -f "$routed_runtime_rpt" ]; then
+        routed_runtime=$(sed 's/.*in //' "$routed_runtime_rpt")
+        if ! [[ "$routed_runtime" ]]; then routed_runtime=-1; fi
 else
         routed_runtime=-1;
 fi
 
 #Extracting total_runtime info
-if [ -f $total_runtime_rpt ]; then
-        total_runtime=$(sed 's/.*in //' $total_runtime_rpt)
-        if ! [[ $total_runtime ]]; then total_runtime=-1; fi
-        flow_status=$(sed 's/ for .*//' $total_runtime_rpt)
-        if ! [[ $flow_status ]]; then
+if [ -f "$total_runtime_rpt" ]; then
+        total_runtime=$(sed 's/.*in //' "$total_runtime_rpt")
+        if ! [[ "$total_runtime" ]]; then total_runtime=-1; fi
+        flow_status=$(sed 's/ for .*//' "$total_runtime_rpt")
+        if ! [[ "$flow_status" ]]; then
                 flow_status="unknown_no_content_in_file"; 
         else
                 flow_status="${flow_status// /_}"
@@ -87,13 +183,13 @@ else
 fi
 
 #Extracting Die Area info
-if [ -f $tritonRoute_def ]; then
-        tmpa=$(awk  '/DIEAREA/ {print $3, $4, $7, $8; exit}' $tritonRoute_def | cut -d' ' -f 1)
-        tmpb=$(awk  '/DIEAREA/ {print $3, $4, $7, $8; exit}' $tritonRoute_def | cut -d' ' -f 2)
-        tmpc=$(awk  '/DIEAREA/ {print $3, $4, $7, $8; exit}' $tritonRoute_def | cut -d' ' -f 3)
-        tmpd=$(awk  '/DIEAREA/ {print $3, $4, $7, $8; exit}' $tritonRoute_def | cut -d' ' -f 4)
+if [ -f "$tritonRoute_def" ]; then
+        tmpa=$(awk  '/DIEAREA/ {print $3, $4, $7, $8; exit}' "$tritonRoute_def" | cut -d' ' -f 1)
+        tmpb=$(awk  '/DIEAREA/ {print $3, $4, $7, $8; exit}' "$tritonRoute_def" | cut -d' ' -f 2)
+        tmpc=$(awk  '/DIEAREA/ {print $3, $4, $7, $8; exit}' "$tritonRoute_def" | cut -d' ' -f 3)
+        tmpd=$(awk  '/DIEAREA/ {print $3, $4, $7, $8; exit}' "$tritonRoute_def" | cut -d' ' -f 4)
         diearea=$(( (($tmpc-$tmpa)/1000)*(($tmpd-$tmpb)/1000) ))
-        if ! [[ $diearea ]]; then diearea=-1;fi
+        if ! [[ "$diearea" ]]; then diearea=-1;fi
 else
         diearea=-1;
 fi
@@ -103,33 +199,33 @@ cellperum=-1
 #if ! [[ $cellperum ]]; then cellperum=-1;fi
 
 #Extracting OpenDP Reported Utilization
-opendpUtil=$(grep "Util(%):" $replace_log -s | head -1 | sed -E 's/.*Util\(%\): (\S+)/\1/')
-if ! [[ $opendpUtil ]]; then opendpUtil=-1; fi
+opendpUtil=$(grep "Util(%):" "$replace_log" -s | head -1 | sed -E 's/.*Util\(%\): (\S+)/\1/')
+if ! [[ "$opendpUtil" ]]; then opendpUtil=-1; fi
 
 #Extracting TritonRoute memory usage peak
-tritonRoute_memoryPeak=$(grep ", peak = " $tritonRoute_log -s | tail -1 | sed -E 's/.*peak = (\S+).*/\1/')
-if ! [[ $tritonRoute_memoryPeak ]]; then tritonRoute_memoryPeak=-1; fi
+tritonRoute_memoryPeak=$(grep ", peak = " "$tritonRoute_log" -s | tail -1 | sed -E 's/.*peak = (\S+).*/\1/')
+if ! [[ "$tritonRoute_memoryPeak" ]]; then tritonRoute_memoryPeak=-1; fi
 
 #Extracting TritonRoute Violations Information
-tritonRoute_violations=$(grep -si "Number of violations" $tritonRoute_log | tail -1 | python3 -c 'import re; print(re.match(r"\[.+?\].*?\=\s*(\d+)", input())[1])')
-if ! [[ $tritonRoute_violations ]]; then tritonRoute_violations=-1; fi
-Other_violations=$tritonRoute_violations;
+tritonRoute_violations=$(grep -si "Number of violations" "$tritonRoute_log" | tail -1 | sed -r "s/\[.+?\].*?\=\s*([0-9]+)/\1/")
+if ! [[ "$tritonRoute_violations" ]]; then tritonRoute_violations=-1; fi
+Other_violations="$tritonRoute_violations";
 
-if [ -f $tritonRoute_drc ]; then
-        Short_violations=$(grep "Short" $tritonRoute_drc -s | wc -l)
-        if ! [[ $Short_violations ]]; then Short_violations=-1; fi
+if [ -f "$tritonRoute_drc" ]; then
+        Short_violations=$(grep "Short" "$tritonRoute_drc" -s | wc -l)
+        if ! [[ "$Short_violations" ]]; then Short_violations=-1; fi
         Other_violations=$((Other_violations-Short_violations));
 
-        MetSpc_violations=$(grep "MetSpc" $tritonRoute_drc -s | wc -l)
-        if ! [[ $MetSpc_violations ]]; then MetSpc_violations=-1; fi
+        MetSpc_violations=$(grep "MetSpc" "$tritonRoute_drc" -s | wc -l)
+        if ! [[ "$MetSpc_violations" ]]; then MetSpc_violations=-1; fi
         Other_violations=$((Other_violations-MetSpc_violations));
 
-        OffGrid_violations=$(grep "OffGrid" $tritonRoute_drc -s | wc -l)
-        if ! [[ $OffGrid_violations ]]; then OffGrid_violations=-1; fi
+        OffGrid_violations=$(grep "OffGrid" "$tritonRoute_drc" -s | wc -l)
+        if ! [[ "$OffGrid_violations" ]]; then OffGrid_violations=-1; fi
         Other_violations=$((Other_violations-OffGrid_violations));
 
-        MinHole_violations=$(grep "MinHole" $tritonRoute_drc -s | wc -l)
-        if ! [[ $MinHole_violations ]]; then MinHole_violations=-1; fi
+        MinHole_violations=$(grep "MinHole" "$tritonRoute_drc" -s | wc -l)
+        if ! [[ "$MinHole_violations" ]]; then MinHole_violations=-1; fi
         Other_violations=$((Other_violations-MinHole_violations));
 else
         Short_violations=-1;
@@ -139,10 +235,10 @@ else
 fi
 
 #Extracting Magic Violations from Magic drc
-if [ -f $magic_drc ]; then
-        Magic_violations=$(grep "^ [0-9]" $magic_drc -s | wc -l)
-        if ! [[ $Magic_violations ]]; then Magic_violations=-1; fi
-        if [ $Magic_violations -ne -1 ]; then Magic_violations=$(((Magic_violations+3)/4)); fi
+if [ -f "$magic_drc" ]; then
+        Magic_violations=$(grep "^ [0-9]" "$magic_drc" -s | wc -l)
+        if ! [[ "$Magic_violations" ]]; then Magic_violations=-1; fi
+        if [ "$Magic_violations" -ne -1 ]; then Magic_violations=$(((Magic_violations+3)/4)); fi
 else
         Magic_violations=-1;
 fi
@@ -150,22 +246,22 @@ fi
 
 #Extracting Klayout DRC Violations from magic.lydrc
 if [ -f "$klayout_drc" ]; then
-        klayout_violations=$(grep "<item>" $klayout_drc -s | wc -l)
-        if ! [[ $klayout_violations ]]; then klayout_violations=0; fi
+        klayout_violations=$(grep "<item>" "$klayout_drc" -s | wc -l)
+        if ! [[ "$klayout_violations" ]]; then klayout_violations=0; fi
 else
         klayout_violations=-1;
 fi
 
 # Extracting Antenna Violations
-if [ -f $arc_antenna_report ]; then
+if [ -f "$arc_antenna_report" ]; then
         #arc check
-        antenna_violations=$(grep "Number of pins violated:" $arc_antenna_report -s | tail -1 | sed -r 's/.*[^0-9]//')
-        if ! [[ $antenna_violations ]]; then antenna_violations=-1; fi
+        antenna_violations=$(grep "Number of pins violated:" "$arc_antenna_report" -s | tail -1 | sed -r 's/.*[^0-9]//')
+        if ! [[ "$antenna_violations" ]]; then antenna_violations=-1; fi
 else
-        if [ -f $magic_antenna_report ]; then
+        if [ -f "$magic_antenna_report" ]; then
                 #old magic check
-                antenna_violations=$(wc $magic_antenna_report -l | cut -d ' ' -f 1)
-                if ! [[ $antenna_violations ]]; then antenna_violations=-1; fi
+                antenna_violations=$(wc "$magic_antenna_report" -l | cut -d ' ' -f 1)
+                if ! [[ "$antenna_violations" ]]; then antenna_violations=-1; fi
         else
 
                 antenna_violations=-1;
@@ -173,50 +269,50 @@ else
 fi
 
 #Extracting Other information from TritonRoute Logs
-wire_length=$(grep "total wire length =" $tritonRoute_log -s | tail -1 | sed -r 's/[^0-9]*//g')
-if ! [[ $wire_length ]]; then wire_length=-1; fi
-vias=$(grep "total number of vias =" $tritonRoute_log -s | tail -1 | sed -r 's/[^0-9]*//g')
-if ! [[ $vias ]]; then vias=-1; fi
+wire_length=$(grep "total wire length =" "$tritonRoute_log" -s | tail -1 | sed -r 's/[^0-9]*//g')
+if ! [[ "$wire_length" ]]; then wire_length=-1; fi
+vias=$(grep "total number of vias =" "$tritonRoute_log" -s | tail -1 | sed -r 's/[^0-9]*//g')
+if ! [[ "$vias" ]]; then vias=-1; fi
 
 #Extracting Info from OpenSTA
-wns=$(grep "wns" $wns_rpt -s | sed -r 's/wns //')
-if ! [[ $wns ]]; then wns=-1; fi
+wns=$(grep "wns" "$wns_rpt" -s | sed -r 's/wns //')
+if ! [[ "$wns" ]]; then wns=-1; fi
 
 #Extracting info from OpenSTA post global placement using estimate parasitics
-pl_wns=$(grep "wns" $pl_wns_rpt -s | tail -1 |sed -r 's/wns //')
-if ! [[ $pl_wns ]]; then pl_wns=$wns; fi
+pl_wns=$(grep "wns" "$pl_wns_rpt" -s | tail -1 |sed -r 's/wns //')
+if ! [[ "$pl_wns" ]]; then pl_wns="$wns"; fi
 
 #Extracting Info from OpenSTA
-opt_wns=$(grep "wns" $opt_wns_rpt -s | tail -1 |sed -r 's/wns //')
-if ! [[ $opt_wns ]]; then opt_wns=$pl_wns; fi
+opt_wns=$(grep "wns" "$opt_wns_rpt" -s | tail -1 |sed -r 's/wns //')
+if ! [[ "$opt_wns" ]]; then opt_wns="$pl_wns"; fi
 
 #Extracting info from OpenSTA post global routing using estimate parasitics
-fr_wns=$(grep "wns" $fr_wns_rpt -s | sed -r 's/wns //')
-if ! [[ $fr_wns ]]; then fr_wns=$opt_wns; fi
+fr_wns=$(grep "wns" "$fr_wns_rpt" -s | sed -r 's/wns //')
+if ! [[ "$fr_wns" ]]; then fr_wns="$opt_wns"; fi
 
 #Extracting info from OpenSTA post SPEF extraction
-spef_wns=$(grep "wns" $spef_wns_rpt -s | sed -r 's/wns //')
-if ! [[ $spef_wns ]]; then spef_wns=$fr_wns; fi
+spef_wns=$(grep "wns" "$spef_wns_rpt" -s | sed -r 's/wns //')
+if ! [[ "$spef_wns" ]]; then spef_wns="$fr_wns"; fi
 
 #Extracting Info from OpenSTA
-tns=$(grep "tns" $tns_rpt -s | sed -r 's/tns //')
-if ! [[ $tns ]]; then tns=-1; fi
+tns=$(grep "tns" "$tns_rpt" -s | sed -r 's/tns //')
+if ! [[ "$tns" ]]; then tns=-1; fi
 
 #Extracting info from OpenSTA post global placement using estimate parasitics
-pl_tns=$(grep "tns" $pl_tns_rpt -s | tail -1 |sed -r 's/tns //')
-if ! [[ $pl_tns ]]; then pl_tns=$tns; fi
+pl_tns=$(grep "tns" "$pl_tns_rpt" -s | tail -1 |sed -r 's/tns //')
+if ! [[ "$pl_tns" ]]; then pl_tns="$tns"; fi
 
 #Extracting Info from OpenSTA
-opt_tns=$(grep "tns" $opt_tns_rpt -s | tail -1 |sed -r 's/tns //')
-if ! [[ $opt_tns ]]; then opt_tns=$pl_tns; fi
+opt_tns=$(grep "tns" "$opt_tns_rpt" -s | tail -1 |sed -r 's/tns //')
+if ! [[ "$opt_tns" ]]; then opt_tns="$pl_tns"; fi
 
 #Extracting info from FR:estimate_parasitics
-fr_tns=$(grep "tns" $fr_tns_rpt -s | sed -r 's/tns //')
-if ! [[ $fr_tns ]]; then fr_tns=$opt_tns; fi
+fr_tns=$(grep "tns" "$fr_tns_rpt" -s | sed -r 's/tns //')
+if ! [[ "$fr_tns" ]]; then fr_tns="$opt_tns"; fi
 
 #Extracting info from OpenSTA post SPEF extraction
-spef_tns=$(grep "tns" $spef_tns_rpt -s | sed -r 's/tns //')
-if ! [[ $spef_tns ]]; then spef_tns=$opt_tns; fi
+spef_tns=$(grep "tns" "$spef_tns_rpt" -s | sed -r 's/tns //')
+if ! [[ "$spef_tns" ]]; then spef_tns="$opt_tns"; fi
 
 
 #Extracting Info from RePlace
@@ -224,8 +320,8 @@ if ! [[ $spef_tns ]]; then spef_tns=$opt_tns; fi
 #hpwl=$(cat $HPWL_rpt)
 
 #openroad replace extraction
-hpwl=$(grep " HPWL: " $HPWL_rpt -s | tail -1 | sed -E 's/.*HPWL: (\S+).*/\1/')
-if ! [[ $hpwl ]]; then hpwl=-1; fi
+hpwl=$(grep " HPWL: " "$HPWL_rpt" -s | tail -1 | sed -E 's/.*HPWL: (\S+).*/\1/')
+if ! [[ "$hpwl" ]]; then hpwl=-1; fi
 
 #Extracting Info from Yosys logs
 declare -a metrics=(
@@ -249,63 +345,65 @@ declare -a metrics=(
 
 metrics_vals=()
 for metric in "${metrics[@]}"; do
-        val=$(grep " \+${metric}[^0-9]\+ \+[0-9]\+" $yosys_log -s | tail -1 | sed -r 's/.*[^0-9]([0-9]+)$/\1/')
-        if ! [[ $val ]]; then val=0; fi
+        val=$(grep " \+${metric}[^0-9]\+ \+[0-9]\+" "$yosys_log" -s | tail -1 | sed -r 's/.*[^0-9]([0-9]+)$/\1/')
+        if ! [[ "$val" ]]; then val=0; fi
         metrics_vals+=("$val")
 done
 
 #Extracting info from yosys logs
-input_output=$(grep -e "ABC: netlist" $yosys_log -s | tail -1 | sed -r 's/ABC: netlist[^0-9]*([0-9]+)\/ *([0-9]+).*/\1 \2/')
-if ! [[ $input_output ]]; then input_output="-1 -1"; fi
-level=$(grep -e "ABC: netlist" $yosys_log -s | tail -1 | sed -r 's/.*lev.*[^0-9]([0-9]+)$/\1/')
-if ! [[ $level ]]; then level=-1; fi
+input_output=$(grep -e "ABC: netlist" "$yosys_log" -s | tail -1 | sed -r 's/ABC: netlist[^0-9]*([0-9]+)\/ *([0-9]+).*/\1 \2/')
+if ! [[ "$input_output" ]]; then input_output="-1 -1"; fi
+level=$(grep -e "ABC: netlist" "$yosys_log" -s | tail -1 | sed -r 's/.*lev.*[^0-9]([0-9]+)$/\1/')
+if ! [[ "$level" ]]; then level=-1; fi
 
 #Extracting layer usage percentage
-usageLine=$(grep -n -E "Layer\s+Resource" $fr_log | tail -1 | sed -E 's/(\S+):.*/\1/')
+if [ -f "$fr_log" ]; then
+        usageLine=$(grep -n -E "Layer\s+Resource" "$fr_log" | tail -1 | sed -E 's/(\S+):.*/\1/')
 
-layer1=$(sed -n "$(expr $usageLine + 2)p" $fr_log | sed -E 's/.*\s+(\S+)%.*/\1/')
-if ! [[ $layer1 ]]; then layer1=-1; fi
-layer2=$(sed -n "$(expr $usageLine + 3)p" $fr_log | sed -E 's/.*\s+(\S+)%.*/\1/')
-if ! [[ $layer2 ]]; then layer2=-1; fi
-layer3=$(sed -n "$(expr $usageLine + 4)p" $fr_log | sed -E 's/.*\s+(\S+)%.*/\1/')
-if ! [[ $layer3 ]]; then layer3=-1; fi
-layer4=$(sed -n "$(expr $usageLine + 5)p" $fr_log | sed -E 's/.*\s+(\S+)%.*/\1/')
-if ! [[ $layer4 ]]; then layer4=-1; fi
-layer5=$(sed -n "$(expr $usageLine + 6)p" $fr_log | sed -E 's/.*\s+(\S+)%.*/\1/')
-if ! [[ $layer5 ]]; then layer5=-1; fi
-layer6=$(sed -n "$(expr $usageLine + 7)p" $fr_log | sed -E 's/.*\s+(\S+)%.*/\1/')
-if ! [[ $layer6 ]]; then layer6=-1; fi
+        layer1=$(sed -n "$(expr $usageLine + 2)p" "$fr_log" | sed -E 's/.*\s+(\S+)%.*/\1/')
+	layer2=$(sed -n "$(expr $usageLine + 3)p" "$fr_log" | sed -E 's/.*\s+(\S+)%.*/\1/')
+        layer3=$(sed -n "$(expr $usageLine + 4)p" "$fr_log" | sed -E 's/.*\s+(\S+)%.*/\1/')
+        layer4=$(sed -n "$(expr $usageLine + 5)p" "$fr_log" | sed -E 's/.*\s+(\S+)%.*/\1/')
+        layer5=$(sed -n "$(expr $usageLine + 6)p" "$fr_log" | sed -E 's/.*\s+(\S+)%.*/\1/')
+        layer6=$(sed -n "$(expr $usageLine + 7)p" "$fr_log" | sed -E 's/.*\s+(\S+)%.*/\1/')
+fi
+if ! [[ "$layer1" ]]; then layer1=-1; fi
+if ! [[ "$layer2" ]]; then layer2=-1; fi
+if ! [[ "$layer3" ]]; then layer3=-1; fi
+if ! [[ "$layer4" ]]; then layer4=-1; fi
+if ! [[ "$layer5" ]]; then layer5=-1; fi
+if ! [[ "$layer6" ]]; then layer6=-1; fi
 
 #Extracting Endcaps and TapCells
-endcaps=$(grep "Endcaps inserted:" $tapcell_log -s | tail -1 | sed -E 's/.*Endcaps inserted: (\S+)/\1/')
-if ! [[ $endcaps ]]; then endcaps=0; fi
+endcaps=$(grep "Endcaps inserted:" "$tapcell_log" -s | tail -1 | sed -E 's/.*Endcaps inserted: (\S+)/\1/')
+if ! [[ "$endcaps" ]]; then endcaps=0; fi
 
-tapcells=$(grep "Tapcells inserted:" $tapcell_log -s | tail -1 | sed -E 's/.*Tapcells inserted: (\S+)/\1/')
-if ! [[ $tapcells ]]; then tapcells=0; fi
+tapcells=$(grep "Tapcells inserted:" "$tapcell_log" -s | tail -1 | sed -E 's/.*Tapcells inserted: (\S+)/\1/')
+if ! [[ "$tapcells" ]]; then tapcells=0; fi
 
 
 #Extracting Diodes
-diodes=$(grep "inserted!" $diodes_log -s | tail -1 | sed -E 's/.* (\S+) of .* inserted!/\1/')
-if ! [[ $diodes ]]; then
-        diodes=$(grep "diodes inserted" $fr_log -s | tail -1 | sed -E 's/.* (\S+) diodes inserted./\1/')
-        if ! [[ $diodes ]]; then diodes=0; fi
+diodes=$(grep "inserted!" "$diodes_log" -s | tail -1 | sed -E 's/.* (\S+) of .* inserted!/\1/')
+if ! [[ "$diodes" ]]; then
+        diodes=$(grep "diodes inserted" "$fr_log" -s | tail -1 | sed -E 's/.* (\S+) diodes inserted./\1/')
+        if ! [[ "$diodes" ]]; then diodes=0; fi
 fi
 
 #Summing the number of Endcaps, Tapcells, and Diodes
 physical_cells=$(((endcaps+tapcells)+diodes));
 
 #Extracting the total number of lvs errors
-if ! [[ -f "$lvs_report" ]]; then
-        lvs_total_errors=$(grep "Total errors =" $lvs_report -s | tail -1 | sed -r 's/[^0-9]*//g')
-        if ! [[ $lvs_total_errors ]]; then lvs_total_errors=0; fi
+if ! [ -f "$lvs_report" ]; then
+        lvs_total_errors=$(grep "Total errors =" "$lvs_report" -s | tail -1 | sed -r 's/[^0-9]*//g')
+        if ! [[ "$lvs_total_errors" ]]; then lvs_total_errors=0; fi
 else
         lvs_total_errors=-1;
 fi
 
 
 #Extracting the total number of cvc errors
-cvc_total_errors=$(grep "CVC: Total: " $cvc_log -s | tail -1 | sed -r 's/[^0-9]*//g')
-if ! [[ $cvc_total_errors ]]; then cvc_total_errors=-1; fi
+cvc_total_errors=$(grep "CVC: Total: " "$cvc_log" -s | tail -1 | sed -r 's/[^0-9]*//g')
+if ! [[ "$cvc_total_errors" ]]; then cvc_total_errors=-1; fi
 
 result="$flow_status $total_runtime $routed_runtime $diearea $cellperum $opendpUtil $tritonRoute_memoryPeak $cell_count $tritonRoute_violations $Short_violations $MetSpc_violations $OffGrid_violations $MinHole_violations $Other_violations $Magic_violations $antenna_violations $lvs_total_errors $cvc_total_errors $klayout_violations $wire_length $vias $wns $pl_wns $opt_wns $fr_wns $spef_wns $tns $pl_tns $opt_tns $fr_tns $spef_tns $hpwl $layer1 $layer2 $layer3 $layer4 $layer5 $layer6"
 for val in "${metrics_vals[@]}"; do
@@ -315,97 +413,3 @@ result+=" $input_output"
 result+=" $level"
 result+=" $endcaps $tapcells $diodes $physical_cells"
 echo "$result"
-
-test_file() {
-        # Tests if a log file exists and is greater than 10 bytes
-        find $1 -type f -size +10c 2> /dev/null
-}
-
-parse_to_report() {
-        export LOG=$1
-        export REPORT_PATH=$2
-        export REPORT=$3
-        export FROM=$4
-        export TO=$5
-        python3 $SCRIPT_PATH/report_parser.py $LOG $(python3 $SCRIPT_PATH/get_file_name.py -p ${REPORT_PATH} -o ${REPORT} 2>&1) $FROM $TO 
-}
-
-REPORT_PATH=${path}/reports/cts/
-if [[ $(test_file $cts_log) ]]; then
-        parse_to_report $cts_log $REPORT_PATH cts.timing.rpt timing_report timing_report_end
-        parse_to_report $cts_log $REPORT_PATH cts.timing.rpt timing_report timing_report_end
-        parse_to_report $cts_log $REPORT_PATH cts.min_max.rpt min_max_report min_max_report_end
-        parse_to_report $cts_log $REPORT_PATH cts.rpt check_report check_report_end
-        parse_to_report $cts_log $REPORT_PATH cts_wns.rpt wns_report wns_report_end
-        parse_to_report $cts_log $REPORT_PATH cts_tns.rpt tns_report tns_report_end
-        parse_to_report $cts_log $REPORT_PATH cts_clock_skew.rpt clock_skew_report clock_skew_report_end
-else 
-	echo "CTS log not found or empty." > $REPORT_PATH/cts.rpt
-fi
-
-REPORT_PATH=${path}/reports/routing/
-if [[ $(test_file $routing_log) ]]; then
-        parse_to_report $routing_log $REPORT_PATH fastroute.timing.rpt timing_report timing_report_end
-        parse_to_report $routing_log $REPORT_PATH fastroute.min_max.rpt min_max_report min_max_report_end
-        parse_to_report $routing_log $REPORT_PATH fastroute.rpt check_report check_report_end
-        parse_to_report $routing_log $REPORT_PATH fastroute_wns.rpt wns_report wns_report_end
-        parse_to_report $routing_log $REPORT_PATH fastroute_tns.rpt tns_report tns_report_end
-else 
-	echo "Routing log not found or empty." > $REPORT_PATH/fastroute.rpt
-fi
-
-REPORT_PATH=${path}/reports/placement/
-if [[ $(test_file $placement_log) ]]; then
-        parse_to_report $placement_log $REPORT_PATH replace.timing.rpt timing_report timing_report_end
-        parse_to_report $placement_log $REPORT_PATH replace.min_max.rpt min_max_report min_max_report_end
-        parse_to_report $placement_log $REPORT_PATH replace.rpt check_report check_report_end
-        parse_to_report $placement_log $REPORT_PATH replace_wns.rpt wns_report wns_report_end
-        parse_to_report $placement_log $REPORT_PATH replace_tns.rpt tns_report tns_report_end
-else 
-	echo "Placement log not found or empty." > $REPORT_PATH/replace.rpt
-fi
-
-REPORT_PATH=${path}/reports/synthesis/
-if [[ $(test_file $sta_log) ]]; then
-	parse_to_report $sta_log $REPORT_PATH opensta.timing.rpt timing_report timing_report_end
-	parse_to_report $sta_log $REPORT_PATH opensta.min_max.rpt min_max_report min_max_report_end
-	parse_to_report $sta_log $REPORT_PATH opensta.rpt check_report check_report_end
-	parse_to_report $sta_log $REPORT_PATH opensta_wns.rpt wns_report wns_report_end
-	parse_to_report $sta_log $REPORT_PATH opensta_tns.rpt tns_report tns_report_end
-	parse_to_report $sta_log $REPORT_PATH opensta.slew.rpt check_slew check_slew_end
-else 
-	echo "Static Timing Analysis log not found or empty." > $REPORT_PATH/opensta.rpt
-fi
-
-if [[ $(test_file $sta_post_resizer_log) ]]; then
-	parse_to_report $sta_post_resizer_log $REPORT_PATH opensta_post_resizer.timing.rpt timing_report timing_report_end
-	parse_to_report $sta_post_resizer_log $REPORT_PATH opensta_post_resizer.min_max.rpt min_max_report min_max_report_end
-	parse_to_report $sta_post_resizer_log $REPORT_PATH opensta_post_resizer.rpt check_report check_report_end
-	parse_to_report $sta_post_resizer_log $REPORT_PATH opensta_post_resizer_wns.rpt wns_report wns_report_end
-	parse_to_report $sta_post_resizer_log $REPORT_PATH opensta_post_resizer_tns.rpt tns_report tns_report_end
-	parse_to_report $sta_post_resizer_log $REPORT_PATH opensta_post_resizer.slew.rpt check_slew check_slew_end
-else 
-	echo "Static Timing Analysis Post Resizer log not found or empty." > $REPORT_PATH/opensta_post_resizer.rpt
-fi
-
-if [[ $(find $sta_post_resizer_timing_log -type f -size +10c 2> /dev/null) ]]; then
-	parse_to_report $sta_post_resizer_timing_log $REPORT_PATH opensta_post_resizer_timing.timing.rpt timing_report timing_report_end
-	parse_to_report $sta_post_resizer_timing_log $REPORT_PATH opensta_post_resizer_timing.min_max.rpt min_max_report min_max_report_end
-	parse_to_report $sta_post_resizer_timing_log $REPORT_PATH opensta_post_resizer_timing.rpt check_report check_report_end
-	parse_to_report $sta_post_resizer_timing_log $REPORT_PATH opensta_post_resizer_timing_wns.rpt wns_report wns_report_end
-	parse_to_report $sta_post_resizer_timing_log $REPORT_PATH opensta_post_resizer_timing_tns.rpt tns_report tns_report_end
-	parse_to_report $sta_post_resizer_timing_log $REPORT_PATH opensta_post_resizer_timing.slew.rpt check_slew check_slew_end
-else 
-	echo "Static Timing Analysis Post Resizer Timing log not found or empty." > $REPORT_PATH/opensta_post_resizer_timing.rpt
-fi
-
-if [[ $(test_file $sta_spef_log) ]]; then
-	parse_to_report $sta_spef_log $REPORT_PATH opensta_spef.timing.rpt timing_report timing_report_end
-	parse_to_report $sta_spef_log $REPORT_PATH opensta_spef.min_max.rpt min_max_report min_max_report_end
-	parse_to_report $sta_spef_log $REPORT_PATH opensta_spef.rpt check_report check_report_end
-	parse_to_report $sta_spef_log $REPORT_PATH opensta_spef_wns.rpt wns_report wns_report_end
-	parse_to_report $sta_spef_log $REPORT_PATH opensta_spef_tns.rpt tns_report tns_report_end
-	parse_to_report $sta_spef_log $REPORT_PATH opensta_spef.slew.rpt check_slew check_slew_end
-else 
-	echo "Static Timing Analysis SPEF log not found or empty." > $REPORT_PATH/opensta_spef.rpt
-fi

--- a/scripts/utils/utils.tcl
+++ b/scripts/utils/utils.tcl
@@ -171,8 +171,8 @@ proc try_catch {args} {
             puts $error_log_file "Last 10 lines:\n[exec tail -10 << $error_msg]\n"
             close $error_log_file
         }
-		flow_fail
-		return -code error
+        if { ! [info exists writing_report] || ! $writing_report } { flow_fail }
+        return -code error
     }
 }
 
@@ -310,6 +310,7 @@ proc generate_final_summary_report {args} {
 		set_if_unset arg_values(-man_report) $::env(REPORTS_DIR)/manufacturability_report.rpt
 		set_if_unset arg_values(-runtime_summary) $::env(REPORTS_DIR)/runtime_summary_report.rpt
 
+        set writing_report 1
         try_catch $::env(OPENROAD_BIN) -python $::env(OPENLANE_ROOT)/report_generation_wrapper.py -d $::env(DESIGN_DIR) \
 			-dn $::env(DESIGN_NAME) \
 			-t $::env(RUN_TAG) \


### PR DESCRIPTION
The issue I faced is that if the `flow.tcl` is run with `'-to <step>` parameter and it succedes, `report.sh` (run by `report_generation_wrapper.py`) fails due to missing reports from the steps of the flow that were not run.

Moreover, it caused the wrapper to fail as well, and since in the `utils.py` the wrapper is called with `try_catch`, it sets the flow status to `flow failed` and runs the report wrapper again. Thus, the report says that the flow is failed though it is actually not.

These two commits resolve the crashing problem.