### PR TITLE
Allow Klayout to be used as the primary or exclusive gds generation tool

### DIFF
--- a/configuration/README.md
+++ b/configuration/README.md
@@ -281,6 +281,7 @@ These variables worked initially, but they were too sky130 specific and will be 
 | `LEC_ENABLE` | Enables logic verification using yosys, for comparing each netlist at each stage of the flow with the previous netlist and verifying that they are logically equivalent. Warning: this will increase the runtime significantly. 1 = Enabled, 0 = Disabled <br> (Default: `0`)|
 | `RUN_ROUTING_DETAILED` | Enables detailed routing. 1 = Enabled, 0 = Disabled <br> (Default: `1`)|
 | `RUN_LVS` | Enables running LVS. 1 = Enabled, 0 = Disabled <br> (Default: `1`)|
+| `PRIMARY_SIGNOFF_TOOL` | Determines whether `magic` or `klayout` is the primary signoff tool. <br> (Default: `magic`) |
 | `RUN_MAGIC` | Enables running magic and GDSII streaming. 1 = Enabled, 0 = Disabled <br> (Default: `1`)|
 | `RUN_MAGIC_DRC` | Enables running magic DRC on GDS-II produced by magic. 1 = Enabled, 0 = Disabled <br> (Default: `1`)|
 | `RUN_KLAYOUT` | Enables running Klayout and GDSII streaming. 1 = Enabled, 0 = Disabled <br> (Default: `1`)|

--- a/configuration/general.tcl
+++ b/configuration/general.tcl
@@ -27,6 +27,8 @@ set ::env(RUN_LVS) 1
 set ::env(LEC_ENABLE) 0
 set ::env(YOSYS_REWRITE_VERILOG) 0
 
+set ::env(PRIMARY_SIGNOFF_TOOL) magic
+
 set ::env(RUN_MAGIC) 1
 set ::env(RUN_MAGIC_DRC) 1
 set ::env(MAGIC_PAD) 0

--- a/scripts/magic/gds_pointers.tcl
+++ b/scripts/magic/gds_pointers.tcl
@@ -19,7 +19,7 @@ gds rescale false
 
 # This comes afterwards, so that it would contain GDS pointers
 # And yes, we need to re-read the GDS we just generated...
-gds read $::env(finishing_results)/$::env(DESIGN_NAME).gds
+gds read $::env(MAGIC_GDS)
 cellname filepath $::env(DESIGN_NAME) $::env(finishing_tmpfiles)
 save
 

--- a/scripts/magic/mag.tcl
+++ b/scripts/magic/mag.tcl
@@ -20,7 +20,7 @@ gds rescale false
 puts "\[INFO\]: Saving .mag view With BBox Values: [box values]"
 # This comes afterwards, so that it would contain GDS pointers
 # And yes, we need to re-read the GDS we just generated...
-gds read $::env(finishing_results)/$::env(DESIGN_NAME).gds
+gds read $::env(MAGIC_GDS)
 cellname filepath $::env(DESIGN_NAME) $::env(finishing_results)
 save
 

--- a/scripts/magic/mag_gds.tcl
+++ b/scripts/magic/mag_gds.tcl
@@ -94,7 +94,7 @@ if { $::env(MAGIC_GENERATE_GDS) } {
 
 	gds nodatestamp yes
 
-	gds write $::env(finishing_results)/$::env(DESIGN_NAME).gds
+	gds write $::env(MAGIC_GDS)
 	puts "\[INFO\]: GDS Write Complete"
 }
 


### PR DESCRIPTION
This introduces a new variable, `$::env(PRIMARY_SIGNOFF_TOOL)` (set to `magic` by default), and makes setting `$::env(RUN_MAGIC)` functional.

It enables klayout to be used as the primary or exclusive tool as well, to ease porting new PDKs that may not yet support magic.