### PR TITLE
Fix typo in python exit call

### DIFF
--- a/scripts/io_place.py
+++ b/scripts/io_place.py
@@ -252,7 +252,7 @@ for side in pin_placement_cfg:
                 if bterm in bterm_regex_map:
                     print("Error: Multiple regexes matched", pin_name,
                           ". Those are", bterm_regex_map[bterm], "and", regex)
-                    sys.exit(os.EX_DATA)
+                    sys.exit(os.EX_DATAERR)
                 bterm_regex_map[bterm] = regex
                 pin_placement[side].append(bterm)  # to maintain the order
 


### PR DESCRIPTION
In commit 4e158a77ef7a ("Quit on timing violations at the typical
corner (#659)"), os.EX_DATA should have been os.EX_DATAERR.