### PR TITLE
Read additional .lib files for macros

### DIFF
--- a/scripts/openroad/or_cts.tcl
+++ b/scripts/openroad/or_cts.tcl
@@ -17,6 +17,12 @@ if {[catch {read_lef $::env(MERGED_LEF_UNPADDED)} errmsg]} {
     exit 1
 }
 
+if { [info exists ::env(EXTRA_LIBS) ] } {
+	foreach lib $::env(EXTRA_LIBS) {
+		read_liberty $lib
+	}
+}
+
 foreach lib $::env(LIB_CTS) {
     read_liberty $lib
 }

--- a/scripts/openroad/or_groute.tcl
+++ b/scripts/openroad/or_groute.tcl
@@ -12,6 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+if { [info exists ::env(EXTRA_LIBS) ] } {
+	foreach lib $::env(EXTRA_LIBS) {
+		read_liberty $lib
+	}
+}
+
 foreach lib $::env(LIB_SYNTH_COMPLETE) {
 	read_liberty $lib
 }

--- a/scripts/openroad/or_pdn.tcl
+++ b/scripts/openroad/or_pdn.tcl
@@ -12,6 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+if { [info exists ::env(EXTRA_LIBS) ] } {
+	foreach lib $::env(EXTRA_LIBS) {
+		read_liberty $lib
+	}
+}
+
 foreach lib $::env(LIB_SYNTH_COMPLETE) {
 	read_liberty $lib
 }

--- a/scripts/openroad/or_rcx.tcl
+++ b/scripts/openroad/or_rcx.tcl
@@ -12,6 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+if { [info exists ::env(EXTRA_LIBS) ] } {
+	foreach lib $::env(EXTRA_LIBS) {
+		read_liberty $lib
+	}
+}
+
 foreach lib $::env(LIB_RCX) {
 	read_liberty $lib
 }

--- a/scripts/openroad/or_replace.tcl
+++ b/scripts/openroad/or_replace.tcl
@@ -22,6 +22,11 @@ if {[catch {read_def $::env(CURRENT_DEF)} errmsg]} {
     exit 1
 }
 
+if { [info exists ::env(EXTRA_LIBS) ] } {
+	foreach lib $::env(EXTRA_LIBS) {
+		read_liberty $lib
+	}
+}
 
 set ::block [[[::ord::get_db] getChip] getBlock]
 set ::insts [$::block getInsts]

--- a/scripts/openroad/or_resizer.tcl
+++ b/scripts/openroad/or_resizer.tcl
@@ -16,6 +16,12 @@ foreach lib $::env(LIB_RESIZER_OPT) {
     read_liberty $lib
 }
 
+if { [info exists ::env(EXTRA_LIBS) ] } {
+	foreach lib $::env(EXTRA_LIBS) {
+		read_liberty $lib
+	}
+}
+
 if {[catch {read_lef $::env(MERGED_LEF_UNPADDED)} errmsg]} {
     puts stderr $errmsg
     exit 1

--- a/scripts/openroad/or_resizer_routing_timing.tcl
+++ b/scripts/openroad/or_resizer_routing_timing.tcl
@@ -16,6 +16,12 @@ foreach lib $::env(LIB_RESIZER_OPT) {
     read_liberty $lib
 }
 
+if { [info exists ::env(EXTRA_LIBS) ] } {
+	foreach lib $::env(EXTRA_LIBS) {
+		read_liberty $lib
+	}
+}
+
 if {[catch {read_lef $::env(MERGED_LEF_UNPADDED)} errmsg]} {
     puts stderr $errmsg
     exit 1

--- a/scripts/openroad/or_resizer_timing.tcl
+++ b/scripts/openroad/or_resizer_timing.tcl
@@ -16,6 +16,12 @@ foreach lib $::env(LIB_RESIZER_OPT) {
     read_liberty $lib
 }
 
+if { [info exists ::env(EXTRA_LIBS) ] } {
+	foreach lib $::env(EXTRA_LIBS) {
+		read_liberty $lib
+	}
+}
+
 if {[catch {read_lef $::env(MERGED_LEF_UNPADDED)} errmsg]} {
     puts stderr $errmsg
     exit 1

--- a/scripts/openroad/or_sta.tcl
+++ b/scripts/openroad/or_sta.tcl
@@ -24,6 +24,13 @@ if { $::env(RUN_STANDALONE) == 1 } {
             exit 1
         }
     }
+
+    if { [info exists ::env(EXTRA_LIBS) ] } {
+	    foreach lib $::env(EXTRA_LIBS) {
+		    read_liberty $lib
+	    }
+    }
+
     read_liberty $::env(LIB_SYNTH_COMPLETE)
     read_verilog $::env(CURRENT_NETLIST)
     link_design $::env(DESIGN_NAME)

--- a/scripts/openroad/or_sta_multi_corner.tcl
+++ b/scripts/openroad/or_sta_multi_corner.tcl
@@ -24,6 +24,12 @@ if { $::env(CURRENT_DEF) != 0 } {
     }
 }
 
+if { [info exists ::env(EXTRA_LIBS) ] } {
+	foreach lib $::env(EXTRA_LIBS) {
+		read_liberty $lib
+	}
+}
+
 set_cmd_units -time ns -capacitance pF -current mA -voltage V -resistance kOhm -distance um
 
 define_corners ss tt ff


### PR DESCRIPTION
- Allow reading extra .lib files for macros. Like `EXTRA_LEFS`, `EXTRA_GDS_FILES`, `EXTRA_LIBS` should point to the .lib file for the macros in the design. 