### PR TITLE
Move fill insertion after detailed placement

### DIFF
--- a/scripts/tcl_commands/routing.tcl
+++ b/scripts/tcl_commands/routing.tcl
@@ -383,12 +383,6 @@ proc run_routing {args} {
 		}
     }
 
-	# if diode insertion does *not* happen as part of global routing, then
-	# we can insert fill cells early on
-	if { $::env(DIODE_INSERTION_STRATEGY) != 3 } {
-		ins_fill_cells
-	}
-
     use_original_lefs
 
     add_route_obs
@@ -396,6 +390,12 @@ proc run_routing {args} {
 	#legalize if not yet legalized
 	if { ($::env(DIODE_INSERTION_STRATEGY) != 4) && ($::env(DIODE_INSERTION_STRATEGY) != 5) } {
 		detailed_placement_or
+	}
+
+	# if diode insertion does *not* happen as part of global routing, then
+	# we can insert fill cells early on
+	if { $::env(DIODE_INSERTION_STRATEGY) != 3 } {
+		ins_fill_cells
 	}
 	
     global_routing


### PR DESCRIPTION
I have a design that fails detailed placement just before global routing.
Looking closer, I'm not sure why we do fill insertion before the final
detailed placement step, because adding filler cells is just going to
make it impossible to fix any placement issues.