### PR TITLE
Non-fixed layer count for GLB RT adjustments

### DIFF
--- a/configuration/README.md
+++ b/configuration/README.md
@@ -158,14 +158,7 @@ These variables are optional that can be specified in the design configuration f
 | `GLB_RT_MAXLAYER` | The number of highest layer to be used in routing. <br> (Default: `6`)|
 | `GLB_RT_CLOCK_MINLAYER` | The number of lowest layer to be used in routing the clock net. <br> (Default: `GLB_RT_MINLAYER`)|
 | `GLB_RT_CLOCK_MAXLAYER` | The number of highest layer to be used in routing the clock net. <br> (Default: `GLB_RT_MAXLAYER`)|
-| `GLB_RT_ADJUSTMENT` | Reduction in the routing capacity of the edges between the cells in the global routing graph. Values range from 0 to 1. <br> 1 = most reduction, 0 = least reduction  <br> (Default: `0`)|
-| `GLB_RT_L1_ADJUSTMENT` | Reduction in the routing capacity of the edges between the cells in the global routing graph but specific to li1 layer in sky130A. Values range from 0 to 1 <br> (Default: `0.99`) |
-| `GLB_RT_L2_ADJUSTMENT` | Reduction in the routing capacity of the edges between the cells in the global routing graph but specific to met1 in sky130A. Values range from 0 to 1 <br> (Default: `0`) |
-| `GLB_RT_L3_ADJUSTMENT` | Reduction in the routing capacity of the edges between the cells in the global routing graph but specific to met2 in sky130A. Values range from 0 to 1 <br> (Default: `0`) |
-| `GLB_RT_L4_ADJUSTMENT` | Reduction in the routing capacity of the edges between the cells in the global routing graph but specific to met3 in sky130A. Values range from 0 to 1 <br> (Default: `0`) |
-| `GLB_RT_L5_ADJUSTMENT` | Reduction in the routing capacity of the edges between the cells in the global routing graph but specific to met4 in sky130A. Values range from 0 to 1 <br> (Default: `0`) |
-| `GLB_RT_L6_ADJUSTMENT` | Reduction in the routing capacity of the edges between the cells in the global routing graph but specific to met5 in sky130A. Values range from 0 to 1 <br> (Default: `0`) |
-| `GLB_RT_ALLOW_CONGESTION` | Allow congestion in the resultign guides. 0 = false, 1 = true <br> (Default: `0`) |
+| `GLB_RT_ALLOW_CONGESTION` | Allow congestion in the resultign guides. 0 = false, 1 = true <br> (Default: `0`) 
 | `GLB_RT_OVERFLOW_ITERS` | The maximum number of iterations waiting for the overflow to reach the desired value. <br> (Default: `50`) |
 | `GLB_RT_ANT_ITERS` | The maximum number of iterations for global router repair_antenna. This option is only available in `DIODE_INSERTION_STRATEGY` = `3`. <br> (Default: `3`) |
 | `GLB_RT_ESTIMATE_PARASITICS` | Specifies whether or not to run STA after global routing using OpenROAD's estimate_parasitics -global_routing and generates reports under `logs/routing`. 1 = Enabled, 0 = Disabled. <br> (Default: `1`) |
@@ -181,7 +174,26 @@ These variables are optional that can be specified in the design configuration f
 | `GLB_RESIZER_HOLD_MAX_BUFFER_PERCENT` | Specifies a max number of buffers to insert to fix hold violations. This number is calculated as a percentage of the number of instances in the design. <br> (Default: `50`)|
 | `GLB_RESIZER_SETUP_MAX_BUFFER_PERCENT` | Specifies a max number of buffers to insert to fix setup violations. This number is calculated as a percentage of the number of instances in the design. <br> (Default: `50`)|
 | `GLB_RESIZER_ALLOW_SETUP_VIOS` | Allows setup violations when fixing hold. <br> (Default: `0`)|
-| `GLB_OPTIMIZE_MIRRORING` | Specifies whether or not to run an optimize_mirroring pass whenever detailed placement happens after Routing timing optimization. This pass will mirror the cells whenever possible to optimize the design. 1 = Enabled, 0 = Disabled. <br> (Default: `1`) | 
+| `GLB_OPTIMIZE_MIRRORING` | Specifies whether or not to run an optimize_mirroring pass whenever detailed placement happens after Routing timing optimization. This pass will mirror the cells whenever possible to optimize the design. 1 = Enabled, 0 = Disabled. <br> (Default: `1`) |
+| `GLB_RT_ADJUSTMENT` | Reduction in the routing capacity of the edges between the cells in the global routing graph. Values range from 0 to 1. <br> 1 = most reduction, 0 = least reduction  <br> (Default: `0`)|
+| `GLB_RT_LAYER_ADJUSTMENTS` | Layer-specific reductions in the routing capacity of the edges between the cells in the global routing graph, delimited by commas. Values range from 0 to 1. <br> (Default: `0.99,0,0,0,0,0`)
+
+#### Deprecated Layer Adjustment Variables
+These variables worked initially, but they were too sky130 specific to be scalable. Currently, if they exist, they'll be concatenated into GLB_RT_LAYER_ADJUSTMENTS, but it's recommended to update your configuration to use `GLB_RT_LAYER_ADJUSTMENTS`.
+
+| Variable      | Description                                                   |
+|---------------|---------------------------------------------------------------|
+| `GLB_RT_L1_ADJUSTMENT` | **Deprecated**: Reduction in the routing capacity of the edges between the cells in the global routing graph but specific to li1 layer in sky130A. Values range from 0 to 1 <br> (Default: `0.99`) |
+| `GLB_RT_L2_ADJUSTMENT` | **Deprecated**: Reduction in the routing capacity of the edges between the cells in the global routing graph but specific to met1 in sky130A. Values range from 0 to 1 <br> (Default: `0`) |
+| `GLB_RT_L3_ADJUSTMENT` | **Deprecated**: Reduction in the routing capacity of the edges between the cells in the global routing graph but specific to met2 in sky130A. Values range from 0 to 1 <br> (Default: `0`) |
+| `GLB_RT_L4_ADJUSTMENT` | **Deprecated**: Reduction in the routing capacity of the edges between the cells in the global routing graph but specific to met3 in sky130A. Values range from 0 to 1 <br> (Default: `0`) |
+| `GLB_RT_L5_ADJUSTMENT` | **Deprecated**: Reduction in the routing capacity of the edges between the cells in the global routing graph but specific to met4 in sky130A. Values range from 0 to 1 <br> (Default: `0`) |
+| `GLB_RT_L6_ADJUSTMENT` | **Deprecated**: Reduction in the routing capacity of the edges between the cells in the global routing graph but specific to met5 in sky130A. Values range from 0 to 1 <br> (Default: `0`) |
+
+#### Removed
+
+| Variable      | Description                                                   |
+|---------------|---------------------------------------------------------------|
 | `GLB_RT_UNIDIRECTIONAL` | **Removed**: Allow unidirectional routing. 0 = false, 1 = true <br> (Default: `1`) |
 | `GLB_RT_TILES` | **Removed**: The size of the GCELL used by Fastroute during global routing. <br> (Default: `15`) |
 

--- a/configuration/routing.tcl
+++ b/configuration/routing.tcl
@@ -17,12 +17,8 @@ if {! [info exists ::env(ROUTING_CORES)] } {
     set ::env(ROUTING_CORES) 2
 }
 set ::env(GLB_RT_ADJUSTMENT) 0.0
-set ::env(GLB_RT_L1_ADJUSTMENT) 0; # more like pdk-specific (e.g., when L1 = li)
-set ::env(GLB_RT_L2_ADJUSTMENT) 0
-set ::env(GLB_RT_L3_ADJUSTMENT) 0
-set ::env(GLB_RT_L4_ADJUSTMENT) 0
-set ::env(GLB_RT_L5_ADJUSTMENT) 0
-set ::env(GLB_RT_L6_ADJUSTMENT) 0; # We go up to 6 here because the lowest met layer we've dealt with was met5, starting from li1. This might need to be adjusted.
+set ::env(GLB_RT_LAYER_ADJUSTMENTS) 0.99,0,0,0,0,0
+
 set ::env(GLB_RT_ALLOW_CONGESTION) 0
 set ::env(GLB_RT_OVERFLOW_ITERS) 50
 set ::env(GLB_RT_MINLAYER) 1

--- a/docker/tar/.bashrc
+++ b/docker/tar/.bashrc
@@ -8,4 +8,4 @@ alias ll='ls -lAGFh';
 
 export OL_GIT_VERSION=$(cat /git_version);
 
-export PS1="\033[1;31mOpenLane Container ($OL_GIT_VERSION)\033[0m:\033[4;30m\w\033[0m$ ";
+export PS1="\[\033[1;31m\]OpenLane Container ($OL_GIT_VERSION)\[\033[0m\]:\[\033[4;30m\]\w\[\033[0m\]$ ";

--- a/docs/source/PDK_STRUCTURE.md
+++ b/docs/source/PDK_STRUCTURE.md
@@ -48,7 +48,6 @@ This section defines the neccessary variables for PDK configuration file
 | `GPIO_PADS_LEF` | A list of the pads lef views. For example:`[glob "$::env(PDK_ROOT)/sky130A/libs.ref/sky130_fd_io/lef/sky130_fd_io.lef"]` |
 | `NETGEN_SETUP_FILE` | Points to the setup file for netgen(lvs), that can exclude certain cells etc.. |
 | `FP_TAPCELL_DIST` | The distance between tapcell columns. Used in floorplanning in tapcell insertion. |
-| `GLB_RT_L1_ADJUSTMENT` | Reduction in the routing capacity of the edges between the cells in the global routing graph but specific to li1 layer in sky130A. Values range from 0 to 1 <br> (Default: `0`) |
 | `DEFAULT_MAX_TRAN` | Defines the default maximum transition value, used in CTS & synthesis. |
 | `FP_PDN_RAIL_OFFSET` | Defines the rail offset for met1 used in PDN. <br> Default: `0`. |
 | `FP_PDN_VWIDTH` | Defines the strap width for the vertical layer used in PDN. <br> Default: `1.6`. |

--- a/scripts/openroad/layer_adjustments.tcl
+++ b/scripts/openroad/layer_adjustments.tcl
@@ -14,51 +14,50 @@
 
 set_global_routing_layer_adjustment * $::env(GLB_RT_ADJUSTMENT)
 
+# Legacy format for layer adjustments: Convert to new format
+set array [split $::env(GLB_RT_LAYER_ADJUSTMENTS) ","]
+
+set conversion_flag 0
+
+set l1_adj [lindex $array 0]
 if { [info exists ::env(GLB_RT_L1_ADJUSTMENT)] } {
-    # Legacy format for layer adjustments: Convert to new format
-    set flag 0
-
-    set l1_adj 0
-    if { [info exists ::env(GLB_RT_L1_ADJUSTMENT)] } {
-        set flag 1
-        set l1_adj $::env(GLB_RT_L1_ADJUSTMENT)
-    }
-    set l2_adj 0
-    if { [info exists ::env(GLB_RT_L2_ADJUSTMENT)] } {
-        set flag 1
-        set l2_adj $::env(GLB_RT_L2_ADJUSTMENT)
-    }
-    set l3_adj 0
-    if { [info exists ::env(GLB_RT_L3_ADJUSTMENT)] } {
-        set flag 1
-        set l3_adj $::env(GLB_RT_L3_ADJUSTMENT)
-    }
-    set l4_adj 0
-    if { [info exists ::env(GLB_RT_L4_ADJUSTMENT)] } {
-        set flag 1
-        set l4_adj $::env(GLB_RT_L4_ADJUSTMENT)
-    }
-    set l5_adj 0
-    if { [info exists ::env(GLB_RT_L5_ADJUSTMENT)] } {
-        set flag 1
-        set l5_adj $::env(GLB_RT_L5_ADJUSTMENT)
-    }
-    set l6_adj 0
-    if { [info exists ::env(GLB_RT_L6_ADJUSTMENT)] } {
-        set flag 1
-        set l6_adj $::env(GLB_RT_L6_ADJUSTMENT)
-    }
-
-    set ::env(GLB_RT_LAYER_ADJUSTMENTS) "$l1_adj,$l2_adj,$l3_adj,$l4_adj,$l5_adj,$l6_adj"
-
-    if { $flag } {
-        puts stderr "\[DEPRECATION WARNING] A GLB_RT_LX_ADJUSTMENT variable is still used by your design and will be removed in a future version of OpenLane. We recommend you update to GLB_RT_LAYER_ADJUSTMENTS. Check configuration/README.md for more info."
-
-        puts stderr "Recommended replacement:\nset ::env(GLB_RT_LAYER_ADJUSTMENTS) $::env(GLB_RT_LAYER_ADJUSTMENTS)"
-    }
+    set conversion_flag 1
+    set l1_adj $::env(GLB_RT_L1_ADJUSTMENT)
+}
+set l2_adj [lindex $array 1]
+if { [info exists ::env(GLB_RT_L2_ADJUSTMENT)] } {
+    set conversion_flag 1
+    set l2_adj $::env(GLB_RT_L2_ADJUSTMENT)
+}
+set l3_adj [lindex $array 2]
+if { [info exists ::env(GLB_RT_L3_ADJUSTMENT)] } {
+    set conversion_flag 1
+    set l3_adj $::env(GLB_RT_L3_ADJUSTMENT)
+}
+set l4_adj [lindex $array 3]
+if { [info exists ::env(GLB_RT_L4_ADJUSTMENT)] } {
+    set conversion_flag 1
+    set l4_adj $::env(GLB_RT_L4_ADJUSTMENT)
+}
+set l5_adj [lindex $array 4]
+if { [info exists ::env(GLB_RT_L5_ADJUSTMENT)] } {
+    set conversion_flag 1
+    set l5_adj $::env(GLB_RT_L5_ADJUSTMENT)
+}
+set l6_adj [lindex $array 5]
+if { [info exists ::env(GLB_RT_L6_ADJUSTMENT)] } {
+    set conversion_flag 1
+    set l6_adj $::env(GLB_RT_L6_ADJUSTMENT)
 }
 
-set array [split $::env(GLB_RT_LAYER_ADJUSTMENTS) ","]
+if { $conversion_flag } {
+    set ::env(GLB_RT_LAYER_ADJUSTMENTS) "$l1_adj,$l2_adj,$l3_adj,$l4_adj,$l5_adj,$l6_adj"
+
+    puts stderr "\[DEPRECATION WARNING] A GLB_RT_LX_ADJUSTMENT variable is still used by your design and will be removed in a future version of OpenLane. We recommend you update to GLB_RT_LAYER_ADJUSTMENTS. Check configuration/README.md for more info."
+
+    puts stderr "Recommended replacement:\nset ::env(GLB_RT_LAYER_ADJUSTMENTS) $::env(GLB_RT_LAYER_ADJUSTMENTS)"
+}
+
 set i 0
 foreach adjustment $array {
     set layer_name [lindex $::env(TECH_METAL_LAYERS) $i]

--- a/scripts/openroad/layer_adjustments.tcl
+++ b/scripts/openroad/layer_adjustments.tcl
@@ -14,16 +14,54 @@
 
 set_global_routing_layer_adjustment * $::env(GLB_RT_ADJUSTMENT)
 
-set_global_routing_layer_adjustment [lindex $::env(TECH_METAL_LAYERS) 0] $::env(GLB_RT_L1_ADJUSTMENT)
-set_global_routing_layer_adjustment [lindex $::env(TECH_METAL_LAYERS) 1] $::env(GLB_RT_L2_ADJUSTMENT)
-set_global_routing_layer_adjustment [lindex $::env(TECH_METAL_LAYERS) 2] $::env(GLB_RT_L3_ADJUSTMENT)
+if { [info exists ::env(GLB_RT_L1_ADJUSTMENT)] } {
+    # Legacy format for layer adjustments: Convert to new format
+    set flag 0
 
-if { $::env(GLB_RT_MAXLAYER) > 3 } {
-    set_global_routing_layer_adjustment [lindex $::env(TECH_METAL_LAYERS) 3] $::env(GLB_RT_L4_ADJUSTMENT)
-    if { $::env(GLB_RT_MAXLAYER) > 4 } {
-        set_global_routing_layer_adjustment [lindex $::env(TECH_METAL_LAYERS) 4] $::env(GLB_RT_L5_ADJUSTMENT)
-        if { $::env(GLB_RT_MAXLAYER) > 5 } {
-            set_global_routing_layer_adjustment [lindex $::env(TECH_METAL_LAYERS) 5] $::env(GLB_RT_L6_ADJUSTMENT)
-        }
+    set l1_adj 0
+    if { [info exists ::env(GLB_RT_L1_ADJUSTMENT)] } {
+        set flag 1
+        set l1_adj $::env(GLB_RT_L1_ADJUSTMENT)
     }
+    set l2_adj 0
+    if { [info exists ::env(GLB_RT_L2_ADJUSTMENT)] } {
+        set flag 1
+        set l2_adj $::env(GLB_RT_L2_ADJUSTMENT)
+    }
+    set l3_adj 0
+    if { [info exists ::env(GLB_RT_L3_ADJUSTMENT)] } {
+        set flag 1
+        set l3_adj $::env(GLB_RT_L3_ADJUSTMENT)
+    }
+    set l4_adj 0
+    if { [info exists ::env(GLB_RT_L4_ADJUSTMENT)] } {
+        set flag 1
+        set l4_adj $::env(GLB_RT_L4_ADJUSTMENT)
+    }
+    set l5_adj 0
+    if { [info exists ::env(GLB_RT_L5_ADJUSTMENT)] } {
+        set flag 1
+        set l5_adj $::env(GLB_RT_L5_ADJUSTMENT)
+    }
+    set l6_adj 0
+    if { [info exists ::env(GLB_RT_L6_ADJUSTMENT)] } {
+        set flag 1
+        set l6_adj $::env(GLB_RT_L6_ADJUSTMENT)
+    }
+
+    set ::env(GLB_RT_LAYER_ADJUSTMENTS) "$l1_adj,$l2_adj,$l3_adj,$l4_adj,$l5_adj,$l6_adj"
+
+    if { $flag } {
+        puts stderr "\[DEPRECATION WARNING] A GLB_RT_LX_ADJUSTMENT variable is still used by your design and will be removed in a future version of OpenLane. We recommend you update to GLB_RT_LAYER_ADJUSTMENTS. Check configuration/README.md for more info."
+
+        puts stderr "Recommended replacement:\nset ::env(GLB_RT_LAYER_ADJUSTMENTS) $::env(GLB_RT_LAYER_ADJUSTMENTS)"
+    }
+}
+
+set array [split $::env(GLB_RT_LAYER_ADJUSTMENTS) ","]
+set i 0
+foreach adjustment $array {
+    set layer_name [lindex $::env(TECH_METAL_LAYERS) $i]
+    set_global_routing_layer_adjustment $layer_name $adjustment
+    incr i
 }

--- a/scripts/or_issue.py
+++ b/scripts/or_issue.py
@@ -184,21 +184,24 @@ while current is not None:
     env_keys_used.add(env_key)
     env[env_key] = current
 
-    script = open(current).read()
+    try:
+        script = open(current).read()
 
-    for key, value in env.items():
-        key_accessor = re.compile(rf"((\$::env\({re.escape(key)}\))([/\-\w\.]*))")
-        for use in key_accessor.findall(script):
-            use: List[str]
-            full, accessor, extra = use
-            env_keys_used.add(key)
+        for key, value in env.items():
+            key_accessor = re.compile(rf"((\$::env\({re.escape(key)}\))([/\-\w\.]*))")
+            for use in key_accessor.findall(script):
+                use: List[str]
+                full, accessor, extra = use
+                env_keys_used.add(key)
 
-            value_substituted = full.replace(accessor, value)
+                value_substituted = full.replace(accessor, value)
 
-            if value_substituted.endswith(".tcl") or value_substituted.endswith(".sdc"):
-                if value_substituted not in tcls:
-                    tcls.add(value_substituted)
-                    tcls_to_process.append(value_substituted)
+                if value_substituted.endswith(".tcl") or value_substituted.endswith(".sdc"):
+                    if value_substituted not in tcls:
+                        tcls.add(value_substituted)
+                        tcls_to_process.append(value_substituted)
+    except:
+        print(f"⚠ {current} was not found, might be a product. Skipping", file=sys.stderr)
 
     current = shift(tcls_to_process)
 

--- a/scripts/tcl_commands/all.tcl
+++ b/scripts/tcl_commands/all.tcl
@@ -367,6 +367,12 @@ proc prep {args} {
     set pdk_config $::env(PDK_ROOT)/$::env(PDK)/libs.tech/openlane/config.tcl
     set scl_config $::env(PDK_ROOT)/$::env(PDK)/libs.tech/openlane/$::env(STD_CELL_LIBRARY)/config.tcl
     source $pdk_config
+
+    # Value set by PDK for some reason
+    if { [info exists ::env(GLB_RT_L1_ADJUSTMENT) ] } {
+        unset ::env(GLB_RT_L1_ADJUSTMENT)
+    }
+
     source $scl_config
 
     # needs to be resourced to make sure it overrides the above


### PR DESCRIPTION
This change is to help people implement PDKs that may more have than six metal layers, which I'm going to go out on a limb and say, exist.

Remember kids, nothing is more permanent than a temporary solution.

* GLB_RT_LX_ADJUSTMENT variables consolidated into GLB_RT_LAYER_ADJUSTMENTS, a comma-delimited set of values

* GLB_RT_LX_ADJUSTMENT will continue to be accepted (and converted into GLB_RT_LAYER_ADJUSTMENTS) but display a deprecation warning, and will be removed in a later version of OpenLane.

* The GLB_RT_L1_ADJUSTMENT value from the PDK is now ignored.