### PR TITLE
Assorted OpenROAD-related Updates

### DIFF
--- a/docker/openroad_app/Dockerfile
+++ b/docker/openroad_app/Dockerfile
@@ -53,6 +53,7 @@ COPY ./fetch_submodules_from_tarballs.py .
 RUN python3 ./fetch_submodules_from_tarballs.py ${OPENROAD_APP_REPO} ${OPENROAD_APP_COMMIT}
 
 # Build OpenROAD
+RUN sed -i "s/GITDIR-NOTFOUND/${OPENROAD_APP_COMMIT}/" cmake/GetGitRevisionDescription.cmake
 RUN mkdir build && mkdir -p /build/version && mkdir install
 RUN cd build && cmake -DCMAKE_INSTALL_PREFIX=$(pwd)/install .. && make -j$(nproc)
 RUN cd build && make install

--- a/docs/source/using_or_issue.md
+++ b/docs/source/using_or_issue.md
@@ -35,9 +35,8 @@ Then you'd want to run this script as follows, from the root of the OpenLane Rep
         # run path is implicitly specified by input def: ./designs/spm/runs/config_TEST_fastestTestSet1
 ```
 
-Which will create a folder called `_build`, with two entries:
-* `config_TEST_fastestTestSet1_or_groute_packaged/`: A folder for human inspection
-* `config_TEST_fastestTestSet1_or_groute_packaged.tar.gz`: A gzipped tarball of that same folder.
+Which will create a folder called `_build`, with a single sub entry:
+* `config_TEST_fastestTestSet1_or_groute_packaged/`
 
 Ensure that you inspect this folder manually and the output of this script. This script only attempts a best effort, and it is very likely that it might miss something, in which case, feel free to file an issue.
 
@@ -55,4 +54,4 @@ You can override the OpenROAD binary used as follows:
 ```
 
 # Warning about proprietary files
-When working with a proprietary PDK, also inspect the tarball and ensure no proprietary data resulting ends up in there. This is *critical*, if something leaks, this scripts' authors take no responsibility and you are very much on your own. We will try our best to output warnings for your own good if something looks like a part of a proprietary PDK, but the absence of this message does not necessarily indicate that your folder and tarball are free of confidential material. 
+When working with a proprietary PDK, also inspect the tarball and ensure no proprietary data resulting ends up in there. This is *critical*, if something leaks, this scripts' authors take no responsibility and you are very much on your own. We will try our best to output warnings for your own good if something looks like a part of a proprietary PDK, but the absence of this message does not necessarily indicate that your folder is free of confidential material. 

--- a/scripts/openroad/sta.tcl
+++ b/scripts/openroad/sta.tcl
@@ -23,6 +23,12 @@ if { $::env(RUN_STANDALONE) == 1 } {
             puts stderr $errmsg
             exit 1
         }
+    } else {
+        if {[catch {read_verilog $::env(CURRENT_NETLIST)} errmsg]} {
+            puts stderr $errmsg
+            exit 1
+        }
+        link_design $::env(DESIGN_NAME)
     }
 
     if { [info exists ::env(EXTRA_LIBS) ] } {
@@ -32,8 +38,6 @@ if { $::env(RUN_STANDALONE) == 1 } {
     }
 
     read_liberty $::env(LIB_SYNTH_COMPLETE)
-    read_verilog $::env(CURRENT_NETLIST)
-    link_design $::env(DESIGN_NAME)
     read_sdc -echo $::env(CURRENT_SDC)
 }
 


### PR DESCRIPTION
* Only `read_verilog` if there's no CURRENT_DEF: see https://github.com/The-OpenROAD-Project/OpenROAD/issues/1305#issuecomment-968336079 (Practically didn't cause an issue as all DEFs are used without the standalone flag)
* or_issue now supports netlist inputs and no longer generates tarballs: encourages inspecting and running the code before uploading a tarball
* or_issue now also creates tcl, gdb and lldb files
* OpenROAD commit now sedded in instead of GITDIR-NOTFOUND: See last paragraph of https://github.com/Cloud-V/DFFRAM/issues/115