### PR TITLE
Fix saving def file

### DIFF
--- a/flow.tcl
+++ b/flow.tcl
@@ -200,7 +200,7 @@ proc run_non_interactive_mode {args} {
 			set arg_values(-save_path) ""
 		}
 		save_views 	-lef_path $::env(magic_result_file_tag).lef \
-			-def_path $::env(tritonRoute_result_file_tag).def \
+			-def_path $::env(CURRENT_DEF) \
 			-gds_path $::env(magic_result_file_tag).gds \
 			-mag_path $::env(magic_result_file_tag).mag \
 			-maglef_path $::env(magic_result_file_tag).lef.mag \


### PR DESCRIPTION
- The def file wasn't saved when the `-save` option is passed to flow.tcl because the def file name is pre-fixed with an index which isn't captured in `$::env(tritonRoute_result_file_tag)`. I used `$::env(CURRENT_DEF)` instead, which should point to the last def file written by the flow. 