### PR TITLE
Update OpenROAD SWIG to 4.0.1

### DIFF
--- a/.github/workflows/openlane_ci.yml
+++ b/.github/workflows/openlane_ci.yml
@@ -37,7 +37,16 @@ jobs:
         run: echo "OPENLANE_IMAGE_NAME=openlane:intermediate" >> $GITHUB_ENV
       # END EXPORT BLOCK
 
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
       - name: Docker Build
+        env:
+          BUILD_IF_CANT_PULL: '1'
+          BUILD_IF_CANT_PULL_THEN_PUSH: '1'
         run: cd docker/ && make merge
 
       - name: Export Docker Image

--- a/.github/workflows/openlane_ci.yml
+++ b/.github/workflows/openlane_ci.yml
@@ -37,17 +37,28 @@ jobs:
         run: echo "OPENLANE_IMAGE_NAME=openlane:intermediate" >> $GITHUB_ENV
       # END EXPORT BLOCK
 
+      - name: Check If Going To Push An Image To Docker
+        # # Uncomment the next line if you want to only build & push a container if entire test set succeeds
+        # if: needs.test.result == 'success'
+        # Ruby snippet to print 0 if this is a PR or if there is no DOCKERHUB_USER secret set, otherwise, 1
+        run: |
+          export PUSHING=$(ruby -e 'if ("${{ github.event_name }}" != "pull_request" && "${{ secrets.DOCKERHUB_USER }}" != ""); print(1) else print(0) end')
+          echo "PUSHING=$PUSHING" >> $GITHUB_ENV
+
       - name: Login to DockerHub
+        if: ${{ env.PUSHING == '1' }}
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Docker Build
-        env:
-          BUILD_IF_CANT_PULL: '1'
-          BUILD_IF_CANT_PULL_THEN_PUSH: '1'
-        run: cd docker/ && make merge
+        run: |
+          export BUILD_IF_CANT_PULL=1
+          if [ $PUSHING = '1' ]; then
+            export BUILD_IF_CANT_PULL_THEN_PUSH=1
+          fi
+          cd docker/ && make merge
 
       - name: Export Docker Image
         run: docker save -o /tmp/image.tar ${{ env.OPENLANE_IMAGE_NAME }}

--- a/.github/workflows/tool_updater.yml
+++ b/.github/workflows/tool_updater.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Push Image
         if: ${{ env.NO_UPDATE != '1' }}
         run: |
-          docker push ${{ secrets.TOOL_DOCKER_IMAGE }}:$(python3 ./dependencies/tool.py --docker-tag-for-os=centos-7)
+          docker push ${{ secrets.TOOL_DOCKER_IMAGE }}:$(python3 ./dependencies/tool.py --docker-tag-for-os=centos-7 ${{ env.TOOL }} )
 
       - name: Create Pull Request
         if: ${{ env.NO_UPDATE != '1' }}

--- a/.github/workflows/tool_updater.yml
+++ b/.github/workflows/tool_updater.yml
@@ -36,18 +36,6 @@ jobs:
       - name: Update TOOL
         run: cd ${GITHUB_WORKSPACE}/ && python3 ${GITHUB_WORKSPACE}/.github/scripts/update_tools.py ${{ env.TOOL }}
 
-      - name: Build TOOL
-        if: ${{ env.NO_UPDATE != '1' }}
-        run: |
-          cd ${GITHUB_WORKSPACE}/docker
-          export TOOL_REPOSITORY=${{ secrets.TOOL_DOCKER_IMAGE }}
-          make build-${{ env.TOOL }}
-      
-      - name: Push Image
-        if: ${{ env.NO_UPDATE != '1' }}
-        run: |
-          docker push ${{ secrets.TOOL_DOCKER_IMAGE }}:$(python3 ./dependencies/tool.py --docker-tag-for-os=centos-7 ${{ env.TOOL }} )
-
       - name: Create Pull Request
         if: ${{ env.NO_UPDATE != '1' }}
         uses: peter-evans/create-pull-request@v3

--- a/dependencies/centos-7/compile_time.txt
+++ b/dependencies/centos-7/compile_time.txt
@@ -3,6 +3,9 @@ https://www.klayout.org/downloads/CentOS_7/klayout-0.27.3-0.x86_64.rpm
 devtoolset-8
 devtoolset-8-libatomic-devel
 
+llvm-toolset-7.0-clang
+llvm-toolset-7.0-libomp-devel
+
 Xvfb
 autoconf
 automake

--- a/dependencies/centos-7/run_time.txt
+++ b/dependencies/centos-7/run_time.txt
@@ -15,6 +15,7 @@ libXft
 libXinerama
 libXrandr
 libyaml
+llvm-toolset-7-libomp
 make
 mesa-libGLU
 patch
@@ -48,4 +49,3 @@ wget
 which
 Xvfb
 zlib
-

--- a/dependencies/tool_metadata.yml
+++ b/dependencies/tool_metadata.yml
@@ -78,7 +78,7 @@
     make PREFIX=$PREFIX install
 - name: openroad_app
   repo: https://github.com/The-OpenROAD-Project/OpenROAD
-  commit: e9d88df58cd6e61dec17d0cd7d355f7d6ec25778
+  commit: 719c6dc617d4b8d6896500bb41cdf057864f9e09
   build: ''
   in_install: false
 - name: git

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -45,7 +45,7 @@ $(TOOL_BUILD_TARGETS): build-% : ./%/Dockerfile base_image
 $(TOOL_EXPORT_TARGETS): tar/%.tar.gz : FORCE
 	rm -f tar/$*.tar.gz && echo "Deleted existing tar/$*.tar.gz"
 	mkdir -p tar
-	python3 ./utils.py pull-if-doesnt-exist $(TOOL_REPOSITORY):$(shell python3 ../dependencies/tool.py --docker-tag-for-os=$(OS_NAME) $*)
+	python3 ./utils.py pull-if-doesnt-exist --repository $(TOOL_REPOSITORY) --os $(OS_NAME) $*
 	id=$$(${ROOT} docker create $(TOOL_REPOSITORY):$(shell python3 ../dependencies/tool.py --docker-tag-for-os=$(OS_NAME) $*)) ; \
 	  ${ROOT} docker cp $$id:/build.tar.gz tar/$*.tar.gz ; \
 	  ${ROOT} docker rm -v $$id

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -51,3 +51,5 @@ ENV CC=/opt/rh/devtoolset-8/root/usr/bin/gcc \
     CXX=/opt/rh/devtoolset-8/root/usr/bin/g++ \
     PATH=/opt/rh/devtoolset-8/root/usr/bin:$PATH \
     LD_LIBRARY_PATH=/opt/rh/devtoolset-8/root/usr/lib64:/opt/rh/devtoolset-8/root/usr/lib:/opt/rh/devtoolset-8/root/usr/lib64/dyninst:/opt/rh/devtoolset-8/root/usr/lib/dyninst:/opt/rh/devtoolset-8/root/usr/lib64:/opt/rh/devtoolset-8/root/usr/lib:$LD_LIBRARY_PATH
+
+ENV LD_LIBRARY_PATH=/opt/rh/llvm-toolset-7.0/root/usr/lib64:/opt/rh/llvm-toolset-7.0/root/usr/lib:/opt/rh/llvm-toolset-7.0/root/usr/lib64/dyninst:/opt/rh/llvm-toolset-7.0/root/usr/lib/dyninst:/opt/rh/llvm-toolset-7.0/root/usr/lib64:/opt/rh/llvm-toolset-7.0/root/usr/lib:$LD_LIBRARY_PATH

--- a/docker/openroad_app/Dockerfile
+++ b/docker/openroad_app/Dockerfile
@@ -52,6 +52,12 @@ RUN curl -L https://github.com/swig/swig/archive/refs/tags/v4.0.1.tar.gz | tar -
     make -j $(nproc) && \
     make install
     
+# GCC segfaults
+RUN yum install -y llvm-toolset-7.0-clang llvm-toolset-7.0-libomp-devel
+ENV CC=/opt/rh/llvm-toolset-7.0/root/usr/bin/clang \
+    CXX=/opt/rh/llvm-toolset-7.0/root/usr/bin/clang++ \
+    PATH=/opt/rh/llvm-toolset-7.0/root/usr/bin:$PATH \
+    LD_LIBRARY_PATH=/opt/rh/llvm-toolset-7.0/root/usr/lib64:/opt/rh/llvm-toolset-7.0/root/usr/lib:/opt/rh/llvm-toolset-7.0/root/usr/lib64/dyninst:/opt/rh/llvm-toolset-7.0/root/usr/lib/dyninst:/opt/rh/llvm-toolset-7.0/root/usr/lib64:/opt/rh/llvm-toolset-7.0/root/usr/lib:$LD_LIBRARY_PATH
 
 ARG OPENROAD_APP_REPO
 ARG OPENROAD_APP_COMMIT
@@ -69,7 +75,9 @@ RUN python3 ./utils.py fetch-submodules-from-tarballs ${OPENROAD_APP_REPO} ${OPE
 RUN sed -i "s/GITDIR-NOTFOUND/${OPENROAD_APP_COMMIT}/" cmake/GetGitRevisionDescription.cmake
 RUN mkdir build && mkdir -p /build/version && mkdir install
 RUN cd build && cmake -DCMAKE_INSTALL_PREFIX=$(pwd)/install ..
-RUN cd build && make -j$(nproc)
+# Max will be four cores: more than that and there are too many files open at the same time
+# To clarify, llvm-ar *crashes*.
+RUN cd build && make -j2
 RUN cd build && make install
 RUN cp -r build/install/bin /build/
 

--- a/docker/openroad_app/Dockerfile
+++ b/docker/openroad_app/Dockerfile
@@ -51,13 +51,6 @@ RUN curl -L https://github.com/swig/swig/archive/refs/tags/v4.0.1.tar.gz | tar -
     ./configure --prefix=/usr && \
     make -j $(nproc) && \
     make install
-    
-# GCC segfaults
-RUN yum install -y llvm-toolset-7.0-clang llvm-toolset-7.0-libomp-devel
-ENV CC=/opt/rh/llvm-toolset-7.0/root/usr/bin/clang \
-    CXX=/opt/rh/llvm-toolset-7.0/root/usr/bin/clang++ \
-    PATH=/opt/rh/llvm-toolset-7.0/root/usr/bin:$PATH \
-    LD_LIBRARY_PATH=/opt/rh/llvm-toolset-7.0/root/usr/lib64:/opt/rh/llvm-toolset-7.0/root/usr/lib:/opt/rh/llvm-toolset-7.0/root/usr/lib64/dyninst:/opt/rh/llvm-toolset-7.0/root/usr/lib/dyninst:/opt/rh/llvm-toolset-7.0/root/usr/lib64:/opt/rh/llvm-toolset-7.0/root/usr/lib:$LD_LIBRARY_PATH
 
 ARG OPENROAD_APP_REPO
 ARG OPENROAD_APP_COMMIT

--- a/docker/openroad_app/Dockerfile
+++ b/docker/openroad_app/Dockerfile
@@ -31,17 +31,27 @@ RUN curl -L https://gitlab.com/libeigen/eigen/-/archive/3.3/eigen-3.3.tar.gz | t
 
 # Build Lemon
 WORKDIR /lemon
-RUN curl -L http://lemon.cs.elte.hu/pub/sources/lemon-1.3.1.tar.gz | tar --strip-components=1 -xzC . \
-    && cmake -B build . \
-    && cmake --build build -j $(nproc) --target install
+RUN curl -L http://lemon.cs.elte.hu/pub/sources/lemon-1.3.1.tar.gz | tar --strip-components=1 -xzC . && \
+    cmake -B build . && \
+    cmake --build build -j $(nproc) --target install
 
 # Build Spdlog
-RUN git clone -b v1.8.1 https://github.com/gabime/spdlog \
-    && cd spdlog \
-    && mkdir build \
-    && cd build \
-    && cmake .. \
-    && make install -j $(nproc)
+WORKDIR /spdlog
+RUN curl -L https://github.com/gabime/spdlog/archive/refs/tags/v1.8.1.tar.gz | tar --strip-components=1 -xzC . && \
+    mkdir build && \
+    cd build && \
+    cmake .. && \
+    make install -j $(nproc)
+
+# Build Swig
+RUN yum remove -y swig3
+WORKDIR /swig
+RUN curl -L https://github.com/swig/swig/archive/refs/tags/v4.0.1.tar.gz | tar --strip-components=1 -xzC . && \
+    ./autogen.sh && \
+    ./configure --prefix=/usr && \
+    make -j $(nproc) && \
+    make install
+    
 
 ARG OPENROAD_APP_REPO
 ARG OPENROAD_APP_COMMIT
@@ -58,7 +68,8 @@ RUN python3 ./utils.py fetch-submodules-from-tarballs ${OPENROAD_APP_REPO} ${OPE
 # Build OpenROAD
 RUN sed -i "s/GITDIR-NOTFOUND/${OPENROAD_APP_COMMIT}/" cmake/GetGitRevisionDescription.cmake
 RUN mkdir build && mkdir -p /build/version && mkdir install
-RUN cd build && cmake -DCMAKE_INSTALL_PREFIX=$(pwd)/install .. && make -j$(nproc)
+RUN cd build && cmake -DCMAKE_INSTALL_PREFIX=$(pwd)/install ..
+RUN cd build && make -j$(nproc)
 RUN cd build && make install
 RUN cp -r build/install/bin /build/
 

--- a/docker/utils.py
+++ b/docker/utils.py
@@ -1,3 +1,16 @@
+# Copyright 2021 Efabless Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import re
 import os
 import sys

--- a/scripts/openroad/cts.tcl
+++ b/scripts/openroad/cts.tcl
@@ -56,17 +56,18 @@ puts "\[INFO]: Running Clock Tree Synthesis..."
 
 set arg_list [list]
 
+lappend arg_list -buf_list $::env(CTS_CLK_BUFFER_LIST)
+lappend arg_list -root_buf $::env(CTS_ROOT_BUFFER)
+lappend arg_list -clk_nets $::env(CLOCK_NET)
+lappend arg_list -sink_clustering_size $::env(CTS_SINK_CLUSTERING_SIZE)
+lappend arg_list -sink_clustering_max_diameter $::env(CTS_SINK_CLUSTERING_MAX_DIAMETER)
+lappend arg_list -sink_clustering_enable 
+
 if { $::env(CTS_DISABLE_POST_PROCESSING) } {
     lappend arg_list -post_cts_disable
 }
 
-clock_tree_synthesis {*}arg_list\
-    -buf_list $::env(CTS_CLK_BUFFER_LIST)\
-    -root_buf $::env(CTS_ROOT_BUFFER)\
-    -clk_nets $::env(CLOCK_NET)\
-    -sink_clustering_enable\
-    -sink_clustering_size $::env(CTS_SINK_CLUSTERING_SIZE)\
-    -sink_clustering_max_diameter $::env(CTS_SINK_CLUSTERING_MAX_DIAMETER)
+clock_tree_synthesis {*}$arg_list
 
 set_propagated_clock [all_clocks]
 

--- a/scripts/openroad/groute.tcl
+++ b/scripts/openroad/groute.tcl
@@ -56,14 +56,14 @@ set_routing_layers -signal [subst $signal_min_layer]-[subst $signal_max_layer] -
 
 source $::env(SCRIPTS_DIR)/openroad/layer_adjustments.tcl
 
-# set arg_list [list]
-# lappend arg_list -verbose 3
-# lappend arg_list -congestion_iterations $::env(GLB_RT_OVERFLOW_ITERS)
-# if { $::env(GLB_RT_ALLOW_CONGESTION) == 1 } {
-#     lappend arg_list -allow_congestion
-# }
-# puts $arg_list
-global_route
+set arg_list [list]
+lappend arg_list -congestion_iterations $::env(GLB_RT_OVERFLOW_ITERS)
+lappend arg_list -verbose
+if { $::env(GLB_RT_ALLOW_CONGESTION) == 1 } {
+    lappend arg_list -allow_congestion
+}
+puts $arg_list
+global_route {*}$arg_list
 
 if { $::env(DIODE_INSERTION_STRATEGY) == 3 } {
     repair_antennas "$::env(DIODE_CELL)/$::env(DIODE_CELL_PIN)" -iterations $::env(GLB_RT_ANT_ITERS)

--- a/scripts/openroad/groute.tcl
+++ b/scripts/openroad/groute.tcl
@@ -56,14 +56,14 @@ set_routing_layers -signal [subst $signal_min_layer]-[subst $signal_max_layer] -
 
 source $::env(SCRIPTS_DIR)/openroad/layer_adjustments.tcl
 
-if { $::env(GLB_RT_ALLOW_CONGESTION) == 1 } {
-    global_route -verbose 3\
-        -congestion_iterations $::env(GLB_RT_OVERFLOW_ITERS)\
-        -allow_congestion
-} else {
-    global_route -verbose 3 \
-    -congestion_iterations $::env(GLB_RT_OVERFLOW_ITERS)
-}
+# set arg_list [list]
+# lappend arg_list -verbose 3
+# lappend arg_list -congestion_iterations $::env(GLB_RT_OVERFLOW_ITERS)
+# if { $::env(GLB_RT_ALLOW_CONGESTION) == 1 } {
+#     lappend arg_list -allow_congestion
+# }
+# puts $arg_list
+global_route
 
 if { $::env(DIODE_INSERTION_STRATEGY) == 3 } {
     repair_antennas "$::env(DIODE_CELL)/$::env(DIODE_CELL_PIN)" -iterations $::env(GLB_RT_ANT_ITERS)

--- a/scripts/openroad/resizer_routing_timing.tcl
+++ b/scripts/openroad/resizer_routing_timing.tcl
@@ -57,14 +57,14 @@ set_routing_layers -signal [subst $signal_min_layer]-[subst $signal_max_layer] -
 
 source $::env(SCRIPTS_DIR)/openroad/layer_adjustments.tcl
 
-# set arg_list [list]
-# lappend arg_list -verbose 3
-# lappend arg_list -congestion_iterations $::env(GLB_RT_OVERFLOW_ITERS)
-# if { $::env(GLB_RT_ALLOW_CONGESTION) == 1 } {
-#     lappend arg_list -allow_congestion
-# }
-# puts $arg_list
-global_route
+set arg_list [list]
+lappend arg_list -congestion_iterations $::env(GLB_RT_OVERFLOW_ITERS)
+lappend arg_list -verbose
+if { $::env(GLB_RT_ALLOW_CONGESTION) == 1 } {
+    lappend arg_list -allow_congestion
+}
+puts $arg_list
+global_route {*}$arg_list
 
 # set rc values
 source $::env(SCRIPTS_DIR)/openroad/set_rc.tcl 

--- a/scripts/openroad/resizer_routing_timing.tcl
+++ b/scripts/openroad/resizer_routing_timing.tcl
@@ -57,14 +57,14 @@ set_routing_layers -signal [subst $signal_min_layer]-[subst $signal_max_layer] -
 
 source $::env(SCRIPTS_DIR)/openroad/layer_adjustments.tcl
 
-if { $::env(GLB_RT_ALLOW_CONGESTION) == 1 } {
-    global_route -verbose 3\
-        -congestion_iterations $::env(GLB_RT_OVERFLOW_ITERS)\
-        -allow_congestion
-} else {
-    global_route -verbose 3 \
-    -congestion_iterations $::env(GLB_RT_OVERFLOW_ITERS)
-}
+# set arg_list [list]
+# lappend arg_list -verbose 3
+# lappend arg_list -congestion_iterations $::env(GLB_RT_OVERFLOW_ITERS)
+# if { $::env(GLB_RT_ALLOW_CONGESTION) == 1 } {
+#     lappend arg_list -allow_congestion
+# }
+# puts $arg_list
+global_route
 
 # set rc values
 source $::env(SCRIPTS_DIR)/openroad/set_rc.tcl 


### PR DESCRIPTION
+ Add llvm-devtoolset-7-clang to CentOS 7 dependencies, just in case (OpenROAD was being funny with GCC for a second there)
~ Updates OpenROAD SWIG to 4.0.1
~ Update scripts to support changes in newer versions of OpenROAD
~ Onus of building images moved to the OpenLane CI proper instead of the tool update flow, which now just basically edits one file

---
[ci ets]