### PR TITLE
Fix pdk install for latest open_pdks version 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,7 +145,7 @@ build-pdk: $(PDK_ROOT)/open_pdks $(PDK_ROOT)/skywater-pdk
 		$(MAKE) prerequisites
 	$(ENV_COMMAND) sh -c " cd $(PDK_ROOT)/open_pdks/sky130 && \
 		make && \
-		make install-local && \
+		make install && \
 		make clean"
 
 .PHONY: native-build-pdk

--- a/Makefile
+++ b/Makefile
@@ -139,13 +139,13 @@ build-pdk: $(PDK_ROOT)/open_pdks $(PDK_ROOT)/skywater-pdk
 		rm -rf $(PDK_ROOT)/pdk/sky130A) || \
 		true
 	$(ENV_COMMAND) sh -c " cd $(PDK_ROOT)/open_pdks && \
-		./configure --enable-sky130-pdk=$(PDK_ROOT)/skywater-pdk/libraries --prefix=$(PDK_ROOT) --datarootdir=$(PDK_ROOT)"
+		./configure --enable-sky130-pdk=$(PDK_ROOT)/skywater-pdk/libraries"
 	cd $(PDK_ROOT)/open_pdks/sky130 && \
 		$(MAKE) veryclean && \
 		$(MAKE) prerequisites
 	$(ENV_COMMAND) sh -c " cd $(PDK_ROOT)/open_pdks/sky130 && \
 		make && \
-		make install && \
+		make SHARED_PDKS_PATH=$(PDK_ROOT) install && \
 		make clean"
 
 .PHONY: native-build-pdk
@@ -156,11 +156,11 @@ native-build-pdk: $(PDK_ROOT)/open_pdks $(PDK_ROOT)/skywater-pdk
 		rm -rf $(PDK_ROOT)/pdk/sky130A) || \
 		true
 	cd $(PDK_ROOT)/open_pdks && \
-		./configure --enable-sky130-pdk=$(PDK_ROOT)/skywater-pdk/libraries --prefix=$(PDK_ROOT) --datarootdir=$(PDK_ROOT) --enable-sram-sky130=$(INSTALL_SRAM) && \
+		./configure --enable-sky130-pdk=$(PDK_ROOT)/skywater-pdk/libraries --enable-sram-sky130=$(INSTALL_SRAM) && \
 		cd sky130 && \
 		$(MAKE) veryclean && \
 		$(MAKE) && \
-		$(MAKE) install-local
+		$(MAKE) SHARED_PDKS_PATH=$(PDK_ROOT) install
 
 gen-sources: $(PDK_ROOT)/pdk/sky130A
 	touch $(PDK_ROOT)/pdk/sky130A/SOURCES

--- a/Makefile
+++ b/Makefile
@@ -133,13 +133,13 @@ open_pdks: $(PDK_ROOT)/ $(PDK_ROOT)/open_pdks
 
 .PHONY: build-pdk
 build-pdk: $(PDK_ROOT)/open_pdks $(PDK_ROOT)/skywater-pdk
-	[ -d $(PDK_ROOT)/sky130A ] && \
+	[ -d $(PDK_ROOT)/pdk/sky130A ] && \
 		(echo "Warning: A sky130A build already exists under $(PDK_ROOT). It will be deleted first!" && \
 		sleep 5 && \
-		rm -rf $(PDK_ROOT)/sky130A) || \
+		rm -rf $(PDK_ROOT)/pdk/sky130A) || \
 		true
 	$(ENV_COMMAND) sh -c " cd $(PDK_ROOT)/open_pdks && \
-		./configure --enable-sky130-pdk=$(PDK_ROOT)/skywater-pdk/libraries --with-sky130-local-path=$(PDK_ROOT)"
+		./configure --enable-sky130-pdk=$(PDK_ROOT)/skywater-pdk/libraries --prefix=$(PDK_ROOT) --datarootdir=$(PDK_ROOT)"
 	cd $(PDK_ROOT)/open_pdks/sky130 && \
 		$(MAKE) veryclean && \
 		$(MAKE) prerequisites
@@ -150,27 +150,27 @@ build-pdk: $(PDK_ROOT)/open_pdks $(PDK_ROOT)/skywater-pdk
 
 .PHONY: native-build-pdk
 native-build-pdk: $(PDK_ROOT)/open_pdks $(PDK_ROOT)/skywater-pdk
-	[ -d $(PDK_ROOT)/sky130A ] && \
+	[ -d $(PDK_ROOT)/pdk/sky130A ] && \
 		(echo "Warning: A sky130A build already exists under $(PDK_ROOT). It will be deleted first!" && \
 		sleep 5 && \
-		rm -rf $(PDK_ROOT)/sky130A) || \
+		rm -rf $(PDK_ROOT)/pdk/sky130A) || \
 		true
 	cd $(PDK_ROOT)/open_pdks && \
-		./configure --enable-sky130-pdk=$(PDK_ROOT)/skywater-pdk/libraries --with-sky130-local-path=$(PDK_ROOT) --enable-sram-sky130=$(INSTALL_SRAM) && \
+		./configure --enable-sky130-pdk=$(PDK_ROOT)/skywater-pdk/libraries --prefix=$(PDK_ROOT) --datarootdir=$(PDK_ROOT) --enable-sram-sky130=$(INSTALL_SRAM) && \
 		cd sky130 && \
 		$(MAKE) veryclean && \
 		$(MAKE) && \
 		$(MAKE) install-local
 
-gen-sources: $(PDK_ROOT)/sky130A
-	touch $(PDK_ROOT)/sky130A/SOURCES
+gen-sources: $(PDK_ROOT)/pdk/sky130A
+	touch $(PDK_ROOT)/pdk/sky130A/SOURCES
 	OPENLANE_COMMIT=$(git rev-parse HEAD)
-	echo -ne "openlane " > $(PDK_ROOT)/sky130A/SOURCES
-	cd $(OPENLANE_DIR) && git rev-parse HEAD >> $(PDK_ROOT)/sky130A/SOURCES
-	echo -ne "skywater-pdk " >> $(PDK_ROOT)/sky130A/SOURCES
-	cd $(PDK_ROOT)/skywater-pdk && git rev-parse HEAD >> $(PDK_ROOT)/sky130A/SOURCES
-	echo -ne "open_pdks " >> $(PDK_ROOT)/sky130A/SOURCES
-	cd $(PDK_ROOT)/open_pdks && git rev-parse HEAD >> $(PDK_ROOT)/sky130A/SOURCES
+	echo -ne "openlane " > $(PDK_ROOT)/pdk/sky130A/SOURCES
+	cd $(OPENLANE_DIR) && git rev-parse HEAD >> $(PDK_ROOT)/pdk/sky130A/SOURCES
+	echo -ne "skywater-pdk " >> $(PDK_ROOT)/pdk/sky130A/SOURCES
+	cd $(PDK_ROOT)/skywater-pdk && git rev-parse HEAD >> $(PDK_ROOT)/pdk/sky130A/SOURCES
+	echo -ne "open_pdks " >> $(PDK_ROOT)/pdk/sky130A/SOURCES
+	cd $(PDK_ROOT)/open_pdks && git rev-parse HEAD >> $(PDK_ROOT)/pdk/sky130A/SOURCES
 
 ### OPENLANE
 .PHONY: openlane

--- a/Makefile
+++ b/Makefile
@@ -163,14 +163,14 @@ native-build-pdk: $(PDK_ROOT)/open_pdks $(PDK_ROOT)/skywater-pdk
 		$(MAKE) SHARED_PDKS_PATH=$(PDK_ROOT) install
 
 gen-sources: $(PDK_ROOT)/pdk/sky130A
-	touch $(PDK_ROOT)/pdk/sky130A/SOURCES
+	touch $(PDK_ROOT)/sky130A/SOURCES
 	OPENLANE_COMMIT=$(git rev-parse HEAD)
-	echo -ne "openlane " > $(PDK_ROOT)/pdk/sky130A/SOURCES
-	cd $(OPENLANE_DIR) && git rev-parse HEAD >> $(PDK_ROOT)/pdk/sky130A/SOURCES
+	echo -ne "openlane " > $(PDK_ROOT)/sky130A/SOURCES
+	cd $(OPENLANE_DIR) && git rev-parse HEAD >> $(PDK_ROOT)/sky130A/SOURCES
 	echo -ne "skywater-pdk " >> $(PDK_ROOT)/pdk/sky130A/SOURCES
-	cd $(PDK_ROOT)/skywater-pdk && git rev-parse HEAD >> $(PDK_ROOT)/pdk/sky130A/SOURCES
-	echo -ne "open_pdks " >> $(PDK_ROOT)/pdk/sky130A/SOURCES
-	cd $(PDK_ROOT)/open_pdks && git rev-parse HEAD >> $(PDK_ROOT)/pdk/sky130A/SOURCES
+	cd $(PDK_ROOT)/skywater-pdk && git rev-parse HEAD >> $(PDK_ROOT)/sky130A/SOURCES
+	echo -ne "open_pdks " >> $(PDK_ROOT)/sky130A/SOURCES
+	cd $(PDK_ROOT)/open_pdks && git rev-parse HEAD >> $(PDK_ROOT)/sky130A/SOURCES
 
 ### OPENLANE
 .PHONY: openlane

--- a/Makefile
+++ b/Makefile
@@ -133,10 +133,10 @@ open_pdks: $(PDK_ROOT)/ $(PDK_ROOT)/open_pdks
 
 .PHONY: build-pdk
 build-pdk: $(PDK_ROOT)/open_pdks $(PDK_ROOT)/skywater-pdk
-	[ -d $(PDK_ROOT)/pdk/sky130A ] && \
+	[ -d $(PDK_ROOT)/sky130A ] && \
 		(echo "Warning: A sky130A build already exists under $(PDK_ROOT). It will be deleted first!" && \
 		sleep 5 && \
-		rm -rf $(PDK_ROOT)/pdk/sky130A) || \
+		rm -rf $(PDK_ROOT)/sky130A) || \
 		true
 	$(ENV_COMMAND) sh -c " cd $(PDK_ROOT)/open_pdks && \
 		./configure --enable-sky130-pdk=$(PDK_ROOT)/skywater-pdk/libraries"
@@ -150,10 +150,10 @@ build-pdk: $(PDK_ROOT)/open_pdks $(PDK_ROOT)/skywater-pdk
 
 .PHONY: native-build-pdk
 native-build-pdk: $(PDK_ROOT)/open_pdks $(PDK_ROOT)/skywater-pdk
-	[ -d $(PDK_ROOT)/pdk/sky130A ] && \
+	[ -d $(PDK_ROOT)/sky130A ] && \
 		(echo "Warning: A sky130A build already exists under $(PDK_ROOT). It will be deleted first!" && \
 		sleep 5 && \
-		rm -rf $(PDK_ROOT)/pdk/sky130A) || \
+		rm -rf $(PDK_ROOT)/sky130A) || \
 		true
 	cd $(PDK_ROOT)/open_pdks && \
 		./configure --enable-sky130-pdk=$(PDK_ROOT)/skywater-pdk/libraries --enable-sram-sky130=$(INSTALL_SRAM) && \
@@ -162,12 +162,12 @@ native-build-pdk: $(PDK_ROOT)/open_pdks $(PDK_ROOT)/skywater-pdk
 		$(MAKE) && \
 		$(MAKE) SHARED_PDKS_PATH=$(PDK_ROOT) install
 
-gen-sources: $(PDK_ROOT)/pdk/sky130A
+gen-sources: $(PDK_ROOT)/sky130A
 	touch $(PDK_ROOT)/sky130A/SOURCES
 	OPENLANE_COMMIT=$(git rev-parse HEAD)
 	echo -ne "openlane " > $(PDK_ROOT)/sky130A/SOURCES
 	cd $(OPENLANE_DIR) && git rev-parse HEAD >> $(PDK_ROOT)/sky130A/SOURCES
-	echo -ne "skywater-pdk " >> $(PDK_ROOT)/pdk/sky130A/SOURCES
+	echo -ne "skywater-pdk " >> $(PDK_ROOT)/sky130A/SOURCES
 	cd $(PDK_ROOT)/skywater-pdk && git rev-parse HEAD >> $(PDK_ROOT)/sky130A/SOURCES
 	echo -ne "open_pdks " >> $(PDK_ROOT)/sky130A/SOURCES
 	cd $(PDK_ROOT)/open_pdks && git rev-parse HEAD >> $(PDK_ROOT)/sky130A/SOURCES

--- a/dependencies/tool_metadata.yml
+++ b/dependencies/tool_metadata.yml
@@ -77,7 +77,7 @@
   in_install: false
 - name: open_pdks
   repo: https://github.com/rtimothyedwards/open_pdks
-  commit: 14a2389f9d2ed521fffd3e69928763ddb07bc434
+  commit: 8ae2261602ffc777a5896bbff03f48c5ce29d476
   build: ''
   in_install: false
   in_container: false

--- a/dependencies/tool_metadata.yml
+++ b/dependencies/tool_metadata.yml
@@ -77,7 +77,7 @@
   in_install: false
 - name: open_pdks
   repo: https://github.com/rtimothyedwards/open_pdks
-  commit: 13e0611f6a27fd6e601f8fe207773233f4f3883f
+  commit: 14a2389f9d2ed521fffd3e69928763ddb07bc434
   build: ''
   in_install: false
   in_container: false


### PR DESCRIPTION
- For open_pdks version `1.0.208` or later, the `--with-sky130-local-path` is deprecated. The complete installation path is instead specified by `SHARED_PDKS_PATH` variable. 