### PR TITLE
Bug fix to allow TCL lists for environment vars.

### DIFF
--- a/scripts/utils/utils.tcl
+++ b/scripts/utils/utils.tcl
@@ -138,6 +138,11 @@ proc parse_key_args {cmd arg_var key_var options {flag_var ""} {flags {}} {consu
 # puts a variable in a log file
 proc set_log {var val filepath log_flag} {
         set cmd "set ${var} \"${val}\""
+        if { [string first {[} "$val"] != -1 } {
+                set cmd "set ${var} \{${val}\}"
+        } else {
+                set cmd "set ${var} \"${val}\""
+        }
         uplevel #0 ${cmd}
         set global_cfg_file [open $filepath a+]
 		if { $log_flag } {


### PR DESCRIPTION
This is needed to specify a signal such as a clock that
may have brackets (bus) annotation. Without this, it tries to
interpret the brackets as a command and execute it.
For example:
set ::env(CLOCK_PORT) {io_in\[17\]}