### PR TITLE
Simple CTS Now Suboption Of Clock Tree Synthesis

### DIFF
--- a/.github/test_sets/extended_test_set
+++ b/.github/test_sets/extended_test_set
@@ -1,1 +1,1 @@
-wbqspiflash des BM64 aes_cipher ldpcenc salsa20 aes_core blabla sha512 genericfir picorv32a chacha PPU y_huff  aes aes128
+des BM64 aes_cipher ldpcenc salsa20 aes_core blabla sha512 genericfir picorv32a chacha PPU y_huff  aes aes128

--- a/configuration/README.md
+++ b/configuration/README.md
@@ -132,9 +132,11 @@ These variables are optional that can be specified in the design configuration f
 
 | Variable      | Description                                                   |
 |---------------|---------------------------------------------------------------|
-| `CTS_TARGET_SKEW` | The target clock skew in picoseconds. <br> (Default: `200` ps)|
+| `CTS_TARGET_SKEW` | The target clock skew in picoseconds. <br> (Default: `200`ps)|
 | `CTS_ROOT_BUFFER`| The name of cell inserted at the root of the clock tree. |
-| `CLOCK_TREE_SYNTH` | Enable clock tree synthesis for tirtonCTS. <br> (Default: `1`)|
+| `CLOCK_TREE_SYNTH` | Enable clock tree synthesis. <br> (Default: `1`)|
+| `RUN_SIMPLE_CTS` | Runs an alternative simple clock tree synthesis after synthesis instead of TritonCTS. 1 = Enabled, 0 = Disabled <br> (Default: `1`)|
+| `FILL_INSERTION` | Enables fill cells insertion after cts (if enabled). 1 = Enabled, 0 = Disabled <br> (Default: `1`)|
 | `CTS_TOLERANCE` | An integer value that represents a tradeoff of QoR and runtime. Higher values will produce smaller runtime but worse QoR <br> (Default: `100`) |
 | `CTS_SINK_CLUSTERING_SIZE` | Specifies the maximum number of sinks per cluster. <br> (Default: `20`) |
 | `CTS_SINK_CLUSTERING_MAX_DIAMETER` | Specifies maximum diameter (in micron) of sink cluster. <br> (Default: `50`) |
@@ -241,8 +243,6 @@ These variables are optional that can be specified in the design configuration f
 | `KLAYOUT_XOR_GDS` | If `RUN_KLAYOUT_XOR` is enabled, this will enable producing a GDS output from the XOR along with it's PNG export. 1 = Enabled, 0 = Disabled <br> (Default: `1`)|
 | `KLAYOUT_XOR_XML` | If `RUN_KLAYOUT_XOR` is enabled, this will enable producing an XML output from the XOR. 1 = Enabled, 0 = Disabled <br> (Default: `1`)|
 | `TAKE_LAYOUT_SCROT` | Enables running Klayout to take a PNG screenshot of the produced layout (currently configured to run on the results of each stage).1 = Enabled, 0 = Disabled <br> (Default: `1`)|
-| `RUN_SIMPLE_CTS` | Enables inserting simple clock tree after synthesis .1 = Enabled, 0 = Disabled <br> (Default: `0`)|
-| `FILL_INSERTION` | Enables fill cells insertion after cts (if enabled) .1 = Enabled, 0 = Disabled <br> (Default: `1`)|
 | `TAP_DECAP_INSERTION` | Enables tap and decap cells insertion after floorplanning (if enabled) .1 = Enabled, 0 = Disabled <br> (Default: `1`) |
 | `DIODE_INSERTION_STRATEGY` | Specifies the insertion strategy of diodes to be used in the flow. 0 = No diode insertion, 1 = Spray diodes, 2 = insert fake diodes and replace them with real diodes if needed. 3= use FastRoute Antenna Avoidance flow, 4 = Use Sylvian's Custom Script for diode insertion on design pins and smartly inserting needed diodes inside the design, 5 = a mix of strategy 2 and 4. <br> (Default: `3`) |
 | `WIDEN_SITE` | Specifies the new virtual width of the site to be used in all stages up to diode insertion, then switched back to the original site width. It can be either a factor or an absolute value controlled by `WIDEN_SITE_IS_FACTOR` <br> (Default: `1`) |

--- a/designs/digital_pll_sky130_fd_sc_hd/config.tcl
+++ b/designs/digital_pll_sky130_fd_sc_hd/config.tcl
@@ -11,8 +11,6 @@ set ::env(SYNTH_READ_BLACKBOX_LIB) 1
 set ::env(CLOCK_PERIOD) "100000"
 set ::env(CLOCK_PORT) "w"
 set ::env(CLOCK_TREE_SYNTH) 0
-
-set ::env(RUN_SIMPLE_CTS) 0
 set ::env(SYNTH_BUFFERING) 0
 set ::env(SYNTH_SIZING) 0
 

--- a/scripts/tcl_commands/cts.tcl
+++ b/scripts/tcl_commands/cts.tcl
@@ -73,7 +73,7 @@ proc run_cts {args} {
 		set ::env(CLOCK_TREE_SYNTH) 0
 	}
 
-	if {$::env(CLOCK_TREE_SYNTH)} {
+	if {$::env(CLOCK_TREE_SYNTH) && !$::env(RUN_SIMPLE_CTS)} {
 		puts_info "Running TritonCTS..."
 		set ::env(CURRENT_STAGE) cts
 		TIMER::timer_start
@@ -105,6 +105,8 @@ proc run_cts {args} {
 			logic_equiv_check -rhs $::env(PREV_NETLIST) -lhs $::env(CURRENT_NETLIST)
 		}
 		scrot_klayout -layout $::env(CURRENT_DEF)
+	} elseif { $::env(RUN_SIMPLE_CTS) } {
+		exec echo "Simple CTS was run earlier." >> [index_file $::env(cts_log_file_tag).log]
 	} else {
 		exec echo "SKIPPED!" >> [index_file $::env(cts_log_file_tag).log]
 	}

--- a/scripts/tcl_commands/synthesis.tcl
+++ b/scripts/tcl_commands/synthesis.tcl
@@ -131,7 +131,7 @@ proc run_synthesis {args} {
 
     run_sta
 
-    if {$::env(RUN_SIMPLE_CTS)} {
+    if { $::env(RUN_SIMPLE_CTS) && $::env(CLOCK_TREE_SYNTH) } {
 		if { ! [info exists ::env(CLOCK_NET)] } {
 			set ::env(CLOCK_NET) $::env(CLOCK_PORT)
 		}


### PR DESCRIPTION
* RUN_SIMPLE_CTS no longer runs the Simple CTS if CLOCK_TREE_SYNTH is off.
* TritonCTS will no longer run if RUN_SIMPLE_CTS is on.
* wbqspiflash was apparently duplicated between the FTS and ETS so it's been removed from the ETS.