### PR TITLE
escape env variables that have $ in them

### DIFF
--- a/scripts/tcl_commands/all.tcl
+++ b/scripts/tcl_commands/all.tcl
@@ -22,9 +22,9 @@ proc save_state {args} {
     set_log ::env(PDK_ROOT) $::env(PDK_ROOT) $::env(GLB_CFG_FILE) 1
     foreach index [lsort [array names ::env]] {
         if { $index != "INIT_ENV_VAR_ARRAY" && $index != "PS1" } {
-            set escapped_env_var [string map {\" \\\"} $::env($index)]
-            set escapped_env_var [string map {\$ \\\$} $::env($index)]
-            set_log ::env($index) $escapped_env_var env(GLB_CFG_FILE) 1
+            set escaped_env_var [string map {\" \\\"} $::env($index)]
+            set escaped_env_var [string map {\$ \\\$} $::env($index)]
+            set_log ::env($index) $escaped_env_var env(GLB_CFG_FILE) 1
         }
     }
 }

--- a/scripts/tcl_commands/all.tcl
+++ b/scripts/tcl_commands/all.tcl
@@ -22,7 +22,9 @@ proc save_state {args} {
     set_log ::env(PDK_ROOT) $::env(PDK_ROOT) $::env(GLB_CFG_FILE) 1
     foreach index [lsort [array names ::env]] {
         if { $index != "INIT_ENV_VAR_ARRAY" && $index != "PS1" } {
-            set_log ::env($index) [string map {\" \\\"} $::env($index)] $::env(GLB_CFG_FILE) 1
+            set escapped_env_var [string map {\" \\\"} $::env($index)]
+            set escapped_env_var [string map {\$ \\\$} $::env($index)]
+            set_log ::env($index) $escapped_env_var env(GLB_CFG_FILE) 1
         }
     }
 }


### PR DESCRIPTION
When openlane is saving the state, it access all environment variables. The environment variable may contain `$` resulting in tcl trying to resolve a variable and exiting. This escapes and preservers dollars signs in environment variables.

Note: This might need to be revisited as there are possibly other special characters that needs escapping