### PR TITLE
Uploading Log Tarballs to GCP

### DIFF
--- a/.github/scripts/gh.py
+++ b/.github/scripts/gh.py
@@ -115,7 +115,7 @@ if os.getenv("GITHUB_ACTIONS") != "true":
     os.environ["BRANCH_NAME"] = branch
     os.environ["GITHUB_WORKSPACE"] = git_directory
     os.environ["GITHUB_EVENT_NAME"] = "workspace_dispatch"
-    os.environ["GITHUB_RUN_ID"] = "test_run"
+    os.environ["GITHUB_RUN_ID"] = "mock_gha_run"
     
     def export_env_alt(key, value):
         os.environ[key] = value

--- a/.github/scripts/upload_log_tarballs.py
+++ b/.github/scripts/upload_log_tarballs.py
@@ -21,8 +21,9 @@ import sys
 import glob
 import base64
 import traceback
-from typing import Callable
+import subprocess
 from gh import gh
+from typing import Callable
 
 def upload_log_tarballs():
     log_upload_info = os.getenv("LOG_UPLOAD_INFO")
@@ -36,6 +37,16 @@ def upload_log_tarballs():
     cleanup = lambda x: None
 
     if platform == "gcp":
+        try:
+            import google.cloud.storage
+        except ImportError:
+            print("Google Cloud Storage SDK not installed, attempting to install…", file=sys.stderr)
+            try:
+                subprocess.check_call([sys.executable, "-m", "pip", "install", "--upgrade", "google-cloud-storage"])
+            except:
+                print("Failed to install Google Cloud Storage SDK.", file=sys.stderr)
+                exit(os.EX_UNAVAILABLE)
+        
         from google.cloud import storage
         
         json = base64.b64decode(encoded_data).decode("utf8")

--- a/.github/scripts/upload_log_tarballs.py
+++ b/.github/scripts/upload_log_tarballs.py
@@ -78,5 +78,5 @@ if __name__ == "__main__":
         upload_log_tarballs()
     except Exception as e:
         print("An unhandled exception has occurred while uploading log tarballs.", file=sys.stderr)
-        print(e, file=sys.stderr)
+        # print(e, file=sys.stderr)
         exit(os.EX_UNAVAILABLE)

--- a/.github/scripts/upload_log_tarballs.py
+++ b/.github/scripts/upload_log_tarballs.py
@@ -17,16 +17,70 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
+import sys
 import glob
+import base64
+import traceback
+from typing import Callable
 from gh import gh
-from google.cloud import storage
 
-gcs_client = storage.Client()
-tarball_glob = os.path.join(gh.root, "designs", "*", "runs", "*.tar.gz")
-for tarball in glob.glob(tarball_glob):
-    tarball_basename = os.path.basename(tarball)
-    final_key = os.path.join(gh.run_id, tarball_basename)
-    
-    print(final_key)
+def upload_log_tarballs():
+    log_upload_info = os.getenv("LOG_UPLOAD_INFO")
+    if log_upload_info is None or log_upload_info.strip() == "":
+        print("No upload key was provided. Log tarballs will not be uploaded.", file=sys.stderr)
+        exit(0)
 
-#for report in glob.glob(os.path.join(results_folder, "%s*.rpt" % test_name)):
+    platform, bucket_name, encoded_data = log_upload_info.split(":")
+
+    upload: Callable[[str, str], None] = None
+    cleanup = lambda x: None
+
+    if platform == "gcp":
+        from google.cloud import storage
+        
+        json = base64.b64decode(encoded_data).decode("utf8")
+        with open("/tmp/gcp_credentials.json", "w") as f:
+            f.write(json)
+
+        gcs_client = storage.Client.from_service_account_json(
+            "/tmp/gcp_credentials.json"
+        )
+        bucket = gcs_client.get_bucket(bucket_name)
+
+
+        def gcp_upload(key, file):
+            blob = bucket.blob(key)
+            blob.upload_from_filename(file)
+
+        def gcp_cleanup():
+            os.remove("/tmp/gcp_credentials.json")
+
+        upload = gcp_upload
+        cleanup = gcp_cleanup
+    else:
+        print("Platform not supported. Ensure your key is formatted correctly as {platform}:{bucket_name}:{encoded_data}.", file=sys.stderr)
+        exit(os.EX_CONFIG)
+
+    tarball_glob = os.path.join(gh.root, "designs", "*", "runs", "*.tar.gz")
+    for tarball in glob.glob(tarball_glob):
+        design_name = os.path.basename(os.path.dirname(os.path.dirname(tarball)))
+        tarball_name = f"{design_name}.tar.gz"
+        final_key = os.path.join(gh.run_id, tarball_name)
+        
+        try:
+            upload(final_key, tarball)
+            print(f"Uploaded {design_name}'s tarball…")
+        except Exception as e:
+            print(e, file=sys.stderr)
+            print(traceback.format_exc(), file=sys.stderr)
+            print(f"Failed to upload tarball for {design_name}, skipping…", file=sys.stderr)
+
+    cleanup()
+    print("Done.")
+
+if __name__ == "__main__":
+    try:
+        upload_log_tarballs()
+    except:
+        print("An unhandled exception has occurred while uploading log tarballs.", file=sys.stderr)
+        exit(os.EX_UNAVAILABLE)

--- a/.github/scripts/upload_log_tarballs.py
+++ b/.github/scripts/upload_log_tarballs.py
@@ -69,7 +69,7 @@ def upload_log_tarballs():
         
         try:
             upload(final_key, tarball)
-            print(f"Uploaded {design_name}'s tarball…")
+            print(f"Uploaded {design_name}'s tarball to {final_key}.")
         except Exception as e:
             print(e, file=sys.stderr)
             print(traceback.format_exc(), file=sys.stderr)

--- a/.github/scripts/upload_log_tarballs.py
+++ b/.github/scripts/upload_log_tarballs.py
@@ -92,6 +92,7 @@ def upload_log_tarballs():
 if __name__ == "__main__":
     try:
         upload_log_tarballs()
-    except:
+    except Exception as e:
         print("An unhandled exception has occurred while uploading log tarballs.", file=sys.stderr)
+        print(e, file=sys.stderr)
         exit(os.EX_UNAVAILABLE)

--- a/.github/workflow-documentation.md
+++ b/.github/workflow-documentation.md
@@ -21,6 +21,7 @@ Repository secrets are used to protect certain credentials, but also as reposito
 | `DOCKER_IMAGE` | The name of the resulting Docker image (minus the tag). |
 | `DOCKERHUB_USER`  | A username for a user that has push access to the organization that owns `DOCKER_IMAGE` on Docker Hub. |
 | `DOCKERHUB_PASSWORD`  | The password/token for the given username that has push access to the organization that owns `DOCKER_IMAGE` on Docker Hub. |
+| `LOG_UPLOAD_INFO` | Information on a cloud platform to upload buckets to, in the format `platform:bucket:encoded_credentials`, where `platform` can be `gcp`/`aws`/etc, `bucket` is the bucket name, and `encoded_credentials` are simply the relevant credentials encoded in base64. It's a bit convoluted, but it makes it so different CI users can switch the platform out by changing a single secret. Currently, only the Google Cloud Platform is supported. Support for other platforms can be added to `upload_log_tarballs.py`. If this secret is not specified, the logs will not be uploaded. |
 
 ## Tool Updater
 

--- a/.github/workflows/openlane_ci.yml
+++ b/.github/workflows/openlane_ci.yml
@@ -125,6 +125,13 @@ jobs:
         env:
           TEST_SET: extendedTestSet${{ matrix.testset }}
         run: cd ${GITHUB_WORKSPACE}/ && python3 ${GITHUB_WORKSPACE}/.github/scripts/run_tests.py
+
+      - name: Upload Logs
+        if: ${{ always() }}
+        env:
+          LOG_UPLOAD_INFO: ${{ secrets.LOG_UPLOAD_INFO }}
+        run: cd ${GITHUB_WORKSPACE}/ && python3 ${GITHUB_WORKSPACE}/.github/scripts/upload_log_tarballs.py
+        
   cleanup_and_deploy:
       name: Cleanup (and Possibly Deployment)
       needs: test

--- a/.github/workflows/openlane_ci.yml
+++ b/.github/workflows/openlane_ci.yml
@@ -21,6 +21,12 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Upload Logs
+        if: ${{ always() }}
+        env:
+          LOG_UPLOAD_INFO: ${{ secrets.LOG_UPLOAD_INFO }}
+        run: cd ${GITHUB_WORKSPACE}/ && python3 ${GITHUB_WORKSPACE}/.github/scripts/upload_log_tarballs.py
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
 
@@ -125,12 +131,6 @@ jobs:
         env:
           TEST_SET: extendedTestSet${{ matrix.testset }}
         run: cd ${GITHUB_WORKSPACE}/ && python3 ${GITHUB_WORKSPACE}/.github/scripts/run_tests.py
-
-      - name: Upload Logs
-        if: ${{ always() }}
-        env:
-          LOG_UPLOAD_INFO: ${{ secrets.LOG_UPLOAD_INFO }}
-        run: cd ${GITHUB_WORKSPACE}/ && python3 ${GITHUB_WORKSPACE}/.github/scripts/upload_log_tarballs.py
         
   cleanup_and_deploy:
       name: Cleanup (and Possibly Deployment)

--- a/.github/workflows/openlane_ci.yml
+++ b/.github/workflows/openlane_ci.yml
@@ -20,13 +20,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Log Upload Dependencies
-        run: python3 -m pip install apache-libcloud==3.3.1
-      - name: Upload Logs
-        if: ${{ always() }}
-        env:
-          LOG_UPLOAD_INFO: ${{ secrets.LOG_UPLOAD_INFO }}
-        run: cd ${GITHUB_WORKSPACE}/ && python3 ${GITHUB_WORKSPACE}/.github/scripts/upload_log_tarballs.py
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
@@ -132,6 +125,15 @@ jobs:
         env:
           TEST_SET: extendedTestSet${{ matrix.testset }}
         run: cd ${GITHUB_WORKSPACE}/ && python3 ${GITHUB_WORKSPACE}/.github/scripts/run_tests.py
+
+      - name: Log Upload Dependencies
+        run: python3 -m pip install apache-libcloud==3.3.1
+        
+      - name: Upload Logs
+        if: ${{ always() }}
+        env:
+          LOG_UPLOAD_INFO: ${{ secrets.LOG_UPLOAD_INFO }}
+        run: cd ${GITHUB_WORKSPACE}/ && python3 ${GITHUB_WORKSPACE}/.github/scripts/upload_log_tarballs.py
         
   cleanup_and_deploy:
       name: Cleanup (and Possibly Deployment)

--- a/.github/workflows/openlane_ci.yml
+++ b/.github/workflows/openlane_ci.yml
@@ -20,7 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-
+      - name: Log Upload Dependencies
+        run: python3 -m pip install cloudstorage 'cloudstorage[google]'
       - name: Upload Logs
         if: ${{ always() }}
         env:

--- a/.github/workflows/openlane_ci.yml
+++ b/.github/workflows/openlane_ci.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Log Upload Dependencies
-        run: python3 -m pip install cloudstorage 'cloudstorage[google]'
+        run: python3 -m pip install apache-libcloud==3.3.1
       - name: Upload Logs
         if: ${{ always() }}
         env:

--- a/scripts/tcl_commands/all.tcl
+++ b/scripts/tcl_commands/all.tcl
@@ -22,9 +22,7 @@ proc save_state {args} {
     set_log ::env(PDK_ROOT) $::env(PDK_ROOT) $::env(GLB_CFG_FILE) 1
     foreach index [lsort [array names ::env]] {
         if { $index != "INIT_ENV_VAR_ARRAY" && $index != "PS1" } {
-            set escaped_env_var [string map {\" \\\"} $::env($index)]
-            set escaped_env_var [string map {\$ \\\$} $::env($index)]
-            set_log ::env($index) $escaped_env_var env(GLB_CFG_FILE) 1
+            set_log ::env($index) [string map {\" \\\"} $::env($index)] $::env(GLB_CFG_FILE) 1
         }
     }
 }

--- a/scripts/tcl_commands/all.tcl
+++ b/scripts/tcl_commands/all.tcl
@@ -22,7 +22,9 @@ proc save_state {args} {
     set_log ::env(PDK_ROOT) $::env(PDK_ROOT) $::env(GLB_CFG_FILE) 1
     foreach index [lsort [array names ::env]] {
         if { $index != "INIT_ENV_VAR_ARRAY" && $index != "PS1" } {
-            set_log ::env($index) [string map {\" \\\"} $::env($index)] $::env(GLB_CFG_FILE) 1
+            set escaped_env_var [string map {\" \\\"} $::env($index)]
+            set escaped_env_var [string map {\$ \\\$} $::env($index)]
+            set_log ::env($index) $escaped_env_var $::env(GLB_CFG_FILE) 1
         }
     }
 }


### PR DESCRIPTION
This adds a step to the CI that uploads log tarballs to the Google Cloud Platform based on a repository secret to help maintainers isolate issues that may only arise in a CI environment.

The relevant repository secret has already been added.

It can easily be extended to support AWS, Azure, etc as it leverages Apache libcloud.

The bucket being used is not public.