### PR TITLE
Bring back `FP_IO_MIN_DISTANCE`

### DIFF
--- a/configuration/README.md
+++ b/configuration/README.md
@@ -96,7 +96,7 @@ These variables are optional that can be specified in the design configuration f
 | `GND_NETS` | Specifies the ground nets/pins to be used when creating the power grid for the design. |
 | `SYNTH_USE_PG_PINS_DEFINES` | Specifies the power guard used in the verilog source code to specify the power and ground pins. This is used to automatically extract `VDD_NETS` and `GND_NET` variables from the verilog, with the assumption that they will be order `inout vdd1, inout gnd1, inout vdd2, inout gnd2, ...`. |
 | `FP_PDN_IRDROP` | Enable calculation of power grid IR drop during PDN generation. <br> (Default: `1`)|
-| `FP_IO_MIN_DISTANCE`  | **Removed**: The minmimum distance between the IOs in microns. <br> (Default: `5`) |
+| `FP_IO_MIN_DISTANCE`  | The minmimum distance between the IOs in microns. <br> (Default: `5`) |
 ### Placement
 
 | Variable      | Description                                                   |

--- a/configuration/README.md
+++ b/configuration/README.md
@@ -96,7 +96,7 @@ These variables are optional that can be specified in the design configuration f
 | `GND_NETS` | Specifies the ground nets/pins to be used when creating the power grid for the design. |
 | `SYNTH_USE_PG_PINS_DEFINES` | Specifies the power guard used in the verilog source code to specify the power and ground pins. This is used to automatically extract `VDD_NETS` and `GND_NET` variables from the verilog, with the assumption that they will be order `inout vdd1, inout gnd1, inout vdd2, inout gnd2, ...`. |
 | `FP_PDN_IRDROP` | Enable calculation of power grid IR drop during PDN generation. <br> (Default: `1`)|
-| `FP_IO_MIN_DISTANCE`  | The minmimum distance between the IOs in microns. <br> (Default: `5`) |
+| `FP_IO_MIN_DISTANCE`  | The minmimum distance between the IOs in microns. <br> (Default: `3`) |
 ### Placement
 
 | Variable      | Description                                                   |

--- a/configuration/floorplan.tcl
+++ b/configuration/floorplan.tcl
@@ -41,7 +41,7 @@ set ::env(FP_IO_VEXTEND) -1
 set ::env(FP_IO_HEXTEND) -1
 set ::env(FP_IO_VTHICKNESS_MULT) 2
 set ::env(FP_IO_HTHICKNESS_MULT) 2
-set ::env(FP_IO_MIN_DISTANCE) 5
+set ::env(FP_IO_MIN_DISTANCE) 3
 
 set ::env(BOTTOM_MARGIN_MULT) 4
 set ::env(TOP_MARGIN_MULT) 4

--- a/scripts/openroad/ioplacer.tcl
+++ b/scripts/openroad/ioplacer.tcl
@@ -47,6 +47,7 @@ set tech [[ord::get_db] getTech]
 set HMETAL [[$tech findRoutingLayer $::env(FP_IO_HMETAL)] getName]
 set VMETAL [[$tech findRoutingLayer $::env(FP_IO_VMETAL)] getName]
 place_pins $opts\
+	-min_distance $::env(FP_IO_MIN_DISTANCE)\
 	-random_seed 42 \
 	-hor_layers $HMETAL \
 	-ver_layers $VMETAL


### PR DESCRIPTION
- Expose the option for specifying the min distance between the IOs. (this is needed for some of the caravel blocks) 