### PR TITLE
Fix typo in run_resizer_design

### DIFF
--- a/scripts/tcl_commands/placement.tcl
+++ b/scripts/tcl_commands/placement.tcl
@@ -206,7 +206,7 @@ proc run_resizer_design {args} {
             logic_equiv_check -rhs $::env(PREV_NETLIST) -lhs $::env(CURRENT_NETLIST)
         }
     } else {
-        puts_info "Skipping Resizer Timing Optimizations."
+        puts_info "Skipping Resizer Design Optimizations."
     }
 }
 


### PR DESCRIPTION
When skipping design resizing, we incorrectly printed we were
skipping timing resizing.