### PR TITLE
Log Upload Fix

### DIFF
--- a/.github/workflows/openlane_ci.yml
+++ b/.github/workflows/openlane_ci.yml
@@ -125,15 +125,14 @@ jobs:
         env:
           TEST_SET: extendedTestSet${{ matrix.testset }}
         run: cd ${GITHUB_WORKSPACE}/ && python3 ${GITHUB_WORKSPACE}/.github/scripts/run_tests.py
-
-      - name: Log Upload Dependencies
-        run: python3 -m pip install apache-libcloud==3.3.1
-
+        
       - name: Upload Logs
         if: ${{ always() }}
         env:
           LOG_UPLOAD_INFO: ${{ secrets.LOG_UPLOAD_INFO }}
-        run: cd ${GITHUB_WORKSPACE}/ && python3 ${GITHUB_WORKSPACE}/.github/scripts/upload_log_tarballs.py
+        run: |
+          python3 -m pip install apache-libcloud==3.3.1
+          cd ${GITHUB_WORKSPACE}/ && python3 ${GITHUB_WORKSPACE}/.github/scripts/upload_log_tarballs.py
         
   cleanup_and_deploy:
       name: Cleanup (and Possibly Deployment)


### PR DESCRIPTION
Dependencies were not always installed, but the log upload was always attempted.

This always installs the dependencies.