### PR TITLE
Upload logs as GHA Artifacts

### DIFF
--- a/.github/scripts/generate_tag.py
+++ b/.github/scripts/generate_tag.py
@@ -35,13 +35,12 @@ for tag in gh.openlane.tags:
 commit_count = int(subprocess.check_output(["git", "rev-list", "--count", "%s..%s" % (latest_tag_commit, "HEAD")]))
 
 if commit_count == 0:
-    print("No new commits.")
-    gh.export_env("NEW_TAG", "NO_NEW_TAG")
-    exit(0)
+    print("No new commits. A tag will not be created.")
+else:
+    now = datetime.datetime.now()
 
-now = datetime.datetime.now()
+    new_tag = now.strftime("%Y.%m.%d_%H.%M.%S")
 
-new_tag = now.strftime("%Y.%m.%d_%H.%M.%S")
-
-print("Naming new tag %s." % new_tag)
+    print("Naming new tag %s." % new_tag)
+    
 gh.export_env("NEW_TAG", new_tag)

--- a/.github/scripts/gh.py
+++ b/.github/scripts/gh.py
@@ -76,7 +76,7 @@ class Repo(object):
         if self._tags is None:
             print("[Repo Object] Fetching tags for %s…" % self.name)
             p = subprocess.check_output([
-                "git", "ls-remote", "--tags", "--sort=v:refname",
+                "git", "ls-remote", "--tags", "--sort=creatordate",
                 self.url
             ]).decode("utf8")
 

--- a/.github/workflows/openlane_ci.yml
+++ b/.github/workflows/openlane_ci.yml
@@ -126,13 +126,21 @@ jobs:
           TEST_SET: extendedTestSet${{ matrix.testset }}
         run: cd ${GITHUB_WORKSPACE}/ && python3 ${GITHUB_WORKSPACE}/.github/scripts/run_tests.py
         
-      - name: Upload Logs
-        if: ${{ always() }}
-        env:
-          LOG_UPLOAD_INFO: ${{ secrets.LOG_UPLOAD_INFO }}
-        run: |
-          python3 -m pip install apache-libcloud==3.3.1
-          cd ${GITHUB_WORKSPACE}/ && python3 ${GITHUB_WORKSPACE}/.github/scripts/upload_log_tarballs.py
+      ## This is temporarily disabled. It has no way of uploading logs for
+      ## PRs outside using a self-hosted runner on the same cloud platform as
+      ## the bucket and some special permissions trickery.
+      # - name: Upload Logs To Cloud Service
+      #   env:
+      #     LOG_UPLOAD_INFO: ${{ secrets.LOG_UPLOAD_INFO }}
+      #   run: |
+      #     python3 -m pip install apache-libcloud==3.3.1
+      #     cd ${GITHUB_WORKSPACE}/ && python3 ${GITHUB_WORKSPACE}/.github/scripts/upload_log_tarballs.py
+
+      - name: Upload Logs As Artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: run_tarballs
+          path: ${{ github.workspace }}/designs/*/runs/*.tar.gz
         
   cleanup_and_deploy:
       name: Cleanup (and Possibly Deployment)


### PR DESCRIPTION
Unai confirmed that from his experience, GHA Artifact storage for public repositories is unlimited.

Given the limits of GCP (can't upload artifacts from PRs,) we're just going to move to this.