### PR TITLE
Fix sram install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,12 @@ endif
 STD_CELL_LIBRARY ?= sky130_fd_sc_hd
 SPECIAL_VOLTAGE_LIBRARY ?= sky130_fd_sc_hvl
 IO_LIBRARY ?= sky130_fd_io
+INSTALL_SRAM ?= disabled
+
+OPEN_PDK_ARGS ?= ""
+ifeq ($(INSTALL_SRAM), enabled) 
+OPEN_PDK_ARGS ?= --enable-sram-sky130
+endif 
 
 ifeq ($(OPENLANE_IMAGE_NAME),)
 OPENLANE_TAG ?= $(shell python3 ./dependencies/get_tag.py)
@@ -135,7 +141,7 @@ build-pdk: $(PDK_ROOT)/open_pdks $(PDK_ROOT)/skywater-pdk
 		rm -rf $(PDK_ROOT)/sky130A) || \
 		true
 	$(ENV_COMMAND) sh -c " cd $(PDK_ROOT)/open_pdks && \
-		./configure --enable-sky130-pdk=$(PDK_ROOT)/skywater-pdk/libraries --enable-sram-sky130"
+		./configure --enable-sky130-pdk=$(PDK_ROOT)/skywater-pdk/libraries $(OPEN_PDK_ARGS)"
 	cd $(PDK_ROOT)/open_pdks/sky130 && \
 		$(MAKE) veryclean && \
 		$(MAKE) prerequisites
@@ -152,7 +158,7 @@ native-build-pdk: $(PDK_ROOT)/open_pdks $(PDK_ROOT)/skywater-pdk
 		rm -rf $(PDK_ROOT)/sky130A) || \
 		true
 	cd $(PDK_ROOT)/open_pdks && \
-		./configure --enable-sky130-pdk=$(PDK_ROOT)/skywater-pdk/libraries --enable-sram-sky130 && \
+		./configure --enable-sky130-pdk=$(PDK_ROOT)/skywater-pdk/libraries $(OPEN_PDK_ARGS) && \
 		cd sky130 && \
 		$(MAKE) veryclean && \
 		$(MAKE) && \

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,6 @@ endif
 STD_CELL_LIBRARY ?= sky130_fd_sc_hd
 SPECIAL_VOLTAGE_LIBRARY ?= sky130_fd_sc_hvl
 IO_LIBRARY ?= sky130_fd_io
-INSTALL_SRAM ?= disabled
 
 ifeq ($(OPENLANE_IMAGE_NAME),)
 OPENLANE_TAG ?= $(shell python3 ./dependencies/get_tag.py)
@@ -136,7 +135,7 @@ build-pdk: $(PDK_ROOT)/open_pdks $(PDK_ROOT)/skywater-pdk
 		rm -rf $(PDK_ROOT)/sky130A) || \
 		true
 	$(ENV_COMMAND) sh -c " cd $(PDK_ROOT)/open_pdks && \
-		./configure --enable-sky130-pdk=$(PDK_ROOT)/skywater-pdk/libraries --enable-sram-sky130=$(INSTALL_SRAM)"
+		./configure --enable-sky130-pdk=$(PDK_ROOT)/skywater-pdk/libraries --enable-sram-sky130"
 	cd $(PDK_ROOT)/open_pdks/sky130 && \
 		$(MAKE) veryclean && \
 		$(MAKE) prerequisites
@@ -153,7 +152,7 @@ native-build-pdk: $(PDK_ROOT)/open_pdks $(PDK_ROOT)/skywater-pdk
 		rm -rf $(PDK_ROOT)/sky130A) || \
 		true
 	cd $(PDK_ROOT)/open_pdks && \
-		./configure --enable-sky130-pdk=$(PDK_ROOT)/skywater-pdk/libraries --enable-sram-sky130=$(INSTALL_SRAM) && \
+		./configure --enable-sky130-pdk=$(PDK_ROOT)/skywater-pdk/libraries --enable-sram-sky130 && \
 		cd sky130 && \
 		$(MAKE) veryclean && \
 		$(MAKE) && \


### PR DESCRIPTION
- This should fix the SRAM installation for the open_pdks version we are using. 
- By default, the SRAM installation is disabled. To enable, `export INSTALL_SRAM=enabled` . 