### PR TITLE
Restore `-save` Functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,8 +170,8 @@ The following are arguments that can be passed to `flow.tcl`
 | `-synth_explore`  <br>(Boolean) | If enabled, synthesis exploration will be run (only synthesis exploration), which will try out the available synthesis strategies against the input design. The output will be the four possible gate level netlists under &lt;run_path/results/synthesis&gt; and a summary report under reports that compares the 4 outputs. |
 | `-lvs`  <br>(Boolean) | If enabled, only LVS will be run on the design. in which case the user must also pass: -design DESIGN\_DIR -gds DESIGN\_GDS -net DESIGN_NETLIST. |
 | `-drc`  <br>(Boolean) | If enabled, only DRC will be run on the design. in which case the user must also pass: -design DESIGN\_DIR -gds DESIGN\_GDS -report OUTPUT\_REPORT\_PATH -magicrc MAGICRC. |
-| `-save`  <br>(Optional) | **Removed: Always saved**: A flag to save a runs results like .mag and .lef in the design's folder. |
-| `-save_path <path>`  <br>(Optional) | **Removed: Always <run_path>/results/final**: Specifies a different path to save the design's result. This options is to be used with the `-save` flag |
+| `-save`  <br>(Optional) |  A flag to save a runs results like .mag and .lef in the design's folder. |
+| `-save_path <path>`  <br>(Optional) | Specifies a different path to save the design's result. This option is to be used with the `-save` flag. |
 
 ## Adding a design
 

--- a/docs/source/openlane_commands.md
+++ b/docs/source/openlane_commands.md
@@ -50,7 +50,7 @@ Most of the following commands' implementation exists in this [file][0]
 |    | `[-verilog_path <path>]` |  Changes the save path for the verilog files to `<path>`. <br> The default is the `<run_path>` under the `<design_path>` specified by the `<run_tag>` and the processed `design` <br> Optional flag.|
 |    | `[-spice_path <path>]` |  Changes the save path for the spice files to `<path>`. <br> The default is the `<run_path>` under the `<design_path>` specified by the `<run_tag>` and the processed `design` <br> Optional flag.|
 |    | `[-save_path <path>]` |  Changes the save path for the save path for all the types of files to `<path>`. <br> The default is the `<run_path>/results/final`.<br> Optional flag.|
-|    | `-tag <run_tag>` |  **Removed** Specifies the `<run_tag>` from which the views were generated.|
+|    | `-tag <run_tag>` |  **Removed:** Specifies the `<run_tag>` from which the views were generated.|
 | `widen_site_width`   | | generates two new lef files (merged_wider.lef and merged_unpadded_wider.lef) with a widened site width based on the values of `WIDEN_SITE_IS_FACTOR` and `WIDEN_SITE`, more about those in the [configurations/readme.md][13].|
 | `use_widened_lefs`   | | Switches to using the lef files with the widened site width in the flow.|
 | `use_original_lefs`   | | Switches to using the normal lef files in the flow.|

--- a/flow.tcl
+++ b/flow.tcl
@@ -105,7 +105,46 @@ proc run_antenna_check_step {{ antenna_check_enabled 1 }} {
 	}
 }
 
+proc save_final_views {args} {
+	set options {
+		{-save_path optional}
+	}
+	set flags {}
+	parse_key_args "run_non_interactive_mode" args arg_values $options flags_map $flags -no_consume
 
+	set arg_list [list]
+
+	# If they don't exist, save_views will simply not copy them
+	lappend arg_list -lef_path $::env(finishing_results)/$::env(DESIGN_NAME).lef
+	lappend arg_list -gds_path $::env(finishing_results)/$::env(DESIGN_NAME).gds
+	lappend arg_list -mag_path $::env(finishing_results)/$::env(DESIGN_NAME).mag
+	lappend arg_list -maglef_path $::env(finishing_results)/$::env(DESIGN_NAME).lef.mag
+	lappend arg_list -spice_path $::env(finishing_results)/$::env(DESIGN_NAME).spice
+	
+	# Guaranteed to have default values
+	lappend arg_list -def_path $::env(CURRENT_DEF)
+	lappend arg_list -verilog_path $::env(CURRENT_NETLIST)
+
+	# Not guaranteed to have default values
+	if { [info exists ::env(SPEF_TYPICAL)] } {
+		lappend arg_list -spef_path $::env(SPEF_TYPICAL)
+	}
+	if { [info exists ::env(CURRENT_SDF)] } {
+		lappend arg_list -sdf_path $::env(CURRENT_SDF)
+	}
+	if { [info exists ::env(CURRENT_SDC)] } {
+		lappend arg_list -sdc_path $::env(CURRENT_SDC)
+	}
+
+	# Add the path if it exists...
+	if { [info exists arg_values(save_path) ] } {
+		lappend arg_list -save_path $arg_values(save_path)
+	}
+
+	# Aaand fire!
+	save_views {*}$arg_list
+
+}
 
 proc run_non_interactive_mode {args} {
 	set options {
@@ -188,19 +227,19 @@ proc run_non_interactive_mode {args} {
     set next_idx [expr [lsearch $steps_as_list $::env(CURRENT_STEP)] + 1]
     set ::env(CURRENT_STEP) [lindex $steps_as_list $next_idx]
 
+	# Saves to <RUN_DIR>/results/final
 	if { $::env(SAVE_FINAL_VIEWS) == "1" } {
-		save_views \
-			-save_path $::env(RESULTS_DIR)/final \
-			-def_path $::env(CURRENT_DEF) \
-			-lef_path $::env(finishing_results)/$::env(DESIGN_NAME).lef \
-			-gds_path $::env(finishing_results)/$::env(DESIGN_NAME).gds \
-			-mag_path $::env(finishing_results)/$::env(DESIGN_NAME).mag \
-			-maglef_path $::env(finishing_results)/$::env(DESIGN_NAME).lef.mag \
-			-spice_path $::env(finishing_results)/$::env(DESIGN_NAME).spice \
-			-verilog_path $::env(CURRENT_NETLIST) \
-			-spef_path $::env(SPEF_TYPICAL) \
-			-sdf_path $::env(CURRENT_SDF) \
-			-sdc_path $::env(CURRENT_SDC)
+		save_final_views
+	}
+
+	# Saves to design directory or custom
+	if {  [info exists flags_map(-save) ] } {
+		if { ! [info exists arg_values(-save_path)] } {
+			set arg_values(-save_path) $::env(DESIGN_DIR)
+		}
+		save_final_views\
+			-save_path $arg_values(-save_path)\
+			-tag $::env(RUN_TAG)
 	}
 	calc_total_runtime
 	save_state

--- a/flow.tcl
+++ b/flow.tcl
@@ -110,7 +110,7 @@ proc save_final_views {args} {
 		{-save_path optional}
 	}
 	set flags {}
-	parse_key_args "run_non_interactive_mode" args arg_values $options flags_map $flags -no_consume
+	parse_key_args "save_final_views" args arg_values $options flags_map $flags
 
 	set arg_list [list]
 
@@ -137,8 +137,8 @@ proc save_final_views {args} {
 	}
 
 	# Add the path if it exists...
-	if { [info exists arg_values(save_path) ] } {
-		lappend arg_list -save_path $arg_values(save_path)
+	if { [info exists arg_values(-save_path) ] } {
+		lappend arg_list -save_path $arg_values(-save_path)
 	}
 
 	# Aaand fire!

--- a/scripts/tcl_commands/all.tcl
+++ b/scripts/tcl_commands/all.tcl
@@ -648,7 +648,6 @@ proc save_views {args} {
         {-spef_path optional}
         {-sdc_path optional}
         {-save_path optional}
-        {-tag optional}
     }
 
     set flags {}

--- a/scripts/tcl_commands/all.tcl
+++ b/scripts/tcl_commands/all.tcl
@@ -658,7 +658,7 @@ proc save_views {args} {
     } else {
         set path $::env(RESULTS_DIR)/final
     }
-    puts_info "Saving Magic Views in $path"
+    puts_info "Saving final set of views in '$path'..."
 
     if { [info exists arg_values(-lef_path)] } {
         set destination $path/lef


### PR DESCRIPTION
This restores `-save` functionality from previous versions of OpenLane, which was mistakenly removed.

---

Resolves #805.