### PR TITLE
assert existence of EXTRA_GDS_FILES

### DIFF
--- a/scripts/tcl_commands/all.tcl
+++ b/scripts/tcl_commands/all.tcl
@@ -585,6 +585,11 @@ proc prep {args} {
     try_catch $::env(OPENROAD_BIN) -python $::env(SCRIPTS_DIR)/new_tracks.py -i $::env(TRACKS_INFO_FILE) -o $tracks_processed
     set ::env(TRACKS_INFO_FILE) $tracks_processed
 
+    if { [info exists ::env(EXTRA_GDS_FILES)] } {
+        puts_info "Looking for files defined in ::env(EXTRA_GDS_FILES) $::env(EXTRA_GDS_FILES) ..."
+        assert_files_exist $::env(EXTRA_GDS_FILES)
+    }
+
     puts_info "Preparation complete"
     TIMER::timer_stop
     exec echo "[TIMER::get_runtime]" | python3 $::env(SCRIPTS_DIR)/write_runtime.py "openlane design prep"

--- a/scripts/utils/utils.tcl
+++ b/scripts/utils/utils.tcl
@@ -323,4 +323,16 @@ namespace eval TIMER {
 	}
 }
 
+proc assert_files_exist {files} {
+	foreach f $files {
+		if { ! [file exists $f] } {
+			puts_err "$f doesn't exist."
+			exit 1
+		} else {
+			puts_info "$f exists."
+		}
+	}
+}
+
+
 package provide openlane_utils 0.9

--- a/scripts/utils/utils.tcl
+++ b/scripts/utils/utils.tcl
@@ -280,7 +280,7 @@ proc generate_final_summary_report {args} {
 		}
 		set flags {}
 		parse_key_args "generate_final_summary_report" args arg_values $options flags_map $flags
-		
+
 		set_if_unset arg_values(-output) $::env(REPORTS_DIR)/final_summary_report.csv
 		set_if_unset arg_values(-man_report) $::env(REPORTS_DIR)/manufacturability_report.rpt
 		set_if_unset arg_values(-runtime_summary) $::env(REPORTS_DIR)/runtime_summary_report.rpt
@@ -327,7 +327,7 @@ proc assert_files_exist {files} {
 	foreach f $files {
 		if { ! [file exists $f] } {
 			puts_err "$f doesn't exist."
-			exit 1
+			return -code error
 		} else {
 			puts_info "$f exists."
 		}

--- a/scripts/utils/utils.tcl
+++ b/scripts/utils/utils.tcl
@@ -327,6 +327,7 @@ proc assert_files_exist {files} {
 	foreach f $files {
 		if { ! [file exists $f] } {
 			puts_err "$f doesn't exist."
+			flow_fail
 			return -code error
 		} else {
 			puts_info "$f exists."


### PR DESCRIPTION
Files that don't exist in the variable `EXTRA_GDS_FILES` are reported silently during generating the finishing gds. This commit quits the flow if a file in the variable doesn't exists before starting the flow itself. 