### PR TITLE
Fix Race Condition With CI

### DIFF
--- a/.github/workflows/openlane_ci.yml
+++ b/.github/workflows/openlane_ci.yml
@@ -128,7 +128,7 @@ jobs:
 
       - name: Log Upload Dependencies
         run: python3 -m pip install apache-libcloud==3.3.1
-        
+
       - name: Upload Logs
         if: ${{ always() }}
         env:
@@ -212,7 +212,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Docker Push (Branch Name)
-        if: ${{ env.PUSHING == '1' }}
+        if: ${{ env.PUSHING == '1' && github.event_name == 'push'}}
         run: |
           docker image tag ${{ env.IMAGE_NAME }} ${{ secrets.DOCKER_IMAGE }}:${{ env.BRANCH_NAME }}
           docker push ${{ secrets.DOCKER_IMAGE }}:${{ env.BRANCH_NAME }}

--- a/.github/workflows/openlane_ci.yml
+++ b/.github/workflows/openlane_ci.yml
@@ -212,7 +212,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Docker Push (Branch Name)
-        if: ${{ env.PUSHING == '1' && github.event_name == 'push'}}
+        if: ${{ env.PUSHING == '1' && github.event_name == 'push' }}
         run: |
           docker image tag ${{ env.IMAGE_NAME }} ${{ secrets.DOCKER_IMAGE }}:${{ env.BRANCH_NAME }}
           docker push ${{ secrets.DOCKER_IMAGE }}:${{ env.BRANCH_NAME }}


### PR DESCRIPTION
This addresses a race condition when a PR is merged when the scheduled CI is running.

Essentially, an image could be pushed with the tag `master` following a merge, where it would later be rewritten by the CI when it's done with the same `master` tag.

This makes it so the CI only pushes to a proper named tag and `latest`.