### PR TITLE
 Revert #607, #601

### DIFF
--- a/dependencies/tool_metadata.yml
+++ b/dependencies/tool_metadata.yml
@@ -68,7 +68,7 @@
     make PREFIX=$PREFIX install
 - name: openroad_app
   repo: https://github.com/The-OpenROAD-Project/OpenROAD
-  commit: f7a44b69256c0b2a1dce50362997c4091d7f6a06
+  commit: fb8ae93b6c7a5eb0e6fac83360a8a48d76c41885
   build: |
     mkdir -p ./build
     cd ./build

--- a/designs/aes_cipher/config.tcl
+++ b/designs/aes_cipher/config.tcl
@@ -8,6 +8,8 @@ set ::env(CLOCK_PORT) "clk"
 
 set ::env(CLOCK_NET) $::env(CLOCK_PORT)
 
+set ::env(FP_CORE_UTIL) 40
+
 
 set filename $::env(OPENLANE_ROOT)/designs/$::env(DESIGN_NAME)/$::env(PDK)_$::env(STD_CELL_LIBRARY)_config.tcl
 if { [file exists $filename] == 1} {

--- a/designs/aes_core/config.tcl
+++ b/designs/aes_core/config.tcl
@@ -9,6 +9,8 @@ set ::env(CLOCK_PORT) "clk"
 
 set ::env(CLOCK_NET) $::env(CLOCK_PORT)
 
+set ::env(DIODE_INSERTION_STRATEGY) 4
+
 
 set filename $::env(OPENLANE_ROOT)/designs/$::env(DESIGN_NAME)/$::env(PDK)_$::env(STD_CELL_LIBRARY)_config.tcl
 if { [file exists $filename] == 1} {

--- a/scripts/or_issue.py
+++ b/scripts/or_issue.py
@@ -30,7 +30,7 @@ import argparse
 from collections import deque
 from os.path import join, abspath, dirname, basename, isdir, relpath
 
-openlane_path = abspath(dirname(__file__))
+openlane_path = abspath(dirname(dirname(__file__)))
 
 parser = argparse.ArgumentParser(description="OpenROAD Issue Packager")
 parser.add_argument('--or-script', '-s', required=True, help='Path to the OpenROAD script causing the failure: i.e. ./scripts/openroad/or_antenna_check.tcl, ./scripts/openroad/or_pdn.tcl, etc. [required]')

--- a/scripts/tcl_commands/routing.tcl
+++ b/scripts/tcl_commands/routing.tcl
@@ -392,6 +392,11 @@ proc run_routing {args} {
 
     add_route_obs
 
+	#legalize if not yet legalized
+	if { ($::env(DIODE_INSERTION_STRATEGY) != 4) && ($::env(DIODE_INSERTION_STRATEGY) != 5) } {
+		detailed_placement_or
+	}
+	
     global_routing
 
 	if { $::env(DIODE_INSERTION_STRATEGY) == 3 } {


### PR DESCRIPTION
- #607 - Lack of legalization was causing routing issues with OpenROAD.

- #601 - There is a cryptic "maze ripup wrong" message that makes aes_cipher fail: see The-OpenROAD-Project/OpenROAD#1110

- CU of aes_cipher reduced to 40 (50 was causing issues with TR)

- Fixed or_issue

--

Barring any last-minute surprises, this will be the last PR before OpenMPW3.