### PR TITLE
Save SPEF/SDC/SDF files after the flow finishes

### DIFF
--- a/flow.tcl
+++ b/flow.tcl
@@ -198,6 +198,9 @@ proc run_non_interactive_mode {args} {
 			-maglef_path $::env(finishing_results)/$::env(DESIGN_NAME).lef.mag \
 			-spice_path $::env(finishing_results)/$::env(DESIGN_NAME).spice \
 			-verilog_path $::env(CURRENT_NETLIST) \
+			-spef_path $::env(SPEF_TYPICAL) \
+			-sdf_path $::env(CURRENT_SDF) \
+			-sdc_path $::env(CURRENT_SDC) \
 			-save_path $arg_values(-save_path) \
 			-tag $::env(RUN_TAG)
 	}

--- a/scripts/tcl_commands/all.tcl
+++ b/scripts/tcl_commands/all.tcl
@@ -640,6 +640,9 @@ proc save_views {args} {
         {-gds_path optional}
         {-verilog_path optional}
         {-spice_path optional}
+        {-sdf_path optional}
+        {-spef_path optional}
+        {-sdc_path optional}
         {-save_path optional}
         {-tag required}
     }
@@ -706,6 +709,30 @@ proc save_views {args} {
         file mkdir $destination
         if { [file exists $arg_values(-spice_path)] } {
             file copy -force $arg_values(-spice_path) $destination/$arg_values(-tag).spice
+        }
+    }
+
+    if { [info exists arg_values(-spef_path)] } {
+        set destination $path/spef
+        file mkdir $destination
+        if { [file exists $arg_values(-spef_path)] } {
+            file copy -force $arg_values(-spef_path) $destination/$arg_values(-tag).spef
+        }
+    }
+
+    if { [info exists arg_values(-sdf_path)] } {
+        set destination $path/sdf
+        file mkdir $destination
+        if { [file exists $arg_values(-sdf_path)] } {
+            file copy -force $arg_values(-sdf_path) $destination/$arg_values(-tag).sdf
+        }
+    }
+
+    if { [info exists arg_values(-sdc_path)] } {
+        set destination $path/sdc
+        file mkdir $destination
+        if { [file exists $arg_values(-sdc_path)] } {
+            file copy -force $arg_values(-sdc_path) $destination/$arg_values(-tag).sdc
         }
     }
 }

--- a/scripts/tcl_commands/routing.tcl
+++ b/scripts/tcl_commands/routing.tcl
@@ -434,6 +434,8 @@ proc run_routing {args} {
     run_sta -log $::env(routing_logs)/parasitics_sta.log
     set ::env(FINAL_TIMING_REPORT_TAG) [index_file $::env(routing_reports)/parasitics_sta]
 
+    set ::env(CURRENT_SDF) $::env(SAVE_SDF)
+
     # run sta at the three corners
     run_sta -log $::env(routing_logs)/parasitics_multi_corner_sta.log -multi_corner
 


### PR DESCRIPTION
Adds the `spef`/`sdc`/`sdf` files to the list of files that are saved after the flow finishes. 