### PR TITLE
Remove sed command applied on the def file

### DIFF
--- a/scripts/tcl_commands/routing.tcl
+++ b/scripts/tcl_commands/routing.tcl
@@ -413,13 +413,6 @@ proc run_routing {args} {
     # detailed routing
     detailed_routing
 	scrot_klayout -layout $::env(CURRENT_DEF)
-	# pdngen-related hack
-	# remove .extra\d+ "pins" so that magic
-	# generates shapes for each stripes without the ".extra" postfix
-	# until OpenDB can understand this syntax...
-	exec sed \
-		-i -E {/^PINS/,/^END PINS/ s/\.extra[[:digit:]]+(.*USE (GROUND|POWER))/\1/g} \
-		$::env(CURRENT_DEF)
 
     run_spef_extraction
 


### PR DESCRIPTION
This is not needed anymore because openroad now doesn't add the `.extra` postfix to the power pins. 