### PR TITLE
Update macro documentation to use RT_MAX_LAYER

### DIFF
--- a/docs/source/advanced_power_grid_control.md
+++ b/docs/source/advanced_power_grid_control.md
@@ -100,12 +100,12 @@ At this stage you have automated the power grid generation for the Core Module.
 
 For the skywater libraries the hierarchy typically can go one level down at most otherwise you will only have two routing layers, which is usually not recommended. Therefore, although it's supported, your macros will typically have no nested macros inside them.
 
-To begin the configurations for your macro, you want to announce that the design is a macro inside the core, and that it doesn't have a core ring. Also, prohibit the router from using metal 5 by setting the maximum routing layer to met4 (layer 5). This is done by setting the following configs:
+To begin the configurations for your macro, you want to announce that the design is a macro inside the core, and that it doesn't have a core ring. Also, prohibit the router from using metal 5 by setting the maximum routing layer to met4. This is done by setting the following configs:
 
 ```tcl
 set ::env(DESIGN_IS_CORE) 0
 set ::env(FP_PDN_CORE_RING) 0
-set ::env(GLB_RT_MAXLAYER) 5
+set ::env(RT_MAX_LAYER) "met4"
 ```
 
 Then, you should use the same `VDD_NETS` and `GND_NETS` set in the core level by adding these two lines to your `config.tcl`:

--- a/docs/source/hardening_macros.md
+++ b/docs/source/hardening_macros.md
@@ -136,12 +136,12 @@ If you don't want all the clock ports to be used in clock tree synthesis, then y
 
 You can skip reading this section and jump ahead to reading the advanced power grid controls to get an overall vision of how the whole chip would be powered and as such make a more educated decision in this stage. This detailed documentation exists [here][9].
 
-Each macro in your design should configure the `common_pdn.tcl` for it's use. Generally, you want to announce that the design is a macro inside the core, and that it doesn't have a core ring. Also, prohibit the router from using metal 5 by setting the maximum routing layer to met4 (layer 5). This is done by setting the following configs:
+Each macro in your design should configure the `common_pdn.tcl` for it's use. Generally, you want to announce that the design is a macro inside the core, and that it doesn't have a core ring. Also, prohibit the router from using metal 5 by setting the maximum routing layer to met4. This is done by setting the following configs:
 
 ```tcl
 set ::env(DESIGN_IS_CORE) 0
 set ::env(FP_PDN_CORE_RING) 0
-set ::env(GLB_RT_MAXLAYER) 5
+set ::env(RT_MAX_LAYER) "met4"
 ```
 
 Pdngen configs for macros contain a special stdcell section, instead of the one used for the core in the `common_pdn.tcl`. The purpose of this is to prohibit the use of metal 5 in the power grid of the macros and use it exclusively for the core and top level.


### PR DESCRIPTION
The macro and power grid documentation uses the deprecated
GLB_RT_MAXLAYER option.