### PR TITLE
Centralize Calling OpenROAD + Automatic Reproducibles

### DIFF
--- a/configuration/README.md
+++ b/configuration/README.md
@@ -20,8 +20,8 @@ These variables are optional that can be specified in the design configuration f
 
 | Variable      | Description                                                   |
 |---------------|---------------------------------------------------------------|
-| `LIB_SYNTH` | The library used for synthesis by yosys. <br> (Default: `$::env(PDK_ROOT)/$::env(PDK)/libs.ref/$::env(STD_CELL_LIBRARY)/lib/sky130_fd_sc_hd__tt_025C_1v80.lib`)|
 | `SYNTH_BIN` | The yosys binary used in the flow. <br> (Default: `yosys`) |
+| `LIB_SYNTH` | The library used for synthesis by yosys. <br> (Default: `$::env(PDK_ROOT)/$::env(PDK)/libs.ref/$::env(STD_CELL_LIBRARY)/lib/sky130_fd_sc_hd__tt_025C_1v80.lib`)|
 | `SYNTH_DRIVING_CELL`  | The cell to drive the input ports. <br>(Default: `sky130_fd_sc_hd__inv_1`)|
 | `SYNTH_DRIVING_CELL_PIN`  | The name of the SYNTH_DRIVING_CELL output pin. <br>(Default: `Y`)|
 | `SYNTH_CAP_LOAD` | The capacitive load on the output ports in femtofarads. <br> (Default: `33.5` ff)|

--- a/docs/source/openlane_commands.md
+++ b/docs/source/openlane_commands.md
@@ -114,7 +114,6 @@ Most of the following commands' implementation exists in this [file][9]
 
 | Command      | Flags                   | Description                                           |
 |---------------|------------------------|-----------------------------------------|
-| `get_yosys_bin` | | Returns the used binary for yosys. |
 | `run_yosys` | | Runs yosys synthesis on the design processed in the flow (the design is set by the `prep` command). if `LEC_ENABLE` is set to 1, a logic verification will be run after generating the new netlist vs the previous netlist if it exists. |
 |    | `[-output <output_file>]` | Sets the outputfile from yosys synthesis. <br> Defaults to `/<run_path>/results/synthesis/<design_name>.synthesis.v`  <br> Optional flag.       |
 | `run_sta` | | Runs OpenSTA timing analysis on the current design, and produces a log under `/<run_path>/logs/synthesis/` and timing reports under `/<run_path>/reports/synthesis/`. |
@@ -139,6 +138,7 @@ Most of the following commands' implementation exists in this [file][9]
 |    | `[-power <power_pin>]` | The name of the power pin. <br> Defaults to `VDD_PIN` |
 |    | `[-ground <ground_pin>]` | The name of the ground pin. <br> Defaults to `GND_PIN` |
 |    | `[-powered_netlist <verilog_netlist_file>]` | The verilog netlist parsed from yosys that contains the internal power connections in case the design has internal macros file. <br> Defaults to `/<run_path>/tmp/synthesis/synthesis.pg_define.v` if `::env(SYNTH_USE_PG_PINS_DEFINES)` is defined, and to empty string otherwise. |
+| `get_yosys_bin` | | **Deprecated** Returns the used binary for yosys. |
 
 
 ## Floorplan Commands

--- a/scripts/or_issue.py
+++ b/scripts/or_issue.py
@@ -40,11 +40,14 @@ parser.add_argument('--run-path', '-r', default=None, help='The run path. If not
 parser.add_argument('--output', '-o', default="./out.def", help='Name of def file to be generated [default: ./out.def]')
 parser.add_argument('--verbose', action="store_true", default=False, help='Verbose output of all found environment variables.')
 parser.add_argument('--netlist', '-n', action="store_true", default=False, help='Use the netlist as an input instead of a def file. Useful for evaluating some scripts such as floorplan.tcl.')
+parser.add_argument('--output-dir', default=None, help='Output to this directory.')
 parser.add_argument('input', help='Name of input into the OR script (usually denoted by environment variable CURRENT_NETLIST or CURRENT_DEF: get it from the logs) [required]')
 args = parser.parse_args()
 
 OPEN_SOURCE_PDKS = ["sky130A"]
 print("""
+or_issue.py OpenROAD Issue Packager
+
 EFABLESS CORPORATION AND ALL AUTHORS OF THE OPENLANE PROJECT SHALL NOT BE HELD
 LIABLE FOR ANY LEAKS THAT MAY OCCUR TO ANY PROPRIETARY DATA AS A RESULT OF USING
 THIS SCRIPT. THIS SCRIPT IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OR
@@ -147,7 +150,7 @@ env["SAVE_DEF"] = save_def
 
 # Phase 2: Set up destination folder
 script_basename = basename(args.or_script)[:-4]
-destination_folder = abspath(join(".", "_build", f"{run_name}_{script_basename}_packaged"))
+destination_folder = args.output_dir or abspath(join(".", "_build", f"{run_name}_{script_basename}_packaged"))
 print(f"Setting up {destination_folder}…", file=sys.stderr)
 
 def mkdirp(path):

--- a/scripts/tcl_commands/all.tcl
+++ b/scripts/tcl_commands/all.tcl
@@ -18,7 +18,7 @@ package require openlane_utils
 
 proc save_state {args} {
     set ::env(INIT_ENV_VAR_ARRAY) [split [array names ::env] " "]
-    puts_info "Saving Runtime Environment"
+    puts_info "Saving runtime environment..."
     set_log ::env(PDK_ROOT) $::env(PDK_ROOT) $::env(GLB_CFG_FILE) 1
     foreach index [lsort [array names ::env]] {
         if { $index != "INIT_ENV_VAR_ARRAY" && $index != "PS1" } {
@@ -877,7 +877,7 @@ proc write_verilog {filename args} {
 
     set ::env(INPUT_DEF) $arg_values(-def)
 
-    try_catch $::env(OPENROAD_BIN) -exit $::env(SCRIPTS_DIR)/openroad/write_verilog.tcl |& tee $::env(TERMINAL_OUTPUT) [index_file $arg_values(-log)]
+    run_openroad_script $::env(SCRIPTS_DIR)/openroad/write_verilog.tcl -indexed_log [index_file $arg_values(-log)]
     TIMER::timer_stop
     exec echo "[TIMER::get_runtime]" | python3 $::env(SCRIPTS_DIR)/write_runtime.py "write verilog - openroad"
     if { [info exists flags_map(-canonical)] } {
@@ -905,7 +905,7 @@ proc run_or_antenna_check {args} {
     increment_index
     puts_info "Running OpenROAD Antenna Rule Checker..."
     set antenna_log [index_file $::env(finishing_logs)/antenna.log]
-	try_catch $::env(OPENROAD_BIN) -exit $::env(SCRIPTS_DIR)/openroad/antenna_check.tcl |& tee $::env(TERMINAL_OUTPUT) $antenna_log
+	run_openroad_script $::env(SCRIPTS_DIR)/openroad/antenna_check.tcl -indexed_log $antenna_log
     set ::env(ANTENNA_CHECKER_LOG) $antenna_log
     TIMER::timer_stop
     exec echo "[TIMER::get_runtime]" | python3 $::env(SCRIPTS_DIR)/write_runtime.py "antenna check - openroad"

--- a/scripts/tcl_commands/cts.tcl
+++ b/scripts/tcl_commands/cts.tcl
@@ -92,7 +92,7 @@ proc run_cts {args} {
 			set ::env(LIB_CTS) $::env(cts_tmpfiles)/cts.lib
 			trim_lib -input $::env(LIB_SYNTH_COMPLETE) -output $::env(LIB_CTS) -drc_exclude_only
 		}
-		try_catch $::env(OPENROAD_BIN) -exit $::env(SCRIPTS_DIR)/openroad/cts.tcl |& tee $::env(TERMINAL_OUTPUT) [index_file $::env(cts_logs)/cts.log]
+		run_openroad_script $::env(SCRIPTS_DIR)/openroad/cts.tcl -indexed_log [index_file $::env(cts_logs)/cts.log]
 		check_cts_clock_nets
 		set ::env(cts_reports) $report_tag_holder
 		TIMER::timer_stop
@@ -123,7 +123,7 @@ proc run_resizer_timing {args} {
 		puts_info "Running Resizer Timing Optimizations..."
 		set ::env(SAVE_DEF) [index_file $::env(cts_tmpfiles)/resizer_timing.def]
 		set ::env(SAVE_SDC) [index_file $::env(cts_tmpfiles)/resizer_timing.sdc]
-		try_catch $::env(OPENROAD_BIN) -exit $::env(SCRIPTS_DIR)/openroad/resizer_timing.tcl |& tee $::env(TERMINAL_OUTPUT) [index_file $::env(cts_logs)/resizer.log]
+		run_openroad_script $::env(SCRIPTS_DIR)/openroad/resizer_timing.tcl -indexed_log [index_file $::env(cts_logs)/resizer.log]
 		set_def $::env(SAVE_DEF)
 		set ::env(CURRENT_SDC) $::env(SAVE_SDC)
 

--- a/scripts/tcl_commands/floorplan.tcl
+++ b/scripts/tcl_commands/floorplan.tcl
@@ -25,7 +25,7 @@ proc init_floorplan {args} {
 
 	set ::env(fp_report_prefix) [index_file $::env(floorplan_reports)/initial_fp]
 
-	try_catch $::env(OPENROAD_BIN) -exit $::env(SCRIPTS_DIR)/openroad/floorplan.tcl |& tee $::env(TERMINAL_OUTPUT) [index_file $::env(floorplan_logs)/initial_fp.log]
+	run_openroad_script $::env(SCRIPTS_DIR)/openroad/floorplan.tcl -indexed_log [index_file $::env(floorplan_logs)/initial_fp.log] -netlist_in
 
 	check_floorplan_missing_lef
 	check_floorplan_missing_pins
@@ -140,7 +140,7 @@ proc place_io {args} {
 	TIMER::timer_start
 	set ::env(SAVE_DEF) [index_file $::env(floorplan_tmpfiles)/io.def]
 
-	try_catch $::env(OPENROAD_BIN) -exit $::env(SCRIPTS_DIR)/openroad/ioplacer.tcl |& tee $::env(TERMINAL_OUTPUT) [index_file $::env(floorplan_logs)/io.log]
+	run_openroad_script $::env(SCRIPTS_DIR)/openroad/ioplacer.tcl -indexed_log [index_file $::env(floorplan_logs)/io.log]
 	TIMER::timer_stop
 	exec echo "[TIMER::get_runtime]" | python3 $::env(SCRIPTS_DIR)/write_runtime.py "ioplace - openroad"
 	set_def $::env(SAVE_DEF)
@@ -176,7 +176,7 @@ proc place_contextualized_io {args} {
 		set old_mode $::env(FP_IO_MODE)
 		set ::env(FP_IO_MODE) 0; # set matching mode
 		set ::env(CONTEXTUAL_IO_FLAG) 1
-		try_catch $::env(OPENROAD_BIN) -exit $::env(SCRIPTS_DIR)/openroad/ioplacer.tcl |& tee $::env(TERMINAL_OUTPUT) [index_file $::env(floorplan_logs)/io.log]
+		run_openroad_script $::env(SCRIPTS_DIR)/openroad/ioplacer.tcl -indexed_log [index_file $::env(floorplan_logs)/io.log]
 		set ::env(FP_IO_MODE) $old_mode
 
 		move_pins -from $::env(SAVE_DEF) -to $prev_def
@@ -199,7 +199,7 @@ proc tap_decap_or {args} {
 			puts_info "Running Tap/Decap Insertion..."
 			TIMER::timer_start
 			set ::env(SAVE_DEF) $::env(floorplan_results)/$::env(DESIGN_NAME).def
-			try_catch $::env(OPENROAD_BIN) -exit $::env(SCRIPTS_DIR)/openroad/tapcell.tcl |& tee $::env(TERMINAL_OUTPUT) [index_file $::env(floorplan_logs)/tap.log]
+			run_openroad_script $::env(SCRIPTS_DIR)/openroad/tapcell.tcl -indexed_log [index_file $::env(floorplan_logs)/tap.log]
 			TIMER::timer_stop
 			exec echo "[TIMER::get_runtime]" | python3 $::env(SCRIPTS_DIR)/write_runtime.py "tap/decap insertion - openroad"
 			set_def $::env(SAVE_DEF)

--- a/scripts/tcl_commands/placement.tcl
+++ b/scripts/tcl_commands/placement.tcl
@@ -24,7 +24,7 @@ proc global_placement_or {args} {
         set ::env(PL_SKIP_INITIAL_PLACEMENT) 1
     }
 
-    try_catch $::env(OPENROAD_BIN) -exit $::env(SCRIPTS_DIR)/openroad/replace.tcl |& tee $::env(TERMINAL_OUTPUT) [index_file $::env(placement_logs)/global.log]
+    run_openroad_script $::env(SCRIPTS_DIR)/openroad/replace.tcl -indexed_log [index_file $::env(placement_logs)/global.log]
     # sometimes replace fails with a ZERO exit code; the following is a workaround
     # until the cause is found and fixed
     if { ! [file exists $::env(SAVE_DEF)] } {
@@ -73,7 +73,7 @@ proc detailed_placement_or {args} {
     set ::env(SAVE_DEF) $arg_values(-def)
     set log [index_file $arg_values(-log)]
 
-    try_catch $::env(OPENROAD_BIN) -exit $::env(SCRIPTS_DIR)/openroad/opendp.tcl |& tee $::env(TERMINAL_OUTPUT) $log
+    run_openroad_script $::env(SCRIPTS_DIR)/openroad/opendp.tcl -indexed_log $log
     set_def $::env(SAVE_DEF)
 
     if {[catch {exec grep -q -i "fail" $log}] == 0}  {
@@ -121,10 +121,9 @@ proc basic_macro_placement {args} {
     set fbasename [file rootname $::env(CURRENT_DEF)]
     set ::env(SAVE_DEF) ${fbasename}.macro_placement.def
 
-    try_catch $::env(OPENROAD_BIN) -exit $::env(SCRIPTS_DIR)/openroad/basic_mp.tcl |& tee $::env(TERMINAL_OUTPUT) [index_file $::env(placement_logs)/basic_mp.log]
+    run_openroad_script $::env(SCRIPTS_DIR)/openroad/basic_mp.tcl -indexed_log [index_file $::env(placement_logs)/basic_mp.log]
 
     check_macro_placer_num_solns
-
 
     TIMER::timer_stop
     exec echo "[TIMER::get_runtime]" | python3 $::env(SCRIPTS_DIR)/write_runtime.py "macro placement - basic_mp.tcl"
@@ -172,7 +171,7 @@ proc run_resizer_design {args} {
         puts_info "Running Resizer Design Optimizations..."
         set ::env(SAVE_DEF) [index_file $::env(placement_tmpfiles)/resizer.def]
         set ::env(SAVE_SDC) [index_file $::env(placement_tmpfiles)/resizer.sdc]
-        try_catch $::env(OPENROAD_BIN) -exit $::env(SCRIPTS_DIR)/openroad/resizer.tcl |& tee $::env(TERMINAL_OUTPUT) [index_file $::env(placement_logs)/resizer.log]
+        run_openroad_script $::env(SCRIPTS_DIR)/openroad/resizer.tcl -indexed_log [index_file $::env(placement_logs)/resizer.log]
         set_def $::env(SAVE_DEF)
         set ::env(CURRENT_SDC) $::env(SAVE_SDC)
 

--- a/scripts/tcl_commands/routing.tcl
+++ b/scripts/tcl_commands/routing.tcl
@@ -33,7 +33,7 @@ proc global_routing_cugr {args} {
 
 proc global_routing_fastroute {args} {
     set saveLOG [index_file $::env(routing_logs)/global.log]
-    try_catch $::env(OPENROAD_BIN) -exit $::env(SCRIPTS_DIR)/openroad/groute.tcl |& tee $::env(TERMINAL_OUTPUT) $saveLOG
+    run_openroad_script $::env(SCRIPTS_DIR)/openroad/groute.tcl -indexed_log $saveLOG
     if { $::env(DIODE_INSERTION_STRATEGY) == 3 } {
         set_def $::env(SAVE_DEF)
         set_guide $::env(SAVE_GUIDE)
@@ -53,7 +53,7 @@ proc global_routing_fastroute {args} {
             try_catch $::env(OPENROAD_BIN) -python $::env(SCRIPTS_DIR)/replace_prefix_from_def_instances.py -op "ANTENNA" -np $replaceWith -d $::env(CURRENT_DEF)
             puts_info "FastRoute Iteration $iter"
             puts_info "Antenna Violations Previous: $prevAntennaVal"
-            try_catch $::env(OPENROAD_BIN) -exit $::env(SCRIPTS_DIR)/openroad/groute.tcl |& tee $::env(TERMINAL_OUTPUT) $saveLOG
+            run_openroad_script $::env(SCRIPTS_DIR)/openroad/groute.tcl -indexed_log $saveLOG
             set currAntennaVal [exec grep "#Antenna violations:"  $saveLOG -s | tail -1 | sed -r "s/.*\[^0-9\]//"]
             puts_info "Antenna Violations Current: $currAntennaVal"
             if { $currAntennaVal >= $prevAntennaVal } {
@@ -107,7 +107,7 @@ proc detailed_routing_tritonroute {args} {
     set ::env(TRITONROUTE_FILE_PREFIX) $::env(routing_tmpfiles)/detailed
     set ::env(TRITONROUTE_RPT_PREFIX) $::env(routing_reports)/detailed
 
-    try_catch $::env(OPENROAD_BIN) -exit $::env(SCRIPTS_DIR)/openroad/droute.tcl |& tee $::env(TERMINAL_OUTPUT) [index_file $::env(routing_logs)/detailed.log]
+    run_openroad_script $::env(SCRIPTS_DIR)/openroad/droute.tcl -indexed_log [index_file $::env(routing_logs)/detailed.log]
 
     try_catch $::env(OPENROAD_BIN) -python $::env(SCRIPTS_DIR)/tr2klayout.py \
         -i $::env(routing_reports)/detailed.drc \
@@ -162,7 +162,7 @@ proc ins_fill_cells {args} {
         TIMER::timer_start
         puts_info "Running Fill Insertion..."
         set ::env(SAVE_DEF) [index_file $::env(routing_tmpfiles)/fill.def]
-        try_catch $::env(OPENROAD_BIN) -exit $::env(SCRIPTS_DIR)/openroad/fill.tcl |& tee $::env(TERMINAL_OUTPUT) [index_file $::env(routing_logs)/fill.log]
+        run_openroad_script $::env(SCRIPTS_DIR)/openroad/fill.tcl -indexed_log [index_file $::env(routing_logs)/fill.log]
         set_def $::env(SAVE_DEF)
         TIMER::timer_stop
         exec echo "[TIMER::get_runtime]" | python3 $::env(SCRIPTS_DIR)/write_runtime.py "fill insertion - openroad"
@@ -217,8 +217,8 @@ proc gen_pdn {args} {
     set ::env(SAVE_DEF) [index_file $::env(floorplan_tmpfiles)/pdn.def]
     set ::env(PGA_RPT_FILE) [index_file $::env(floorplan_tmpfiles)/pdn.pga.rpt]
 
-    try_catch $::env(OPENROAD_BIN) -exit $::env(SCRIPTS_DIR)/openroad/pdn.tcl \
-        |& tee $::env(TERMINAL_OUTPUT) [index_file $::env(floorplan_logs)/pdn.log]
+    run_openroad_script $::env(SCRIPTS_DIR)/openroad/pdn.tcl \
+        |& -indexed_log [index_file $::env(floorplan_logs)/pdn.log]
 
 
     TIMER::timer_stop
@@ -236,7 +236,7 @@ proc ins_diode_cells_1 {args} {
     puts_info "Running Diode Insertion..."
     set ::env(SAVE_DEF) [index_file $::env(routing_tmpfiles)/diodes.def]
 
-    try_catch $::env(OPENROAD_BIN) -exit $::env(SCRIPTS_DIR)/openroad/diodes.tcl |& tee $::env(TERMINAL_OUTPUT) [index_file $::env(routing_logs)/diodes.log]
+    run_openroad_script $::env(SCRIPTS_DIR)/openroad/diodes.tcl -indexed_log [index_file $::env(routing_logs)/diodes.log]
 
     set_def $::env(SAVE_DEF)
 
@@ -357,7 +357,7 @@ proc run_spef_extraction {args} {
             set ::env(MPLCONFIGDIR) /tmp
             try_catch $::env(OPENROAD_BIN) -python $::env(SCRIPTS_DIR)/spef_extractor/main.py -l $::env(MERGED_LEF_UNPADDED) -d $::env(CURRENT_DEF) -mw $::env(SPEF_WIRE_MODEL) -ec $::env(SPEF_EDGE_CAP_FACTOR) |& tee $::env(TERMINAL_OUTPUT) $log
         } else {
-            try_catch $::env(OPENROAD_BIN) -exit $::env(SCRIPTS_DIR)/openroad/rcx.tcl |& tee $::env(TERMINAL_OUTPUT) $log
+            run_openroad_script $::env(SCRIPTS_DIR)/openroad/rcx.tcl -indexed_log $log
         }
         TIMER::timer_stop
         exec echo "[TIMER::get_runtime]" | python3 $::env(SCRIPTS_DIR)/write_runtime.py "parasitics extraction - $tool"
@@ -459,7 +459,7 @@ proc run_resizer_timing_routing {args} {
         puts_info "Running Resizer Timing Optimizations..."
         set ::env(SAVE_DEF) [index_file $::env(routing_tmpfiles)/resizer_timing.def]
         set ::env(SAVE_SDC) [index_file $::env(routing_tmpfiles)/resizer_timing.sdc]
-        try_catch $::env(OPENROAD_BIN) -exit $::env(SCRIPTS_DIR)/openroad/resizer_routing_timing.tcl |& tee $::env(TERMINAL_OUTPUT) [index_file $::env(routing_logs)/resizer.log]
+        run_openroad_script $::env(SCRIPTS_DIR)/openroad/resizer_routing_timing.tcl -indexed_log [index_file $::env(routing_logs)/resizer.log]
         set_def $::env(SAVE_DEF)
         set ::env(CURRENT_SDC) $::env(SAVE_SDC)
 

--- a/scripts/tcl_commands/synthesis.tcl
+++ b/scripts/tcl_commands/synthesis.tcl
@@ -13,11 +13,7 @@
 # limitations under the License.
 
 proc get_yosys_bin {} {
-    set synth_bin yosys
-    if { [info exists ::env(SYNTH_BIN)] } {
-		set synth_bin $::env(SYNTH_BIN)
-    }
-    return $synth_bin
+    return $::env(SYNTH_BIN)
 }
 
 proc convert_pg_pins {lib_in lib_out} {
@@ -55,7 +51,7 @@ proc run_yosys {args} {
 		lappend ::env(LIB_SYNTH_COMPLETE_NO_PG) $lib_path
 	}
 
-	try_catch [get_yosys_bin] \
+	try_catch $::env(SYNTH_BIN) \
 		-c $::env(SYNTH_SCRIPT) \
 		-l [index_file $::env(synthesis_logs)/synthesis.log] \
 		|& tee $::env(TERMINAL_OUTPUT)
@@ -97,11 +93,11 @@ proc run_sta {args} {
 
 	if {[info exists ::env(CLOCK_PORT)]} {
 		if { $multi_corner == 1 } {
-			try_catch $::env(OPENROAD_BIN) -exit $::env(SCRIPTS_DIR)/openroad/sta_multi_corner.tcl \
-			|& tee $::env(TERMINAL_OUTPUT) $log
+			run_openroad_script $::env(SCRIPTS_DIR)/openroad/sta_multi_corner.tcl \
+				-indexed_log $log
 		} else {
-			try_catch $::env(OPENROAD_BIN) -exit $::env(SCRIPTS_DIR)/openroad/sta.tcl \
-			|& tee $::env(TERMINAL_OUTPUT) $log
+			run_openroad_script $::env(SCRIPTS_DIR)/openroad/sta.tcl \
+				-indexed_log $log
 		}
 	} else {
 		puts_warn "CLOCK_PORT is not set. STA will be skipped..."
@@ -200,9 +196,9 @@ proc yosys_rewrite_verilog {filename} {
 		TIMER::timer_start
 		puts_info "Rewriting $filename into $::env(SAVE_NETLIST)"
 
-		try_catch [get_yosys_bin] \
-		-c $::env(SCRIPTS_DIR)/yosys/rewrite_verilog.tcl \
-		-l [index_file $::env(synthesis_logs)/rewrite_verilog.log]; #|& tee $::env(TERMINAL_OUTPUT)
+		try_catch $::env(SYNTH_BIN) \
+			-c $::env(SCRIPTS_DIR)/yosys/rewrite_verilog.tcl \
+			-l [index_file $::env(synthesis_logs)/rewrite_verilog.log]; #|& tee $::env(TERMINAL_OUTPUT)
 
 		TIMER::timer_stop
 		exec echo "[TIMER::get_runtime]" | python3 $::env(SCRIPTS_DIR)/write_runtime.py "verilog rewrite - yosys"
@@ -239,7 +235,7 @@ proc logic_equiv_check {args} {
     puts_info "Running LEC: $::env(LEC_LHS_NETLIST) Vs. $::env(LEC_RHS_NETLIST)"
 
     if {[ catch {\
-		exec [get_yosys_bin] \
+		exec $::env(SYNTH_BIN) \
 			-c $::env(SCRIPTS_DIR)/yosys/logic_equiv_check.tcl \
 			-l [index_file $::env(synthesis_logs).equiv.log] \
 		|& tee $::env(TERMINAL_OUTPUT)\


### PR DESCRIPTION
All OpenROAD scripts are now called with `run_openroad_script`, a variant of `try_catch`, that upon detecting a failure will automatically invoke `./scripts/or_issue.py` and create a reproducible within the run directory.

Also tweaks to how yosys is invoked.

---

Resolves #736.