### PR TITLE
Update set_wire_rc command

### DIFF
--- a/scripts/openroad/or_cts.tcl
+++ b/scripts/openroad/or_cts.tcl
@@ -35,6 +35,7 @@ set max_cap [expr {$::env(CTS_MAX_CAP) * 1e-12}]; # must convert to farad
 source $::env(SCRIPTS_DIR)/openroad/or_set_rc.tcl 
 set_wire_rc -layer $::env(WIRE_RC_LAYER)
 estimate_parasitics -placement
+
 # Clone clock tree inverters next to register loads
 # so cts does not try to buffer the inverted clocks.
 repair_clock_inverters

--- a/scripts/openroad/or_cts.tcl
+++ b/scripts/openroad/or_cts.tcl
@@ -33,7 +33,6 @@ set max_slew [expr {$::env(SYNTH_MAX_TRAN) * 1e-9}]; # must convert to seconds
 set max_cap [expr {$::env(CTS_MAX_CAP) * 1e-12}]; # must convert to farad
 # set rc values
 source $::env(SCRIPTS_DIR)/openroad/or_set_rc.tcl 
-set_wire_rc -layer $::env(WIRE_RC_LAYER)
 estimate_parasitics -placement
 
 # Clone clock tree inverters next to register loads

--- a/scripts/openroad/or_groute.tcl
+++ b/scripts/openroad/or_groute.tcl
@@ -91,8 +91,6 @@ if {[info exists ::env(CLOCK_PORT)]} {
         source $::env(SCRIPTS_DIR)/openroad/or_set_rc.tcl 
         set_propagated_clock [all_clocks]
         # estimate wire rc parasitics
-        set_wire_rc -signal -layer $::env(WIRE_RC_LAYER)
-        set_wire_rc -clock  -layer $::env(WIRE_RC_LAYER)
         estimate_parasitics -global_routing
 
         set ::env(RUN_STANDALONE) 0

--- a/scripts/openroad/or_groute.tcl
+++ b/scripts/openroad/or_groute.tcl
@@ -30,11 +30,25 @@ if { $::env(DIODE_INSERTION_STRATEGY) == 3 } {
 	set_placement_padding -masters $::env(DIODE_CELL) -left $::env(DIODE_PADDING)
 }
 
-grt::check_routing_layer $::env(GLB_RT_MINLAYER)
-grt::set_min_layer $::env(GLB_RT_MINLAYER)
+set signal_min_layer [lindex $::env(TECH_METAL_LAYERS) [expr {$::env(GLB_RT_MINLAYER)-1}]]
+set signal_max_layer [lindex $::env(TECH_METAL_LAYERS) [expr {$::env(GLB_RT_MAXLAYER)-1}]]
 
-grt::check_routing_layer $::env(GLB_RT_MAXLAYER)
-grt::set_max_layer $::env(GLB_RT_MAXLAYER)
+if { ![info exists ::env(CLB_RT_CLOCK_MIN_LAYER)] } {
+    set clock_min_layer $signal_min_layer
+} else {
+    set clock_min_layer [lindex $::env(TECH_METAL_LAYERS) [expr {$::env(GLB_RT_CLOCK_MINLAYER)-1}]]
+}
+
+if { ![info exists ::env(CLB_RT_CLOCK_MAX_LAYER)] } {
+    set clock_max_layer $signal_max_layer
+} else {
+    set clock_max_layer [lindex $::env(TECH_METAL_LAYERS) [expr {$::env(GLB_RT_CLOCK_MAXLAYER)-1}]]
+}
+
+puts "\[INFO]: Setting singal min routig layer to: $signal_min_layer and clock min routing layer to $clock_min_layer. "
+puts "\[INFO]: Setting signal max routig layer to: $signal_max_layer and clock min routing layer to $clock_max_layer.  "
+
+set_routing_layers -signal [subst $signal_min_layer]-[subst $signal_max_layer] -clock [subst $clock_min_layer]-[subst $clock_max_layer]
 
 grt::set_capacity_adjustment $::env(GLB_RT_ADJUSTMENT)
 
@@ -75,8 +89,10 @@ if {[info exists ::env(CLOCK_PORT)]} {
 	
         # set rc values
         source $::env(SCRIPTS_DIR)/openroad/or_set_rc.tcl 
-        set_wire_rc -layer $::env(WIRE_RC_LAYER)
         set_propagated_clock [all_clocks]
+        # estimate wire rc parasitics
+        set_wire_rc -signal -layer $::env(WIRE_RC_LAYER)
+        set_wire_rc -clock  -layer $::env(WIRE_RC_LAYER)
         estimate_parasitics -global_routing
 
         set ::env(RUN_STANDALONE) 0

--- a/scripts/openroad/or_pdn.tcl
+++ b/scripts/openroad/or_pdn.tcl
@@ -42,8 +42,6 @@ if { $::env(FP_PDN_CHECK_NODES) } {
 if { $::env(FP_PDN_IRDROP) } {
     # set rc values
     source $::env(SCRIPTS_DIR)/openroad/or_set_rc.tcl 
-    set_wire_rc -signal -layer $::env(WIRE_RC_LAYER)
-    set_wire_rc -clock -layer $::env(WIRE_RC_LAYER)
 
     analyze_power_grid -net $::env(VDD_NET) -outfile $::env(PGA_RPT_FILE)
     

--- a/scripts/openroad/or_pdn.tcl
+++ b/scripts/openroad/or_pdn.tcl
@@ -42,9 +42,8 @@ if { $::env(FP_PDN_CHECK_NODES) } {
 if { $::env(FP_PDN_IRDROP) } {
     # set rc values
     source $::env(SCRIPTS_DIR)/openroad/or_set_rc.tcl 
-    set_wire_rc -layer $::env(WIRE_RC_LAYER)
-    set_wire_rc -signal -layer $::env(DATA_WIRE_RC_LAYER)
-    set_wire_rc -clock -layer $::env(CLOCK_WIRE_RC_LAYER)
+    set_wire_rc -signal -layer $::env(WIRE_RC_LAYER)
+    set_wire_rc -clock -layer $::env(WIRE_RC_LAYER)
 
     analyze_power_grid -net $::env(VDD_NET) -outfile $::env(PGA_RPT_FILE)
     

--- a/scripts/openroad/or_rcx.tcl
+++ b/scripts/openroad/or_rcx.tcl
@@ -37,8 +37,6 @@ if { !$::env(RCX_MERGE_VIA_WIRE_RES) } {
 
 # set rc values
 source $::env(SCRIPTS_DIR)/openroad/or_set_rc.tcl 
-set_wire_rc -signal -layer $::env(WIRE_RC_LAYER)
-set_wire_rc -clock -layer $::env(WIRE_RC_LAYER)
 
 # RCX 
 define_process_corner -ext_model_index 0 X

--- a/scripts/openroad/or_rcx.tcl
+++ b/scripts/openroad/or_rcx.tcl
@@ -37,8 +37,8 @@ if { !$::env(RCX_MERGE_VIA_WIRE_RES) } {
 
 # set rc values
 source $::env(SCRIPTS_DIR)/openroad/or_set_rc.tcl 
-set_wire_rc -signal -layer $::env(DATA_WIRE_RC_LAYER)
-set_wire_rc -clock -layer $::env(CLOCK_WIRE_RC_LAYER)
+set_wire_rc -signal -layer $::env(WIRE_RC_LAYER)
+set_wire_rc -clock -layer $::env(WIRE_RC_LAYER)
 
 # RCX 
 define_process_corner -ext_model_index 0 X

--- a/scripts/openroad/or_replace.tcl
+++ b/scripts/openroad/or_replace.tcl
@@ -102,7 +102,6 @@ if {[info exists ::env(CLOCK_PORT)]} {
 		read_sdc -echo $::env(CURRENT_SDC)
 		# set rc values
 		source $::env(SCRIPTS_DIR)/openroad/or_set_rc.tcl 
-		set_wire_rc -layer $::env(WIRE_RC_LAYER)
 		estimate_parasitics -placement
 
         set ::env(RUN_STANDALONE) 0

--- a/scripts/openroad/or_resizer.tcl
+++ b/scripts/openroad/or_resizer.tcl
@@ -31,9 +31,9 @@ read_sdc -echo $::env(CURRENT_SDC)
 # Resize
 # set rc values
 source $::env(SCRIPTS_DIR)/openroad/or_set_rc.tcl 
-# estimate wire rc parasitics
 set_wire_rc -signal -layer $::env(WIRE_RC_LAYER)
 set_wire_rc -clock  -layer $::env(WIRE_RC_LAYER)
+# estimate wire rc parasitics
 estimate_parasitics -placement
 
 if { [info exists ::env(DONT_USE_CELLS)] } {
@@ -77,6 +77,7 @@ check_placement -verbose
 write_def $::env(SAVE_DEF)
 write_sdc $::env(SAVE_SDC)
 
-# Run STA
+# Run post design optimizations STA
+estimate_parasitics -placement
 set ::env(RUN_STANDALONE) 0
 source $::env(SCRIPTS_DIR)/openroad/or_sta.tcl 

--- a/scripts/openroad/or_resizer.tcl
+++ b/scripts/openroad/or_resizer.tcl
@@ -28,11 +28,9 @@ if {[catch {read_def $::env(CURRENT_DEF)} errmsg]} {
 
 read_sdc -echo $::env(CURRENT_SDC)
 
-# Resize
 # set rc values
 source $::env(SCRIPTS_DIR)/openroad/or_set_rc.tcl 
-set_wire_rc -signal -layer $::env(WIRE_RC_LAYER)
-set_wire_rc -clock  -layer $::env(WIRE_RC_LAYER)
+
 # estimate wire rc parasitics
 estimate_parasitics -placement
 
@@ -47,7 +45,7 @@ if { [info exists ::env(PL_RESIZER_BUFFER_INPUT_PORTS)] && $::env(PL_RESIZER_BUF
 if { [info exists ::env(PL_RESIZER_BUFFER_OUTPUT_PORTS)] && $::env(PL_RESIZER_BUFFER_OUTPUT_PORTS) } {
     buffer_ports -outputs
 }
-
+# Resize
 if { [info exists ::env(PL_RESIZER_MAX_WIRE_LENGTH)] && $::env(PL_RESIZER_MAX_WIRE_LENGTH) } {
     repair_design -max_wire_length $::env(PL_RESIZER_MAX_WIRE_LENGTH) \
                   -slew_margin $::env(PL_RESIZER_MAX_SLEW_MARGIN) \

--- a/scripts/openroad/or_resizer_routing_timing.tcl
+++ b/scripts/openroad/or_resizer_routing_timing.tcl
@@ -81,9 +81,6 @@ source $::env(SCRIPTS_DIR)/openroad/or_set_rc.tcl
 
 set_propagated_clock [all_clocks]
 
-# CTS and detailed placement move instances, so update parasitic estimates.
-set_wire_rc -signal -layer $::env(WIRE_RC_LAYER)
-set_wire_rc -clock  -layer $::env(WIRE_RC_LAYER)
 # estimate wire rc parasitics
 estimate_parasitics -global_routing
 

--- a/scripts/openroad/or_resizer_timing.tcl
+++ b/scripts/openroad/or_resizer_timing.tcl
@@ -38,8 +38,6 @@ source $::env(SCRIPTS_DIR)/openroad/or_set_rc.tcl
 set_propagated_clock [all_clocks]
 
 # CTS and detailed placement move instances, so update parastic estimates.
-set_wire_rc -signal -layer $::env(WIRE_RC_LAYER)
-set_wire_rc -clock -layer $::env(WIRE_RC_LAYER)
 # estimate wire rc parasitics
 estimate_parasitics -placement
 

--- a/scripts/openroad/or_set_rc.tcl
+++ b/scripts/openroad/or_set_rc.tcl
@@ -20,3 +20,6 @@ if { [info exist ::env(LAYERS_RC)] } {
         set_layer_rc -layer $layer_name -capacitance $capacitance -resistance $resistance
     }
 }
+
+set_wire_rc -signal -layer $::env(WIRE_RC_LAYER)
+set_wire_rc -clock -layer $::env(WIRE_RC_LAYER)


### PR DESCRIPTION
- Move `set_wire_rc` command to  `or_set_rc.tcl` script to make sure that it is run after calling the `set_layer_rc` 
- Add option for specifying the clock min and max routing layers `GLB_RT_CLOCK_MINLAYER` and `GLB_RT_CLOCK_MAXLAYER`. 