### PR TITLE
Fixes apply_def_template.py crashing see #869

### DIFF
--- a/scripts/apply_def_template.py
+++ b/scripts/apply_def_template.py
@@ -21,9 +21,11 @@ import argparse
 import subprocess
 
 @click.command()
-@click.option("-t", "--def-template", "templateDEF", required=True, help="Template DEF")
-@click.argument("userDEF")
-def cli(templateDEF, userDEF):
+@click.option("-t", "--def-template", "templatedef", required=True, help="Template DEF")
+@click.argument("userdef")
+def cli(templatedef, userdef):
+    userDEF = userdef
+    templateDEF = templatedef
     scriptsDir = os.path.dirname(__file__)
 
     def remove_power_pins(DEF):


### PR DESCRIPTION
Fixes apply_def_template.py crashing see #869.

Clicks passes arguments to CLI all lower case, however the CLI function expects clicks to be case insensitive. Crash report can be seen in the issue mentioned above.

Still DEF test does not pass, as the Donn's pull request fixing defutil.py call has not been merged yet.