### PR TITLE
Reinstate changes from 673a63e lost in 0a5afc3

### DIFF
--- a/flow.tcl
+++ b/flow.tcl
@@ -166,12 +166,9 @@ proc run_non_interactive_mode {args} {
 		{-from optional}
 		{-to optional}
 		{-save_path optional}
-		{-no_lvs optional}
-		{-no_drc optional}
-		{-no_antennacheck optional}
 		{-override_env optional}
 	}
-	set flags {-save -run_hooks}
+	set flags {-save -run_hooks -no_lvs -no_drc -no_antennacheck }
 	parse_key_args "run_non_interactive_mode" args arg_values $options flags_map $flags -no_consume
 	prep {*}$args
     # signal trap SIGINT save_state;


### PR DESCRIPTION
* In run_non_interactive_mode make -no_lvs -no_drc -no_antennacheck into flags

These don't need an argument and the code was already looking in flags_map.

Signed-off-by: Matt Liberty <mliberty@eng.ucsd.edu>