### PR TITLE
Fix PIP issue with rtd

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -19,4 +19,4 @@ channels:
 dependencies:
 - python>=3.8
 - pip:
-  - -r file:requirements.txt
+  - -r ./requirements.txt


### PR DESCRIPTION
This fixes an issue with pip where support for file: was abruptly removed.