### PR TITLE
Fixing some issues in report generation

### DIFF
--- a/flow.tcl
+++ b/flow.tcl
@@ -123,7 +123,7 @@ proc run_antenna_check_step {{ antenna_check_enabled 1 }} {
 	}
 }
 
-	
+
 
 proc run_non_interactive_mode {args} {
 	set options {
@@ -213,8 +213,8 @@ proc run_non_interactive_mode {args} {
 
 
 	calc_total_runtime
+	save_state
 	generate_final_summary_report
-    save_state
 
 	puts_success "Flow Completed Without Fatal Errors."
 }

--- a/scripts/report/report.sh
+++ b/scripts/report/report.sh
@@ -59,30 +59,125 @@ cvc_log=$(python3 $3/get_file_name.py -p ${path}/logs/cvc/ -o cvc_screen.log 2>&
 tritonRoute_def=$(python3 $3/get_file_name.py -p ${path}/results/routing/ -o ${designName}.def 2>&1)
 replace_log=$(python3 $3/get_file_name.py -p ${path}/logs/placement/ -o replace.log 2>&1)
 lvs_report=${path}/results/lvs/${designName}.lvs_parsed.*.log
+
+test_file() {
+        # Tests if a log file exists and is greater than 10 bytes
+        find $1 -type f -size +10c 2> /dev/null
+}
+
+parse_to_report() {
+        export LOG=$1
+        export REPORT_PATH=$2
+        export REPORT=$3
+        export FROM=$4
+        export TO=$5
+        python3 $SCRIPT_PATH/report_parser.py $LOG $(python3 $SCRIPT_PATH/get_file_name.py -p ${REPORT_PATH} -o ${REPORT} 2>&1) $FROM $TO
+}
+
+REPORT_PATH=${path}/reports/cts/
+if [[ $(test_file $cts_log) ]]; then
+        parse_to_report $cts_log $REPORT_PATH cts.timing.rpt timing_report timing_report_end
+        parse_to_report $cts_log $REPORT_PATH cts.timing.rpt timing_report timing_report_end
+        parse_to_report $cts_log $REPORT_PATH cts.min_max.rpt min_max_report min_max_report_end
+        parse_to_report $cts_log $REPORT_PATH cts.rpt check_report check_report_end
+        parse_to_report $cts_log $REPORT_PATH cts_wns.rpt wns_report wns_report_end
+        parse_to_report $cts_log $REPORT_PATH cts_tns.rpt tns_report tns_report_end
+        parse_to_report $cts_log $REPORT_PATH cts_clock_skew.rpt clock_skew_report clock_skew_report_end
+else
+        echo "CTS log not found or empty." > $REPORT_PATH/cts.rpt
+fi
+
+REPORT_PATH=${path}/reports/routing/
+if [[ $(test_file $routing_log) ]]; then
+        parse_to_report $routing_log $REPORT_PATH fastroute.timing.rpt timing_report timing_report_end
+        parse_to_report $routing_log $REPORT_PATH fastroute.min_max.rpt min_max_report min_max_report_end
+        parse_to_report $routing_log $REPORT_PATH fastroute.rpt check_report check_report_end
+        parse_to_report $routing_log $REPORT_PATH fastroute_wns.rpt wns_report wns_report_end
+        parse_to_report $routing_log $REPORT_PATH fastroute_tns.rpt tns_report tns_report_end
+else
+        echo "Routing log not found or empty." > $REPORT_PATH/fastroute.rpt
+fi
+
+REPORT_PATH=${path}/reports/placement/
+if [[ $(test_file $placement_log) ]]; then
+        parse_to_report $placement_log $REPORT_PATH replace.timing.rpt timing_report timing_report_end
+        parse_to_report $placement_log $REPORT_PATH replace.min_max.rpt min_max_report min_max_report_end
+        parse_to_report $placement_log $REPORT_PATH replace.rpt check_report check_report_end
+        parse_to_report $placement_log $REPORT_PATH replace_wns.rpt wns_report wns_report_end
+        parse_to_report $placement_log $REPORT_PATH replace_tns.rpt tns_report tns_report_end
+else
+        echo "Placement log not found or empty." > $REPORT_PATH/replace.rpt
+fi
+
+REPORT_PATH=${path}/reports/synthesis/
+if [[ $(test_file $sta_log) ]]; then
+        parse_to_report $sta_log $REPORT_PATH opensta.timing.rpt timing_report timing_report_end
+        parse_to_report $sta_log $REPORT_PATH opensta.min_max.rpt min_max_report min_max_report_end
+        parse_to_report $sta_log $REPORT_PATH opensta.rpt check_report check_report_end
+        parse_to_report $sta_log $REPORT_PATH opensta_wns.rpt wns_report wns_report_end
+        parse_to_report $sta_log $REPORT_PATH opensta_tns.rpt tns_report tns_report_end
+        parse_to_report $sta_log $REPORT_PATH opensta.slew.rpt check_slew check_slew_end
+else
+        echo "Static Timing Analysis log not found or empty." > $REPORT_PATH/opensta.rpt
+fi
+
+if [[ $(test_file $sta_post_resizer_log) ]]; then
+        parse_to_report $sta_post_resizer_log $REPORT_PATH opensta_post_resizer.timing.rpt timing_report timing_report_end
+        parse_to_report $sta_post_resizer_log $REPORT_PATH opensta_post_resizer.min_max.rpt min_max_report min_max_report_end
+        parse_to_report $sta_post_resizer_log $REPORT_PATH opensta_post_resizer.rpt check_report check_report_end
+        parse_to_report $sta_post_resizer_log $REPORT_PATH opensta_post_resizer_wns.rpt wns_report wns_report_end
+        parse_to_report $sta_post_resizer_log $REPORT_PATH opensta_post_resizer_tns.rpt tns_report tns_report_end
+        parse_to_report $sta_post_resizer_log $REPORT_PATH opensta_post_resizer.slew.rpt check_slew check_slew_end
+else
+        echo "Static Timing Analysis Post Resizer log not found or empty." > $REPORT_PATH/opensta_post_resizer.rpt
+fi
+
+if [[ $(find $sta_post_resizer_timing_log -type f -size +10c 2> /dev/null) ]]; then
+        parse_to_report $sta_post_resizer_timing_log $REPORT_PATH opensta_post_resizer_timing.timing.rpt timing_report timing_report_end
+        parse_to_report $sta_post_resizer_timing_log $REPORT_PATH opensta_post_resizer_timing.min_max.rpt min_max_report min_max_report_end
+        parse_to_report $sta_post_resizer_timing_log $REPORT_PATH opensta_post_resizer_timing.rpt check_report check_report_end
+        parse_to_report $sta_post_resizer_timing_log $REPORT_PATH opensta_post_resizer_timing_wns.rpt wns_report wns_report_end
+        parse_to_report $sta_post_resizer_timing_log $REPORT_PATH opensta_post_resizer_timing_tns.rpt tns_report tns_report_end
+        parse_to_report $sta_post_resizer_timing_log $REPORT_PATH opensta_post_resizer_timing.slew.rpt check_slew check_slew_end
+else
+        echo "Static Timing Analysis Post Resizer Timing log not found or empty." > $REPORT_PATH/opensta_post_resizer_timing.rpt
+fi
+
+if [[ $(test_file $sta_spef_log) ]]; then
+        parse_to_report $sta_spef_log $REPORT_PATH opensta_spef.timing.rpt timing_report timing_report_end
+        parse_to_report $sta_spef_log $REPORT_PATH opensta_spef.min_max.rpt min_max_report min_max_report_end
+        parse_to_report $sta_spef_log $REPORT_PATH opensta_spef.rpt check_report check_report_end
+        parse_to_report $sta_spef_log $REPORT_PATH opensta_spef_wns.rpt wns_report wns_report_end
+        parse_to_report $sta_spef_log $REPORT_PATH opensta_spef_tns.rpt tns_report tns_report_end
+        parse_to_report $sta_spef_log $REPORT_PATH opensta_spef.slew.rpt check_slew check_slew_end
+else
+        echo "Static Timing Analysis SPEF log not found or empty." > $REPORT_PATH/opensta_spef.rpt
+fi
+
 # Extracting info from Yosys
 cell_count=$(grep "cells" $yosys_rprt -s | tail -1 | sed -r 's/.*[^0-9]//')
-if ! [[ $cell_count ]]; then cell_count=-1; fi
+if ! [[ $cell_count ]]; then cell_count="E404"; fi
 
 #Extracting routed_runtime info
 if [ -f $routed_runtime_rpt ]; then
         routed_runtime=$(sed 's/.*in //' $routed_runtime_rpt)
-        if ! [[ $routed_runtime ]]; then routed_runtime=-1; fi
+        if ! [[ $routed_runtime ]]; then routed_runtime="E404"; fi
 else
-        routed_runtime=-1;
+        routed_runtime="E404";
 fi
 
 #Extracting total_runtime info
 if [ -f $total_runtime_rpt ]; then
         total_runtime=$(sed 's/.*in //' $total_runtime_rpt)
-        if ! [[ $total_runtime ]]; then total_runtime=-1; fi
+        if ! [[ $total_runtime ]]; then total_runtime="E404"; fi
         flow_status=$(sed 's/ for .*//' $total_runtime_rpt)
         if ! [[ $flow_status ]]; then
-                flow_status="unknown_no_content_in_file"; 
+                flow_status="unknown_no_content_in_file";
         else
                 flow_status="${flow_status// /_}"
         fi
 else
-        total_runtime=-1;
+        total_runtime="E404";
         flow_status="unknown_no_total_runtime_file";
 fi
 
@@ -93,58 +188,58 @@ if [ -f $tritonRoute_def ]; then
         tmpc=$(awk  '/DIEAREA/ {print $3, $4, $7, $8; exit}' $tritonRoute_def | cut -d' ' -f 3)
         tmpd=$(awk  '/DIEAREA/ {print $3, $4, $7, $8; exit}' $tritonRoute_def | cut -d' ' -f 4)
         diearea=$(( (($tmpc-$tmpa)/1000)*(($tmpd-$tmpb)/1000) ))
-        if ! [[ $diearea ]]; then diearea=-1;fi
+        if ! [[ $diearea ]]; then diearea="E404";fi
 else
-        diearea=-1;
+        diearea="E404";
 fi
 
 #Place Holder for cell per um
-cellperum=-1
-#if ! [[ $cellperum ]]; then cellperum=-1;fi
+cellperum="E404"
+#if ! [[ $cellperum ]]; then cellperum="E404";fi
 
 #Extracting OpenDP Reported Utilization
 opendpUtil=$(grep "Util(%):" $replace_log -s | head -1 | sed -E 's/.*Util\(%\): (\S+)/\1/')
-if ! [[ $opendpUtil ]]; then opendpUtil=-1; fi
+if ! [[ $opendpUtil ]]; then opendpUtil="E404"; fi
 
 #Extracting TritonRoute memory usage peak
 tritonRoute_memoryPeak=$(grep ", peak = " $tritonRoute_log -s | tail -1 | sed -E 's/.*peak = (\S+).*/\1/')
-if ! [[ $tritonRoute_memoryPeak ]]; then tritonRoute_memoryPeak=-1; fi
+if ! [[ $tritonRoute_memoryPeak ]]; then tritonRoute_memoryPeak="E404"; fi
 
 #Extracting TritonRoute Violations Information
 tritonRoute_violations=$(grep -si "Number of violations" $tritonRoute_log | tail -1 | python3 -c 'import re; print(re.match(r"\[.+?\].*?\=\s*(\d+)", input())[1])')
-if ! [[ $tritonRoute_violations ]]; then tritonRoute_violations=-1; fi
+if ! [[ $tritonRoute_violations ]]; then tritonRoute_violations="E404"; fi
 Other_violations=$tritonRoute_violations;
 
 if [ -f $tritonRoute_drc ]; then
         Short_violations=$(grep "Short" $tritonRoute_drc -s | wc -l)
-        if ! [[ $Short_violations ]]; then Short_violations=-1; fi
+        if ! [[ $Short_violations ]]; then Short_violations="E404"; fi
         Other_violations=$((Other_violations-Short_violations));
 
         MetSpc_violations=$(grep "MetSpc" $tritonRoute_drc -s | wc -l)
-        if ! [[ $MetSpc_violations ]]; then MetSpc_violations=-1; fi
+        if ! [[ $MetSpc_violations ]]; then MetSpc_violations="E404"; fi
         Other_violations=$((Other_violations-MetSpc_violations));
 
         OffGrid_violations=$(grep "OffGrid" $tritonRoute_drc -s | wc -l)
-        if ! [[ $OffGrid_violations ]]; then OffGrid_violations=-1; fi
+        if ! [[ $OffGrid_violations ]]; then OffGrid_violations="E404"; fi
         Other_violations=$((Other_violations-OffGrid_violations));
 
         MinHole_violations=$(grep "MinHole" $tritonRoute_drc -s | wc -l)
-        if ! [[ $MinHole_violations ]]; then MinHole_violations=-1; fi
+        if ! [[ $MinHole_violations ]]; then MinHole_violations="E404"; fi
         Other_violations=$((Other_violations-MinHole_violations));
 else
-        Short_violations=-1;
-        MetSpc_violations=-1;
-        OffGrid_violations=-1;
-        MinHole_violations=-1;
+        Short_violations="E404";
+        MetSpc_violations="E404";
+        OffGrid_violations="E404";
+        MinHole_violations="E404";
 fi
 
 #Extracting Magic Violations from Magic drc
 if [ -f $magic_drc ]; then
         Magic_violations=$(grep "^ [0-9]" $magic_drc -s | wc -l)
-        if ! [[ $Magic_violations ]]; then Magic_violations=-1; fi
+        if ! [[ $Magic_violations ]]; then Magic_violations="E404"; fi
         if [ $Magic_violations -ne -1 ]; then Magic_violations=$(((Magic_violations+3)/4)); fi
 else
-        Magic_violations=-1;
+        Magic_violations="E404";
 fi
 
 
@@ -153,34 +248,34 @@ if [ -f "$klayout_drc" ]; then
         klayout_violations=$(grep "<item>" $klayout_drc -s | wc -l)
         if ! [[ $klayout_violations ]]; then klayout_violations=0; fi
 else
-        klayout_violations=-1;
+        klayout_violations="E404";
 fi
 
 # Extracting Antenna Violations
 if [ -f $arc_antenna_report ]; then
         #arc check
         antenna_violations=$(grep "Number of pins violated:" $arc_antenna_report -s | tail -1 | sed -r 's/.*[^0-9]//')
-        if ! [[ $antenna_violations ]]; then antenna_violations=-1; fi
+        if ! [[ $antenna_violations ]]; then antenna_violations="E404"; fi
 else
         if [ -f $magic_antenna_report ]; then
                 #old magic check
                 antenna_violations=$(wc $magic_antenna_report -l | cut -d ' ' -f 1)
-                if ! [[ $antenna_violations ]]; then antenna_violations=-1; fi
+                if ! [[ $antenna_violations ]]; then antenna_violations="E404"; fi
         else
 
-                antenna_violations=-1;
+                antenna_violations="E404";
         fi
 fi
 
 #Extracting Other information from TritonRoute Logs
-wire_length=$(grep "total wire length =" $tritonRoute_log -s | tail -1 | sed -r 's/[^0-9]*//g')
-if ! [[ $wire_length ]]; then wire_length=-1; fi
-vias=$(grep "total number of vias =" $tritonRoute_log -s | tail -1 | sed -r 's/[^0-9]*//g')
-if ! [[ $vias ]]; then vias=-1; fi
+wire_length=$(grep "Total wire length =" $tritonRoute_log -s | tail -1 | sed -r 's/[^0-9]*//g')
+if ! [[ $wire_length ]]; then wire_length="E404"; fi
+vias=$(grep "Total number of vias =" $tritonRoute_log -s | tail -1 | sed -r 's/[^0-9]*//g')
+if ! [[ $vias ]]; then vias="E404"; fi
 
 #Extracting Info from OpenSTA
 wns=$(grep "wns" $wns_rpt -s | sed -r 's/wns //')
-if ! [[ $wns ]]; then wns=-1; fi
+if ! [[ $wns ]]; then wns="E404"; fi
 
 #Extracting info from OpenSTA post global placement using estimate parasitics
 pl_wns=$(grep "wns" $pl_wns_rpt -s | tail -1 |sed -r 's/wns //')
@@ -200,7 +295,7 @@ if ! [[ $spef_wns ]]; then spef_wns=$fr_wns; fi
 
 #Extracting Info from OpenSTA
 tns=$(grep "tns" $tns_rpt -s | sed -r 's/tns //')
-if ! [[ $tns ]]; then tns=-1; fi
+if ! [[ $tns ]]; then tns="E404"; fi
 
 #Extracting info from OpenSTA post global placement using estimate parasitics
 pl_tns=$(grep "tns" $pl_tns_rpt -s | tail -1 |sed -r 's/tns //')
@@ -225,7 +320,7 @@ if ! [[ $spef_tns ]]; then spef_tns=$opt_tns; fi
 
 #openroad replace extraction
 hpwl=$(grep " HPWL: " $HPWL_rpt -s | tail -1 | sed -E 's/.*HPWL: (\S+).*/\1/')
-if ! [[ $hpwl ]]; then hpwl=-1; fi
+if ! [[ $hpwl ]]; then hpwl="E404"; fi
 
 #Extracting Info from Yosys logs
 declare -a metrics=(
@@ -245,7 +340,7 @@ declare -a metrics=(
         "\$_XOR"
         "\$_XNOR"
         "\$_MUX"
-        )
+)
 
 metrics_vals=()
 for metric in "${metrics[@]}"; do
@@ -258,23 +353,23 @@ done
 input_output=$(grep -e "ABC: netlist" $yosys_log -s | tail -1 | sed -r 's/ABC: netlist[^0-9]*([0-9]+)\/ *([0-9]+).*/\1 \2/')
 if ! [[ $input_output ]]; then input_output="-1 -1"; fi
 level=$(grep -e "ABC: netlist" $yosys_log -s | tail -1 | sed -r 's/.*lev.*[^0-9]([0-9]+)$/\1/')
-if ! [[ $level ]]; then level=-1; fi
+if ! [[ $level ]]; then level="E404"; fi
 
 #Extracting layer usage percentage
 usageLine=$(grep -n -E "Layer\s+Resource" $fr_log | tail -1 | sed -E 's/(\S+):.*/\1/')
 
 layer1=$(sed -n "$(expr $usageLine + 2)p" $fr_log | sed -E 's/.*\s+(\S+)%.*/\1/')
-if ! [[ $layer1 ]]; then layer1=-1; fi
+if ! [[ $layer1 ]]; then layer1="E404"; fi
 layer2=$(sed -n "$(expr $usageLine + 3)p" $fr_log | sed -E 's/.*\s+(\S+)%.*/\1/')
-if ! [[ $layer2 ]]; then layer2=-1; fi
+if ! [[ $layer2 ]]; then layer2="E404"; fi
 layer3=$(sed -n "$(expr $usageLine + 4)p" $fr_log | sed -E 's/.*\s+(\S+)%.*/\1/')
-if ! [[ $layer3 ]]; then layer3=-1; fi
+if ! [[ $layer3 ]]; then layer3="E404"; fi
 layer4=$(sed -n "$(expr $usageLine + 5)p" $fr_log | sed -E 's/.*\s+(\S+)%.*/\1/')
-if ! [[ $layer4 ]]; then layer4=-1; fi
+if ! [[ $layer4 ]]; then layer4="E404"; fi
 layer5=$(sed -n "$(expr $usageLine + 6)p" $fr_log | sed -E 's/.*\s+(\S+)%.*/\1/')
-if ! [[ $layer5 ]]; then layer5=-1; fi
+if ! [[ $layer5 ]]; then layer5="E404"; fi
 layer6=$(sed -n "$(expr $usageLine + 7)p" $fr_log | sed -E 's/.*\s+(\S+)%.*/\1/')
-if ! [[ $layer6 ]]; then layer6=-1; fi
+if ! [[ $layer6 ]]; then layer6="E404"; fi
 
 #Extracting Endcaps and TapCells
 endcaps=$(grep "Endcaps inserted:" $tapcell_log -s | tail -1 | sed -E 's/.*Endcaps inserted: (\S+)/\1/')
@@ -299,113 +394,21 @@ if ! [[ -f "$lvs_report" ]]; then
         lvs_total_errors=$(grep "Total errors =" $lvs_report -s | tail -1 | sed -r 's/[^0-9]*//g')
         if ! [[ $lvs_total_errors ]]; then lvs_total_errors=0; fi
 else
-        lvs_total_errors=-1;
+        lvs_total_errors="E404";
 fi
 
 
 #Extracting the total number of cvc errors
 cvc_total_errors=$(grep "CVC: Total: " $cvc_log -s | tail -1 | sed -r 's/[^0-9]*//g')
-if ! [[ $cvc_total_errors ]]; then cvc_total_errors=-1; fi
+if ! [[ $cvc_total_errors ]]; then cvc_total_errors="E404"; fi
 
 result="$flow_status $total_runtime $routed_runtime $diearea $cellperum $opendpUtil $tritonRoute_memoryPeak $cell_count $tritonRoute_violations $Short_violations $MetSpc_violations $OffGrid_violations $MinHole_violations $Other_violations $Magic_violations $antenna_violations $lvs_total_errors $cvc_total_errors $klayout_violations $wire_length $vias $wns $pl_wns $opt_wns $fr_wns $spef_wns $tns $pl_tns $opt_tns $fr_tns $spef_tns $hpwl $layer1 $layer2 $layer3 $layer4 $layer5 $layer6"
 for val in "${metrics_vals[@]}"; do
-	result+=" $val"
+        result+=" $val"
 done
 result+=" $input_output"
 result+=" $level"
 result+=" $endcaps $tapcells $diodes $physical_cells"
 echo "$result"
 
-test_file() {
-        # Tests if a log file exists and is greater than 10 bytes
-        find $1 -type f -size +10c 2> /dev/null
-}
 
-parse_to_report() {
-        export LOG=$1
-        export REPORT_PATH=$2
-        export REPORT=$3
-        export FROM=$4
-        export TO=$5
-        python3 $SCRIPT_PATH/report_parser.py $LOG $(python3 $SCRIPT_PATH/get_file_name.py -p ${REPORT_PATH} -o ${REPORT} 2>&1) $FROM $TO 
-}
-
-REPORT_PATH=${path}/reports/cts/
-if [[ $(test_file $cts_log) ]]; then
-        parse_to_report $cts_log $REPORT_PATH cts.timing.rpt timing_report timing_report_end
-        parse_to_report $cts_log $REPORT_PATH cts.timing.rpt timing_report timing_report_end
-        parse_to_report $cts_log $REPORT_PATH cts.min_max.rpt min_max_report min_max_report_end
-        parse_to_report $cts_log $REPORT_PATH cts.rpt check_report check_report_end
-        parse_to_report $cts_log $REPORT_PATH cts_wns.rpt wns_report wns_report_end
-        parse_to_report $cts_log $REPORT_PATH cts_tns.rpt tns_report tns_report_end
-        parse_to_report $cts_log $REPORT_PATH cts_clock_skew.rpt clock_skew_report clock_skew_report_end
-else 
-	echo "CTS log not found or empty." > $REPORT_PATH/cts.rpt
-fi
-
-REPORT_PATH=${path}/reports/routing/
-if [[ $(test_file $routing_log) ]]; then
-        parse_to_report $routing_log $REPORT_PATH fastroute.timing.rpt timing_report timing_report_end
-        parse_to_report $routing_log $REPORT_PATH fastroute.min_max.rpt min_max_report min_max_report_end
-        parse_to_report $routing_log $REPORT_PATH fastroute.rpt check_report check_report_end
-        parse_to_report $routing_log $REPORT_PATH fastroute_wns.rpt wns_report wns_report_end
-        parse_to_report $routing_log $REPORT_PATH fastroute_tns.rpt tns_report tns_report_end
-else 
-	echo "Routing log not found or empty." > $REPORT_PATH/fastroute.rpt
-fi
-
-REPORT_PATH=${path}/reports/placement/
-if [[ $(test_file $placement_log) ]]; then
-        parse_to_report $placement_log $REPORT_PATH replace.timing.rpt timing_report timing_report_end
-        parse_to_report $placement_log $REPORT_PATH replace.min_max.rpt min_max_report min_max_report_end
-        parse_to_report $placement_log $REPORT_PATH replace.rpt check_report check_report_end
-        parse_to_report $placement_log $REPORT_PATH replace_wns.rpt wns_report wns_report_end
-        parse_to_report $placement_log $REPORT_PATH replace_tns.rpt tns_report tns_report_end
-else 
-	echo "Placement log not found or empty." > $REPORT_PATH/replace.rpt
-fi
-
-REPORT_PATH=${path}/reports/synthesis/
-if [[ $(test_file $sta_log) ]]; then
-	parse_to_report $sta_log $REPORT_PATH opensta.timing.rpt timing_report timing_report_end
-	parse_to_report $sta_log $REPORT_PATH opensta.min_max.rpt min_max_report min_max_report_end
-	parse_to_report $sta_log $REPORT_PATH opensta.rpt check_report check_report_end
-	parse_to_report $sta_log $REPORT_PATH opensta_wns.rpt wns_report wns_report_end
-	parse_to_report $sta_log $REPORT_PATH opensta_tns.rpt tns_report tns_report_end
-	parse_to_report $sta_log $REPORT_PATH opensta.slew.rpt check_slew check_slew_end
-else 
-	echo "Static Timing Analysis log not found or empty." > $REPORT_PATH/opensta.rpt
-fi
-
-if [[ $(test_file $sta_post_resizer_log) ]]; then
-	parse_to_report $sta_post_resizer_log $REPORT_PATH opensta_post_resizer.timing.rpt timing_report timing_report_end
-	parse_to_report $sta_post_resizer_log $REPORT_PATH opensta_post_resizer.min_max.rpt min_max_report min_max_report_end
-	parse_to_report $sta_post_resizer_log $REPORT_PATH opensta_post_resizer.rpt check_report check_report_end
-	parse_to_report $sta_post_resizer_log $REPORT_PATH opensta_post_resizer_wns.rpt wns_report wns_report_end
-	parse_to_report $sta_post_resizer_log $REPORT_PATH opensta_post_resizer_tns.rpt tns_report tns_report_end
-	parse_to_report $sta_post_resizer_log $REPORT_PATH opensta_post_resizer.slew.rpt check_slew check_slew_end
-else 
-	echo "Static Timing Analysis Post Resizer log not found or empty." > $REPORT_PATH/opensta_post_resizer.rpt
-fi
-
-if [[ $(find $sta_post_resizer_timing_log -type f -size +10c 2> /dev/null) ]]; then
-	parse_to_report $sta_post_resizer_timing_log $REPORT_PATH opensta_post_resizer_timing.timing.rpt timing_report timing_report_end
-	parse_to_report $sta_post_resizer_timing_log $REPORT_PATH opensta_post_resizer_timing.min_max.rpt min_max_report min_max_report_end
-	parse_to_report $sta_post_resizer_timing_log $REPORT_PATH opensta_post_resizer_timing.rpt check_report check_report_end
-	parse_to_report $sta_post_resizer_timing_log $REPORT_PATH opensta_post_resizer_timing_wns.rpt wns_report wns_report_end
-	parse_to_report $sta_post_resizer_timing_log $REPORT_PATH opensta_post_resizer_timing_tns.rpt tns_report tns_report_end
-	parse_to_report $sta_post_resizer_timing_log $REPORT_PATH opensta_post_resizer_timing.slew.rpt check_slew check_slew_end
-else 
-	echo "Static Timing Analysis Post Resizer Timing log not found or empty." > $REPORT_PATH/opensta_post_resizer_timing.rpt
-fi
-
-if [[ $(test_file $sta_spef_log) ]]; then
-	parse_to_report $sta_spef_log $REPORT_PATH opensta_spef.timing.rpt timing_report timing_report_end
-	parse_to_report $sta_spef_log $REPORT_PATH opensta_spef.min_max.rpt min_max_report min_max_report_end
-	parse_to_report $sta_spef_log $REPORT_PATH opensta_spef.rpt check_report check_report_end
-	parse_to_report $sta_spef_log $REPORT_PATH opensta_spef_wns.rpt wns_report wns_report_end
-	parse_to_report $sta_spef_log $REPORT_PATH opensta_spef_tns.rpt tns_report tns_report_end
-	parse_to_report $sta_spef_log $REPORT_PATH opensta_spef.slew.rpt check_slew check_slew_end
-else 
-	echo "Static Timing Analysis SPEF log not found or empty." > $REPORT_PATH/opensta_spef.rpt
-fi


### PR DESCRIPTION
1. Save state before generating the report. Generating the report reads a run's `config.tcl` which is changed after saving the state, so we should save the state first then generate the report.
2. In `report.sh`, fetching some values happens before generating the values themselve. This adjusts the sequence of commands properly. 
3. Report `E404` instead of `-1` in values that fail to get captured as some of these values can be `-1` themselves.
4. Some indenting in `report.sh`