### PR TITLE
Remove *_REPO and *_COMMIT defaults in Dockerfiles

### DIFF
--- a/docker/cugr/Dockerfile
+++ b/docker/cugr/Dockerfile
@@ -41,8 +41,8 @@ RUN cd boost_1_72_0 && \
 # into C arrays to be linked directly into the executable
 RUN yum -y install vim-common
 
-ARG CUGR_REPO=https://github.com/ax3ghazy/cu-gr
-ARG CUGR_COMMIT=1632b4b450cbd3e5b6bdc9bf92c96cadde6a01b9
+ARG CUGR_REPO
+ARG CUGR_COMMIT
 RUN git clone ${CUGR_REPO} cugr_12012021
 
 WORKDIR cugr_12012021

--- a/docker/cvc/Dockerfile
+++ b/docker/cvc/Dockerfile
@@ -14,8 +14,8 @@
 
 FROM openlane-build-base
 
-ARG CVC_REPO=https://github.com/d-m-bailey/cvc
-ARG CVC_COMMIT=38c74b0857ecf8f05a1bfde81d197b5a3d33a531
+ARG CVC_REPO
+ARG CVC_COMMIT
 
 # Build
 WORKDIR /cvc

--- a/docker/drcu/Dockerfile
+++ b/docker/drcu/Dockerfile
@@ -37,8 +37,8 @@ RUN cd boost_1_72_0 && \
     ./bootstrap.sh && \
     ./b2 install --with-system --with-filesystem --with-program_options link=static -j $(nproc)
 
-ARG DRCU_REPO=https://github.com/cuhk-eda/dr-cu
-ARG DRCU_COMMIT=427b4a4f03bb98d8a78b1712fe9e52cfb83a8347
+ARG DRCU_REPO
+ARG DRCU_COMMIT
 RUN git clone ${DRCU_REPO} drcu_18012021
 
 WORKDIR drcu_18012021

--- a/docker/magic/Dockerfile
+++ b/docker/magic/Dockerfile
@@ -14,8 +14,8 @@
 FROM openlane-build-base
 
 # Upstream is git://opencircuitdesign.com/magic, but servers are not stable enough for CI.
-ARG MAGIC_REPO=https://github.com/rtimothyedwards/magic
-ARG MAGIC_COMMIT=958d6f16701c1ee25e27440381b5c2c37b5fee7c
+ARG MAGIC_REPO
+ARG MAGIC_COMMIT
 
 WORKDIR /magic
 RUN curl -L ${MAGIC_REPO}/tarball/${MAGIC_COMMIT} | tar -xzC . --strip-components=1 && \

--- a/docker/netgen/Dockerfile
+++ b/docker/netgen/Dockerfile
@@ -14,8 +14,8 @@
 FROM openlane-build-base
 
 # Upstream is git://opencircuitdesign.com/netgen, but servers are not stable enough for CI.
-ARG NETGEN_REPO=https://github.com/rtimothyedwards/netgen
-ARG NETGEN_COMMIT=738c1f7b3705bca2f1cc66fbc1cfb20f12d49a06
+ARG NETGEN_REPO
+ARG NETGEN_COMMIT
 
 WORKDIR /netgen
 

--- a/docker/openroad_app/Dockerfile
+++ b/docker/openroad_app/Dockerfile
@@ -44,8 +44,8 @@ RUN git clone -b v1.8.1 https://github.com/gabime/spdlog \
     && cmake .. \
     && make install -j $(nproc)
 
-ARG OPENROAD_APP_REPO=https://github.com/The-OpenROAD-Project/OpenROAD
-ARG OPENROAD_APP_COMMIT=4d4d7205fd0292dbf3fae55fad9109b3f0bd5786
+ARG OPENROAD_APP_REPO
+ARG OPENROAD_APP_COMMIT
 
 WORKDIR /openroad
 RUN curl -L ${OPENROAD_APP_REPO}/tarball/${OPENROAD_APP_COMMIT} | tar -xzC . --strip-components=1

--- a/docker/padring/Dockerfile
+++ b/docker/padring/Dockerfile
@@ -14,8 +14,8 @@
 
 FROM openlane-build-base
 
-ARG PADRING_REPO=https://github.com/ax3ghazy/padring
-ARG PADRING_COMMIT=a88faf5a4faef75ff241276599fef81c3653cb70
+ARG PADRING_REPO
+ARG PADRING_COMMIT
 WORKDIR /padring
 
 RUN curl -L ${PADRING_REPO}/tarball/${PADRING_COMMIT} | tar -xzC . --strip-components=1 && \

--- a/docker/vlogtoverilog/Dockerfile
+++ b/docker/vlogtoverilog/Dockerfile
@@ -13,8 +13,8 @@
 # limitations under the License.
 FROM openlane-build-base
 
-ARG VLOGTOVERILOG_REPO=https://github.com/RTimothyEdwards/qflow
-ARG VLOGTOVERILOG_COMMIT=a550469b63e910ede6e3022e2886bca96462c540
+ARG VLOGTOVERILOG_REPO
+ARG VLOGTOVERILOG_COMMIT
 
 WORKDIR /qflow
 RUN curl -L ${VLOGTOVERILOG_REPO}/tarball/${VLOGTOVERILOG_COMMIT} | tar -xzC . --strip-components=1 && \

--- a/docker/yosys/Dockerfile
+++ b/docker/yosys/Dockerfile
@@ -16,8 +16,8 @@
 FROM openlane-build-base
 
 # git clone yosys
-ARG YOSYS_REPO=https://github.com/YosysHQ/yosys
-ARG YOSYS_COMMIT=d061b0e41a2023b5e72794563b94d6a9b5ab41a1
+ARG YOSYS_REPO
+ARG YOSYS_COMMIT
 
 WORKDIR /yosys
 RUN curl -L ${YOSYS_REPO}/tarball/${YOSYS_COMMIT} | tar -xzC . --strip-components=1 && \


### PR DESCRIPTION
It took me a while to realise we no longer specify commit IDs directly
in Dockerfiles, but now use dependencies/tool_metadata.yml. To make it
clearer, remove the defaults in the Dockerilfes.