### PR TITLE
Allow Including sky130A in the OpenLane Docker Image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,8 +58,8 @@ SKYWATER_COMMIT ?= $(shell $(PYTHON_BIN) ./dependencies/tool.py sky130 -f commit
 OPEN_PDKS_COMMIT ?= $(shell $(PYTHON_BIN) ./dependencies/tool.py open_pdks -f commit)
 
 PDK_OPTS = 
-# ifeq ($(EXTERNAL_PDK_INSTALLATION), 1)
-ifneq ($(EXTERNAL_PDK_INSTALLATION), 1)
+EXTERNAL_PDK_INSTALLATION ?= 1
+ifeq ($(EXTERNAL_PDK_INSTALLATION), 1)
 export PDK_ROOT ?= ./pdks
 export PDK_ROOT := $(shell python3 -c "import os; print(os.path.realpath('$(PDK_ROOT)'), end='')")
 PDK_OPTS = -v $(PDK_ROOT):$(PDK_ROOT) -e PDK_ROOT=$(PDK_ROOT)

--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,6 @@ PYTHON_BIN ?= python3
 
 OPENLANE_DIR ?= $(shell pwd)
 
-PDK_ROOT ?= $(shell pwd)/pdks
-
 DOCKER_OPTIONS = $(shell $(PYTHON_BIN) ./env.py docker-config)
 
 ifneq (,$(DOCKER_SWAP)) # Set to -1 for unlimited
@@ -71,18 +69,22 @@ OPEN_PDKS_COMMIT ?= $(shell $(PYTHON_BIN) ./dependencies/tool.py open_pdks -f co
 
 # designs is mounted over install so env.tcl is not found inside the Docker
 # container.
+ENV_COMMAND = $(ENV_START) $(OPENLANE_IMAGE_NAME)
+
+PDK_OPTS = 
+ifeq ($(INSTALL_SRAM), enabled)
+ifdef PDK_ROOT
+$(error PDK_ROOT is undefined, please export it before running make)
+else
+PDK_OPTS = -v $(PDK_ROOT):$(PDK_ROOT) -e PDK_ROOT=$(PDK_ROOT)
+endif
+endif
+
 ENV_START = docker run --rm\
 	-v $(OPENLANE_DIR):/openlane\
 	-v $(OPENLANE_DIR)/designs:/openlane/install\
-	-v $(PDK_ROOT):$(PDK_ROOT)\
-	-e PDK_ROOT=$(PDK_ROOT)\
+	$(PDK_OPTS)\
 	$(DOCKER_OPTIONS)
-
-ENV_COMMAND = $(ENV_START) $(OPENLANE_IMAGE_NAME)
-
-ifndef PDK_ROOT
-$(error PDK_ROOT is undefined, please export it before running make)
-endif
 
 .DEFAULT_GOAL := all
 

--- a/dependencies/pdk.mk
+++ b/dependencies/pdk.mk
@@ -1,0 +1,115 @@
+# Copyright 2020-2022 Efabless Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is intended to be included by the top-level Makefile. Please don't use it directly. :)
+
+STD_CELL_LIBRARY ?= sky130_fd_sc_hd
+SPECIAL_VOLTAGE_LIBRARY ?= sky130_fd_sc_hvl
+IO_LIBRARY ?= sky130_fd_io
+INSTALL_SRAM ?= disabled
+
+OPEN_PDK_ARGS ?= ""
+ifeq ($(INSTALL_SRAM), enabled)
+OPEN_PDK_ARGS += --enable-sram-sky130
+else ifneq ($(INSTALL_SRAM), disabled)
+OPEN_PDK_ARGS += --enable-sram-sky130=$(INSTALL_SRAM)
+endif 
+
+.PHONY: pdk
+pdk: skywater-pdk skywater-library open_pdks build-pdk gen-sources
+
+.PHONY: native-pdk
+native-pdk: skywater-pdk skywater-library open_pdks native-build-pdk gen-sources
+
+.PHONY: full-pdk
+full-pdk: skywater-pdk all-skywater-libraries open_pdks build-pdk gen-sources
+
+.PHONY: native-full-pdk
+native-full-pdk: skywater-pdk all-skywater-libraries open_pdks native-build-pdk gen-sources
+
+$(PDK_ROOT)/:
+	mkdir -p $(PDK_ROOT)
+
+$(PDK_ROOT)/skywater-pdk: $(PDK_ROOT)
+	git clone $(shell $(PYTHON_BIN) ./dependencies/tool.py sky130 -f repo) $(PDK_ROOT)/skywater-pdk
+
+.PHONY: skywater-pdk
+skywater-pdk:
+	cd $(PDK_ROOT)/skywater-pdk && \
+		git checkout main && git submodule init && git pull --no-recurse-submodules && \
+		git checkout -qf $(SKYWATER_COMMIT)
+
+.PHONY: skywater-library
+skywater-library: $(PDK_ROOT)/skywater-pdk
+	cd $(PDK_ROOT)/skywater-pdk && \
+		git submodule update --init libraries/$(STD_CELL_LIBRARY)/latest && \
+		git submodule update --init libraries/$(IO_LIBRARY)/latest && \
+		git submodule update --init libraries/$(SPECIAL_VOLTAGE_LIBRARY)/latest && \
+		git submodule update --init libraries/sky130_fd_pr/latest && \
+		$(MAKE) -j$(NPROC) timing
+
+.PHONY: all-skywater-libraries
+all-skywater-libraries: skywater-pdk
+	cd $(PDK_ROOT)/skywater-pdk && \
+		git submodule update --init libraries/sky130_fd_sc_hd/latest && \
+		git submodule update --init libraries/sky130_fd_sc_hs/latest && \
+		git submodule update --init libraries/sky130_fd_sc_hdll/latest && \
+		git submodule update --init libraries/sky130_fd_sc_ms/latest && \
+		git submodule update --init libraries/sky130_fd_sc_ls/latest && \
+		git submodule update --init libraries/sky130_fd_sc_hvl/latest && \
+		git submodule update --init libraries/sky130_fd_io/latest && \
+		git submodule update --init libraries/sky130_fd_pr/latest && \
+		$(MAKE) -j$(NPROC) timing
+
+### OPEN_PDKS
+$(PDK_ROOT)/open_pdks:
+	git clone $(shell $(PYTHON_BIN) ./dependencies/tool.py open_pdks -f repo) $(PDK_ROOT)/open_pdks
+
+.PHONY: open_pdks
+open_pdks: $(PDK_ROOT)/ $(PDK_ROOT)/open_pdks
+	cd $(PDK_ROOT)/open_pdks && \
+		git checkout master && \
+		git pull && \
+		git checkout -qf $(OPEN_PDKS_COMMIT)
+
+.PHONY: build-pdk
+native-build-pdk: ENV_COMMAND=env
+native-build-pdk: build-pdk
+build-pdk: $(PDK_ROOT)/open_pdks $(PDK_ROOT)/skywater-pdk
+	[ -d $(PDK_ROOT)/sky130A ] && rm -rf $(PDK_ROOT)/sky130A || true
+	$(ENV_COMMAND) sh -c "\
+		cd $(PDK_ROOT)/open_pdks && \
+		./configure --enable-sky130-pdk=$(PDK_ROOT)/skywater-pdk/libraries $(OPEN_PDK_ARGS)\
+	"
+	cd $(PDK_ROOT)/open_pdks/sky130 && \
+		$(MAKE) veryclean && \
+		$(MAKE) prerequisites
+	$(ENV_COMMAND) sh -c "\
+		cd $(PDK_ROOT)/open_pdks/sky130 && \
+		make && \
+		make SHARED_PDKS_PATH=$(PDK_ROOT) install && \
+		make clean \
+	"
+
+gen-sources: $(PDK_ROOT)/sky130A
+	touch $(PDK_ROOT)/sky130A/SOURCES
+	OPENLANE_COMMIT=$(git rev-parse HEAD)
+	printf "openlane " > $(PDK_ROOT)/sky130A/SOURCES
+	cd $(OPENLANE_DIR) && git rev-parse HEAD >> $(PDK_ROOT)/sky130A/SOURCES
+	printf "magic " >> $(PDK_ROOT)/sky130A/SOURCES
+	python3 ./dependencies/tool.py -f commit magic >> $(PDK_ROOT)/sky130A/SOURCES
+	printf "\n" >> $(PDK_ROOT)/sky130A/SOURCES
+	printf "skywater-pdk " >> $(PDK_ROOT)/sky130A/SOURCES
+	cd $(PDK_ROOT)/skywater-pdk && git rev-parse HEAD >> $(PDK_ROOT)/sky130A/SOURCES
+	printf "open_pdks " >> $(PDK_ROOT)/sky130A/SOURCES
+	cd $(PDK_ROOT)/open_pdks && git rev-parse HEAD >> $(PDK_ROOT)/sky130A/SOURCES

--- a/dependencies/pdk.mk
+++ b/dependencies/pdk.mk
@@ -37,14 +37,14 @@ full-pdk: skywater-pdk all-skywater-libraries open_pdks build-pdk gen-sources
 .PHONY: native-full-pdk
 native-full-pdk: skywater-pdk all-skywater-libraries open_pdks native-build-pdk gen-sources
 
-$(PDK_ROOT)/:
+$(PDK_ROOT):
 	mkdir -p $(PDK_ROOT)
 
 $(PDK_ROOT)/skywater-pdk: $(PDK_ROOT)
 	git clone $(shell $(PYTHON_BIN) ./dependencies/tool.py sky130 -f repo) $(PDK_ROOT)/skywater-pdk
 
 .PHONY: skywater-pdk
-skywater-pdk:
+skywater-pdk: $(PDK_ROOT)/skywater-pdk
 	cd $(PDK_ROOT)/skywater-pdk && \
 		git checkout main && git submodule init && git pull --no-recurse-submodules && \
 		git checkout -qf $(SKYWATER_COMMIT)

--- a/dependencies/tool_metadata.yml
+++ b/dependencies/tool_metadata.yml
@@ -91,7 +91,9 @@
   commit: 476f7428f7f686de51a5164c702629a9b9f2da46
   build: ''
   in_install: false
-  in_container: false
+  dependencies:
+  - sky130
+  - magic
 - name: sky130
   repo: https://github.com/google/skywater-pdk
   commit: c094b6e83a4f9298e47f696ec5a7fd53535ec5eb

--- a/dependencies/tool_metadata.yml
+++ b/dependencies/tool_metadata.yml
@@ -91,6 +91,7 @@
   commit: 476f7428f7f686de51a5164c702629a9b9f2da46
   build: ''
   in_install: false
+  pdk: true
   dependencies:
   - sky130
   - magic

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -10,7 +10,13 @@ DOCKER_BUILD_OPTS ?= --rm
 DOCKER_BUILD_INVOCATION ?= docker build # docker buildx build --platform linux/amd64 --load
 BUILD_COMMAND = $(DOCKER_BUILD_INVOCATION) $(DOCKER_BUILD_OPTS)
 
-TOOLS = $(shell python3 ../dependencies/tool.py --containerized .)
+NO_PDKS_ARGS =
+NO_PDKS ?= 1
+ifeq ($(NO_PDKS), 1)
+NO_PDKS_ARGS = --no-pdks
+endif
+
+TOOLS = $(shell python3 ../dependencies/tool.py --containerized $(NO_PDKS_ARGS) .)
 
 TOOL_BUILD_TARGETS = $(foreach tool,$(TOOLS),build-$(tool))
 TOOL_EXPORT_TARGETS = $(foreach tool,$(TOOLS),tar/$(tool).tar.gz)
@@ -60,13 +66,13 @@ $(TOOL_EXPORT_TARGETS): tar/%.tar.gz : FORCE
 	  ${ROOT} docker rm -v $$id
 
 ./tar/build: $(TOOL_EXPORT_TARGETS)
-	for tarFile in $(foreach tool,$(TOOLS),tar/$(tool).tar.gz); do \
-	  tar -xzf $$tarFile ; \
-	done
-	chmod -R +x ./build/bin
-	find ./build/ -name "*.tcl" -exec chmod +x {} \;
 	rm -rf ./tar/build
-	mv ./build/ ./tar/build
+	cd tar && \
+	for tarFile in $(foreach tool,$(TOOLS),$(tool).tar.gz); do \
+	  	tar -xzf $$tarFile ; \
+		chmod -R +x ./build/bin ; \
+		find ./build/ -name "*.tcl" -exec chmod +x {} \; ;\
+	done
 
 OPENLANE_SKELETON=configuration dependencies designs regression_results scripts AUTHORS.md env.py flow.tcl LICENSE run_designs.py
 ./tar/openlane: FORCE

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -10,7 +10,7 @@ DOCKER_BUILD_OPTS ?= --rm
 DOCKER_BUILD_INVOCATION ?= docker build # docker buildx build --platform linux/amd64 --load
 BUILD_COMMAND = $(DOCKER_BUILD_INVOCATION) $(DOCKER_BUILD_OPTS)
 
-TOOLS = cugr drcu yosys magic openroad_app padring netgen vlogtoverilog cvc git
+TOOLS = $(shell python3 ../dependencies/tool.py --containerized .)
 
 TOOL_BUILD_TARGETS = $(foreach tool,$(TOOLS),build-$(tool))
 TOOL_EXPORT_TARGETS = $(foreach tool,$(TOOLS),tar/$(tool).tar.gz)
@@ -59,22 +59,28 @@ $(TOOL_EXPORT_TARGETS): tar/%.tar.gz : FORCE
 	  ${ROOT} docker cp $$id:/build.tar.gz tar/$*.tar.gz ; \
 	  ${ROOT} docker rm -v $$id
 
-tar/openroad_tools.tar.gz: $(TOOL_EXPORT_TARGETS)
+./tar/build: $(TOOL_EXPORT_TARGETS)
 	for tarFile in $(foreach tool,$(TOOLS),tar/$(tool).tar.gz); do \
 	  tar -xzf $$tarFile ; \
 	done
 	chmod -R +x ./build/bin
 	find ./build/ -name "*.tcl" -exec chmod +x {} \;
-	cd tar && tar -czf openroad_tools.tar.gz ../build
+	rm -rf ./tar/build
+	mv ./build/ ./tar/build
 
-tar/openlane.tar.gz: FORCE
-	cd tar && tar --exclude='../../.git' --exclude='../../docker' --exclude="../../designs" --exclude="../../pdks" --exclude="../../logs/*" -czf openlane.tar.gz ../../
+OPENLANE_SKELETON=configuration dependencies designs regression_results scripts AUTHORS.md env.py flow.tcl LICENSE run_designs.py
+./tar/openlane: FORCE
+	rm -rf ./tar/openlane
+	mkdir -p ./tar/openlane
+	for file in $(OPENLANE_SKELETON); do \
+		cp -r ../$$file ./tar/openlane/$$file ; \
+	done
 
 FORCE:
 
 .PHONY: merge openlane
 openlane: merge
-merge: run_base_image tar/openroad_tools.tar.gz tar/openlane.tar.gz ../dependencies/tool_metadata.yml
+merge: run_base_image ./tar/build ./tar/openlane ../dependencies/tool_metadata.yml
 	cat ../dependencies/tool_metadata.yml > ./tar/tool_metadata.yml
 	printf "$(shell git rev-parse --short=7 HEAD)" > ./tar/git_version
 	mkdir -p logs/tar
@@ -86,12 +92,8 @@ merge: run_base_image tar/openroad_tools.tar.gz tar/openlane.tar.gz ../dependenc
 
 .PHONY: clean_merge
 clean_merge:
-ifneq (,$(wildcard ./tar/openroad_tools.tar.gz))
-ifneq (,$(wildcard ./tar/openlane.tar.gz))
-		rm ./tar/openlane.tar.gz
-		rm ./tar/openroad_tools.tar.gz
-endif
-endif
+	rm -rf ./tar/openlane
+	rm -rf ./tar/build
 
 clean_export: 
 	rm -rf export/*.tar.gz

--- a/docker/README.md
+++ b/docker/README.md
@@ -26,16 +26,8 @@ make # or make openlane # or make merge
 ```
 
 ## Updating a Tool Binary
-You can update a tool binary as follows:
+You can build a tool runnable using the following command: `make build-<tool_name>`.
 
-```
-make build-<tool_name>
-```
+To list the available tools, `python3 ../dependencies/tool.py --containerized`.
 
-The following are the available tools:
-
-```bash
-cugr drcu yosys magic openroad_app padring netgen vlogtoverilog cvc git
-```
-
-Be sure to make openlane after.
+Be sure to `make openlane` after building any tool.

--- a/docker/open_pdks/Dockerfile
+++ b/docker/open_pdks/Dockerfile
@@ -39,7 +39,6 @@ RUN git submodule update --init libraries/sky130_fd_sc_hd/latest &&\
     git submodule update --init libraries/sky130_fd_sc_hvl/latest &&\
     git submodule update --init libraries/sky130_fd_io/latest &&\
     git submodule update --init libraries/sky130_fd_pr/latest
-RUN sed -i 's/sky130_\*_sc_\*/sky130_\*_sc_\*\/latest/' ./Makefile
 RUN make -j 1 NPROC=1 timing 2>&1 | tee /build/pdk_timing.log 
 
 ARG MAGIC_REPO

--- a/docker/open_pdks/Dockerfile
+++ b/docker/open_pdks/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 Efabless Corporation
+# Copyright 2022 Efabless Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -37,8 +37,10 @@ RUN git submodule update --init libraries/sky130_fd_sc_hd/latest &&\
     git submodule update --init libraries/sky130_fd_sc_ms/latest &&\
     git submodule update --init libraries/sky130_fd_sc_ls/latest &&\
     git submodule update --init libraries/sky130_fd_sc_hvl/latest &&\
-    git submodule update --init libraries/sky130_fd_io/latest
-RUN make -j$(nproc) timing > /build/pdk_timing.log 2>&1
+    git submodule update --init libraries/sky130_fd_io/latest &&\
+    git submodule update --init libraries/sky130_fd_pr/latest
+RUN sed -i 's/sky130_\*_sc_\*/sky130_\*_sc_\*\/latest/' ./Makefile
+RUN make -j 1 NPROC=1 timing 2>&1 | tee /build/pdk_timing.log 
 
 ARG MAGIC_REPO
 ARG MAGIC_COMMIT
@@ -59,16 +61,24 @@ RUN git checkout master &&\
 	git checkout -qf ${OPEN_PDKS_COMMIT}
 RUN ./configure --enable-sky130-pdk=${PDK_ROOT}/skywater-pdk/libraries --enable-sram-sky130
 WORKDIR ${PDK_ROOT}/open_pdks/sky130
-RUN make alpha-repo xschem-repo sram-repo > /build/pdk_prereq.log 2>&1 
-RUN make > ./build/pdk.log 2>&1
+RUN make alpha-repo xschem-repo sram-repo 2>&1 | tee /build/pdk_prereq.log
+RUN make 2>&1 | tee /build/pdk.log
 RUN make SHARED_PDKS_PATH=${PDK_ROOT} install
 
+RUN printf "skywater-pdk ${SKY130_COMMIT}" > ${PDK_ROOT}/sky130A/SOURCES
+RUN printf "magic ${MAGIC_COMMIT}" >> ${PDK_ROOT}/sky130A/SOURCES
+RUN printf "open_pdks ${OPEN_PDKS_COMMIT}" >> ${PDK_ROOT}/sky130A/SOURCES
 
+RUN rm -rf ${PDK_ROOT}/skywater-pdk
+RUN rm -rf ${PDK_ROOT}/open_pdks
+
+
+RUN tar -c /build | gzip -1 > /build.tar.gz
 
 # ---
-FROM openlane-run-base AS runnable
+# pdk can't really be runnable, might as well shed a few layers
+FROM centos:centos7 as runnable
 
-COPY --from=builder /build/pdk/pdk.log /build/pdk/pdk.log
-COPY --from=builder /build/pdk/sky130A /build/pdk/sky130A
+COPY --from=builder /build.tar.gz /build.tar.gz
 
 

--- a/docker/open_pdks/Dockerfile
+++ b/docker/open_pdks/Dockerfile
@@ -39,7 +39,26 @@ RUN git submodule update --init libraries/sky130_fd_sc_hd/latest &&\
     git submodule update --init libraries/sky130_fd_sc_hvl/latest &&\
     git submodule update --init libraries/sky130_fd_io/latest &&\
     git submodule update --init libraries/sky130_fd_pr/latest
-RUN make -j 1 NPROC=1 timing 2>&1 | tee /build/pdk_timing.log 
+RUN python3 -m pip install -e scripts/python-skywater-pdk
+RUN python3 -m skywater_pdk.liberty libraries/sky130_fd_sc_hd/latest
+RUN python3 -m skywater_pdk.liberty libraries/sky130_fd_sc_hd/latest all
+RUN python3 -m skywater_pdk.liberty libraries/sky130_fd_sc_hd/latest all --ccsnoise
+RUN python3 -m skywater_pdk.liberty libraries/sky130_fd_sc_hdll/latest
+RUN python3 -m skywater_pdk.liberty libraries/sky130_fd_sc_hdll/latest all
+RUN python3 -m skywater_pdk.liberty libraries/sky130_fd_sc_hdll/latest all --ccsnoise
+RUN python3 -m skywater_pdk.liberty libraries/sky130_fd_sc_hs/latest
+RUN python3 -m skywater_pdk.liberty libraries/sky130_fd_sc_hs/latest all
+RUN python3 -m skywater_pdk.liberty libraries/sky130_fd_sc_hs/latest all --ccsnoise
+RUN python3 -m skywater_pdk.liberty libraries/sky130_fd_sc_hvl/latest
+RUN python3 -m skywater_pdk.liberty libraries/sky130_fd_sc_hvl/latest all
+RUN python3 -m skywater_pdk.liberty libraries/sky130_fd_sc_hvl/latest all --ccsnoise
+RUN python3 -m skywater_pdk.liberty libraries/sky130_fd_sc_ls/latest
+RUN python3 -m skywater_pdk.liberty libraries/sky130_fd_sc_ls/latest all
+RUN python3 -m skywater_pdk.liberty libraries/sky130_fd_sc_ls/latest all --ccsnoise
+RUN python3 -m skywater_pdk.liberty libraries/sky130_fd_sc_ms/latest all --leakage
+RUN python3 -m skywater_pdk.liberty libraries/sky130_fd_sc_ms/latest
+RUN python3 -m skywater_pdk.liberty libraries/sky130_fd_sc_ms/latest all
+RUN python3 -m skywater_pdk.liberty libraries/sky130_fd_sc_ms/latest all --ccsnoise
 
 ARG MAGIC_REPO
 ARG MAGIC_COMMIT

--- a/docker/openlane/Dockerfile
+++ b/docker/openlane/Dockerfile
@@ -25,6 +25,7 @@ ENV MANPATH=$OPENROAD/share/man:$MANPATH
 ENV LANG en_US.UTF-8
 ENV LC_ALL en_US.UTF-8
 ENV LC_CTYPE en_US.UTF-8
+ENV PDK_ROOT /build/pdk
 
 # Tools
 ARG CACHE_INVALIDATOR=1
@@ -39,9 +40,9 @@ ADD ./tool_metadata.yml /tool_metadata.yml
 ## Copy Version
 ADD ./git_version /git_version
 
-## Tarballs
-ADD ./openroad_tools.tar.gz /
-ADD ./openlane.tar.gz $OPENLANE_ROOT
+## Artifacts
+COPY ./build /build
+COPY ./openlane /openlane
 
 ## Tclsh RC
 COPY ./.tclshrc /.tclshrc

--- a/docker/tar/.gitignore
+++ b/docker/tar/.gitignore
@@ -2,3 +2,5 @@
 /*.yml
 /*.txt
 /git_version
+/build
+/openlane


### PR DESCRIPTION
+ Add a dependency system for tools, so some tools can be built first in local installs or have other repos and commits included in docker image builds
+ Add fully working `open_pdks` image
+ Add options to list containerized tools in `dependencies/tool.py`, with a `--no-pdks` flag to exclude open_pdks
+ Add libraries/sky130_fd_pr/latest to the full PDK build (was missing)
~ Isolated PDK building stuff into `./dependencies/pdk.mk`
~ Final merge no longer uses a tarball, just uses a good 'ol copy

---
Caveat is this will not be enabled by default or used by the CI for now. The reason is the PDK adds another 3 gigabytes to the final image and takes positively forever to build.

To use an internally built PDK, you need to export two variables:

```
export EXTERNAL_PDK_INSTALLATION=0
export NO_PDKS=0
```

Then you'd `make openlane` as normal.

To finally enable this, we'd need to rewrite make_timing to not take forever (probably in Rust/Swift/Go/whatever) and Open_PDKs would need to be updated so it gzips the liberty files. We'd also need to ensure that all tools can load .lib.gz files.
