### PR TITLE
Fix mapping rotations in `manual_macro_place.py`

### DIFF
--- a/scripts/manual_macro_place.py
+++ b/scripts/manual_macro_place.py
@@ -57,8 +57,8 @@ LEF2OA_MAP = {"N": "R0",
               "E": "R270",
               "FN": "MY",
               "FS": "MX",
-              "FW": "MX90",
-              "FE": "MY90"}
+              "FW": "MXR90",
+              "FE": "MYR90"}
 def lef_rot_to_oa_rot(rot):
     if rot in LEF2OA_MAP:
         return LEF2OA_MAP[rot]


### PR DESCRIPTION
The `FW` and `FE` rotations would result in a `ValueError`, because `MX90` and `MY90` are unknown.

```
Traceback (most recent call last):
  File "/openlane/scripts/manual_macro_place.py", line 111, in <module>
    inst.setOrient(lef_rot_to_oa_rot(macro_data[2]))
  File "odbpy.py", line 2401, in setOrient
ValueError: Unknown orientation
```

They should be `MXR90` and `MYR90` instead.