### PR TITLE
Added IR Drop Calculation To PDN Step

### DIFF
--- a/configuration/README.md
+++ b/configuration/README.md
@@ -16,6 +16,12 @@ This page describes configuration variables and their default values.
 
 These variables are optional that can be specified in the design configuration file.
 
+### Multiple
+| Variable      | Description                                                   |
+|---------------|---------------------------------------------------------------|
+| `DATA_WIRE_RC_LAYER` | The metal layer used for estimating the resistance/capacitence values for data nets. <br> (Default: `met2`)|
+| `CLOCK_WIRE_RC_LAYER` | The metal layer used for estimating the resistance/capacitence values for clock nets. <br> (Default: `met5`)|
+
 ### Synthesis
 
 | Variable      | Description                                                   |
@@ -89,8 +95,8 @@ These variables are optional that can be specified in the design configuration f
 | `VDD_NETS` | Specifies the power nets/pins to be used when creating the power grid for the design. |
 | `GND_NETS` | Specifies the ground nets/pins to be used when creating the power grid for the design. |
 | `SYNTH_USE_PG_PINS_DEFINES` | Specifies the power guard used in the verilog source code to specify the power and ground pins. This is used to automatically extract `VDD_NETS` and `GND_NET` variables from the verilog, with the assumption that they will be order `inout vdd1, inout gnd1, inout vdd2, inout gnd2, ...`. |
+| `FP_PDN_IRDROP` | Enable calculation of power grid IR drop during PDN generation. <br> (Default: `0`)|
 | `FP_IO_MIN_DISTANCE`  | **Removed**: The minmimum distance between the IOs in microns. <br> (Default: `5`) |
-
 ### Placement
 
 | Variable      | Description                                                   |
@@ -170,9 +176,6 @@ These variables are optional that can be specified in the design configuration f
 | `RCX_CC_MODEL` | Specifies the maximum number of tracks on the same routing level. Coupling is calculated within the `RCX_CC_MODEL` distance. <br> (Default: `10`)|
 | `RCX_CONTEXT_DEPTH` | Specifies the number of levels considered when calculating the capacitance. <br> (Default: `5`)|
 | `RCX_MERGE_VIA_WIRE_RES` | Specifies whether to merge the via resistance with the wire resistance or separate it from the wire resistance. 1 = Merge via resistance, 0 = Separate via resistance <br> (Default: `1`)|
-| `WIRE_RC_LAYER` | The metal layer used in estimate parastics `set_wire_rc`. Should be moved to PDK configurations later.. <br> (Default: `met1`)|
-| `DATA_WIRE_RC_LAYER` | The metal layer used for estimating the resistance/capacitence values for data nets. <br> (Default: `met2`)|
-| `CLOCK_WIRE_RC_LAYER` | The metal layer used for estimating the resistance/capacitence values for clock nets. <br> (Default: `met5`)|
 | `SPEF_WIRE_MODEL` | Specifies the wire model used in SPEF extraction. Options are `L` or `Pi`  <br> (Default: `L`) |
 | `SPEF_EDGE_CAP_FACTOR` | Specifies the edge capacitance factor used in SPEF extraction. Ranges from 0 to 1 <br> (Default: `1`) |
 

--- a/configuration/README.md
+++ b/configuration/README.md
@@ -16,12 +16,6 @@ This page describes configuration variables and their default values.
 
 These variables are optional that can be specified in the design configuration file.
 
-### Multiple
-| Variable      | Description                                                   |
-|---------------|---------------------------------------------------------------|
-| `DATA_WIRE_RC_LAYER` | The metal layer used for estimating the resistance/capacitence values for data nets. <br> (Default: `met2`)|
-| `CLOCK_WIRE_RC_LAYER` | The metal layer used for estimating the resistance/capacitence values for clock nets. <br> (Default: `met5`)|
-
 ### Synthesis
 
 | Variable      | Description                                                   |
@@ -95,7 +89,7 @@ These variables are optional that can be specified in the design configuration f
 | `VDD_NETS` | Specifies the power nets/pins to be used when creating the power grid for the design. |
 | `GND_NETS` | Specifies the ground nets/pins to be used when creating the power grid for the design. |
 | `SYNTH_USE_PG_PINS_DEFINES` | Specifies the power guard used in the verilog source code to specify the power and ground pins. This is used to automatically extract `VDD_NETS` and `GND_NET` variables from the verilog, with the assumption that they will be order `inout vdd1, inout gnd1, inout vdd2, inout gnd2, ...`. |
-| `FP_PDN_IRDROP` | Enable calculation of power grid IR drop during PDN generation. <br> (Default: `0`)|
+| `FP_PDN_IRDROP` | Enable calculation of power grid IR drop during PDN generation. <br> (Default: `1`)|
 | `FP_IO_MIN_DISTANCE`  | **Removed**: The minmimum distance between the IOs in microns. <br> (Default: `5`) |
 ### Placement
 

--- a/configuration/extraction.tcl
+++ b/configuration/extraction.tcl
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set ::env(WIRE_RC_LAYER) "met1"; # Used for estimate_parasitics
-
 # Options are rcx/def2spef
 set ::env(SPEF_EXTRACTOR) "openrcx"
 
@@ -24,8 +22,6 @@ set ::env(RCX_COUPLING_THRESHOLD) 0.1
 set ::env(RCX_CC_MODEL) 10
 set ::env(RCX_CONTEXT_DEPTH) 5
 set ::env(RCX_MERGE_VIA_WIRE_RES) 1
-set ::env(DATA_WIRE_RC_LAYER) "met2"
-set ::env(CLOCK_WIRE_RC_LAYER) "met5"
 
 # DEF2SPEF default configurations
 set ::env(SPEF_WIRE_MODEL) "L"

--- a/configuration/floorplan.tcl
+++ b/configuration/floorplan.tcl
@@ -32,7 +32,7 @@ set ::env(FP_PDN_CORE_RING) 0
 set ::env(FP_PDN_ENABLE_RAILS) 1
 
 set ::env(FP_PDN_CHECK_NODES) 1
-set ::env(FP_PDN_IRDROP) 0
+set ::env(FP_PDN_IRDROP) 1
 
 set ::env(FP_IO_MODE) 1; # 0 matching mode - 1 random equidistant mode
 set ::env(FP_IO_HLENGTH) 4

--- a/configuration/floorplan.tcl
+++ b/configuration/floorplan.tcl
@@ -32,6 +32,7 @@ set ::env(FP_PDN_CORE_RING) 0
 set ::env(FP_PDN_ENABLE_RAILS) 1
 
 set ::env(FP_PDN_CHECK_NODES) 1
+set ::env(FP_PDN_IRDROP) 0
 
 set ::env(FP_IO_MODE) 1; # 0 matching mode - 1 random equidistant mode
 set ::env(FP_IO_HLENGTH) 4

--- a/configuration/general.tcl
+++ b/configuration/general.tcl
@@ -75,6 +75,3 @@ if { [file exists /build/transforms/] } {
 } else {
 	set ::env(PSN_TRANSFORM_PATH) $::env(HOME)/.local/transforms
 }
-
-set ::env(DATA_WIRE_RC_LAYER) "met2"
-set ::env(CLOCK_WIRE_RC_LAYER) "met5"

--- a/configuration/general.tcl
+++ b/configuration/general.tcl
@@ -75,3 +75,6 @@ if { [file exists /build/transforms/] } {
 } else {
 	set ::env(PSN_TRANSFORM_PATH) $::env(HOME)/.local/transforms
 }
+
+set ::env(DATA_WIRE_RC_LAYER) "met2"
+set ::env(CLOCK_WIRE_RC_LAYER) "met5"

--- a/dependencies/tool_metadata.yml
+++ b/dependencies/tool_metadata.yml
@@ -77,7 +77,7 @@
   in_install: false
 - name: open_pdks
   repo: https://github.com/rtimothyedwards/open_pdks
-  commit: 81d28fd0423ca6bbf3f3bf00b7d407958cf8f0f3
+  commit: 14beb9c5386c21be5ad0d644986c839619d5f983
   build: ''
   in_install: false
   in_container: false

--- a/designs/APU/config.tcl
+++ b/designs/APU/config.tcl
@@ -7,8 +7,9 @@ set ::env(CLOCK_PORT) "clk"
 
 set ::env(CLOCK_NET) $::env(CLOCK_PORT)
 
+set ::env(FP_PDN_IRDROP) 1
 
-set filename $::env(OPENLANE_ROOT)/designs/$::env(DESIGN_NAME)/$::env(PDK)_$::env(STD_CELL_LIBRARY)_config.tcl
+set filename $::env(DESIGN_DIR)/$::env(PDK)_$::env(STD_CELL_LIBRARY)_config.tcl
 if { [file exists $filename] == 1} {
 	source $filename
 }

--- a/scripts/openroad/or_pdn.tcl
+++ b/scripts/openroad/or_pdn.tcl
@@ -63,7 +63,8 @@ if { $::env(FP_PDN_IRDROP) } {
     set_wire_rc -signal -layer $::env(DATA_WIRE_RC_LAYER)
     set_wire_rc -clock -layer $::env(CLOCK_WIRE_RC_LAYER)
 
-    analyze_power_grid -net $::env(VDD_NET)
+    analyze_power_grid -net $::env(VDD_NET) -outfile $::env(PGA_RPT_FILE)
+    
 }
 
 write_def $::env(SAVE_DEF)

--- a/scripts/openroad/or_pdn.tcl
+++ b/scripts/openroad/or_pdn.tcl
@@ -26,7 +26,6 @@ if {[catch {read_def $::env(CURRENT_DEF)} errmsg]} {
     exit 1
 }
 
-
 if {[catch {pdngen $::env(PDN_CFG) -verbose} errmsg]} {
     puts stderr $errmsg
     exit 1
@@ -36,6 +35,35 @@ if {[catch {pdngen $::env(PDN_CFG) -verbose} errmsg]} {
 if { $::env(FP_PDN_CHECK_NODES) } {
     check_power_grid -net $::env(VDD_NET)
     check_power_grid -net $::env(GND_NET)
+}
+
+
+
+if { $::env(FP_PDN_IRDROP) } {
+    if { [info exist ::env(VIAS_RC)] } {
+        set vias_rc [split $::env(VIAS_RC) ","]
+        foreach via_rc $vias_rc {
+            set layer_name [lindex $via_rc 0]
+            set resistance [lindex $via_rc 1]
+            set_layer_rc -via $layer_name -resistance $resistance
+        }
+    }
+
+    if { [info exist ::env(LAYERS_RC)] } {
+        set layers_rc [split $::env(LAYERS_RC) ","]
+        foreach layer_rc $layers_rc {
+            set layer_name [lindex $layer_rc 0]
+            set capacitance [lindex $layer_rc 1]
+            set resistance [lindex $layer_rc 2]
+            set_layer_rc -layer $layer_name -capacitance $capacitance -resistance $resistance
+        }
+    }
+
+    set_wire_rc -layer $::env(WIRE_RC_LAYER)
+    set_wire_rc -signal -layer $::env(DATA_WIRE_RC_LAYER)
+    set_wire_rc -clock -layer $::env(CLOCK_WIRE_RC_LAYER)
+
+    analyze_power_grid -net $::env(VDD_NET)
 }
 
 write_def $::env(SAVE_DEF)

--- a/scripts/tcl_commands/all.tcl
+++ b/scripts/tcl_commands/all.tcl
@@ -359,6 +359,10 @@ proc prep {args} {
         puts_info "Optimization Standard Cell Library: $::env(STD_CELL_LIBRARY_OPT)"
     }
 
+    if {![info exists ::env(PDN_CFG)]} {
+        set ::env(PDN_CFG) $::env(PDKPATH)/libs.tech/openlane/common_pdn.tcl
+    }
+
     # source PDK and SCL specific configurations
     set pdk_config $::env(PDK_ROOT)/$::env(PDK)/libs.tech/openlane/config.tcl
     set scl_config $::env(PDK_ROOT)/$::env(PDK)/libs.tech/openlane/$::env(STD_CELL_LIBRARY)/config.tcl

--- a/scripts/tcl_commands/routing.tcl
+++ b/scripts/tcl_commands/routing.tcl
@@ -225,6 +225,8 @@ proc gen_pdn {args} {
     TIMER::timer_start
 	
     set ::env(SAVE_DEF) [index_file $::env(pdn_tmp_file_tag).def]
+    set ::env(PGA_RPT_FILE) [index_file $::env(pdn_report_file_tag).pga.rpt]
+
     try_catch $::env(OPENROAD_BIN) -exit $::env(SCRIPTS_DIR)/openroad/or_pdn.tcl \
 	|& tee $::env(TERMINAL_OUTPUT) [index_file $::env(pdn_log_file_tag).log 0]
 

--- a/scripts/tcl_commands/routing.tcl
+++ b/scripts/tcl_commands/routing.tcl
@@ -223,9 +223,7 @@ proc power_routing {args} {
 proc gen_pdn {args} {
     puts_info "Generating PDN..."
     TIMER::timer_start
-    if {![info exists ::env(PDN_CFG)]} {
-	set ::env(PDN_CFG) $::env(PDK_ROOT)/$::env(PDK)/libs.tech/openlane/common_pdn.tcl
-    }
+	
     set ::env(SAVE_DEF) [index_file $::env(pdn_tmp_file_tag).def]
     try_catch $::env(OPENROAD_BIN) -exit $::env(SCRIPTS_DIR)/openroad/or_pdn.tcl \
 	|& tee $::env(TERMINAL_OUTPUT) [index_file $::env(pdn_log_file_tag).log 0]


### PR DESCRIPTION
This adds the ability to optionally calculate the IR drop as requested in #535.

A small report as added to the end of `7-pdn.log`:

```
########## IR report #################
Worstcase voltage: 1.80e+00 V
Average IR drop  : 2.63e-09 V
Worstcase IR drop: 8.32e-08 V
######################################
```

---

Some notes for @Manarabdelaty before approval or merge:

- WIRE_RC_LAYER appears to have been added to the PDK at some point, so I removed it from the OpenLane config
- I moved DATA/CLOCK_WIRE_RC_LAYER to be "independent" as they are used in more than one step now.
    - Should these also be moved to the PDK?
- FP_PDN_IRDROP was added, but it's turned off by default, should it be turned on?