### PR TITLE
Make Klayout an OpenLane Tool Proper, Update to Klayout 0.27.7

### DIFF
--- a/dependencies/centos-7/compile_time.txt
+++ b/dependencies/centos-7/compile_time.txt
@@ -1,5 +1,3 @@
-https://www.klayout.org/downloads/CentOS_7/klayout-0.27.3-0.x86_64.rpm
-
 devtoolset-8
 devtoolset-8-libatomic-devel
 
@@ -49,7 +47,12 @@ pcre-devel
 python36-devel
 python36-libs
 qt5-qtbase-devel
+qt5-qtmultimedia-devel
+qt5-qtxmlpatterns-devel
+qt5-qtsvg-devel
+qt5-qttools-devel
 readline-devel
+ruby-devel
 strace
 spdlog-devel
 swig3

--- a/dependencies/centos-7/run_time.txt
+++ b/dependencies/centos-7/run_time.txt
@@ -1,5 +1,3 @@
-https://www.klayout.org/downloads/CentOS_7/klayout-0.27.3-0.x86_64.rpm
-
 alsa-lib
 cairo
 gdb
@@ -29,6 +27,13 @@ python36-tkinter
 qt
 qt5-qtbase
 qt5-qtimageformats
+qt5-qtmultimedia
+qt5-qtxmlpatterns
+qt5-qtsvg
+qt5-qttools
+qt5-qttools-libs-designer
+qt5-qttools-libs-designercomponents
+qt5-qttools-libs-help
 qt-settings
 qt-x11
 ruby

--- a/dependencies/tool_metadata.yml
+++ b/dependencies/tool_metadata.yml
@@ -76,6 +76,11 @@
     make PREFIX=$PREFIX config-gcc
     make PREFIX=$PREFIX -j$(nproc)
     make PREFIX=$PREFIX install
+- name: klayout
+  repo: https://github.com/KLayout/klayout
+  commit: 428d0fe8c941faece4eceebc54170cc04d916c03
+  build: ''
+  in_install: false
 - name: openroad_app
   repo: https://github.com/The-OpenROAD-Project/OpenROAD
   commit: 3eafa6da2942ec22d27e2208c99c7a449af34fbf

--- a/dependencies/ubuntu-20.04/run_time.txt
+++ b/dependencies/ubuntu-20.04/run_time.txt
@@ -1,5 +1,3 @@
-https://www.klayout.org/downloads/Ubuntu-20/klayout_0.27.3-1_amd64.deb
-
 xvfb
 autoconf
 autopoint

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -96,11 +96,15 @@ merge: run_base_image ./tar/build ./tar/openlane ../dependencies/tool_metadata.y
 		-f $(DOCKERFILE_PATH) ./tar\
 		| tee logs/$<.build.txt
 
+.PHONY: clean
+clean: clean_export clean_merge
+
 .PHONY: clean_merge
 clean_merge:
 	rm -rf ./tar/openlane
 	rm -rf ./tar/build
 
+.PHONY: clean_export
 clean_export: 
 	rm -rf export/*.tar.gz
 

--- a/docker/klayout/Dockerfile
+++ b/docker/klayout/Dockerfile
@@ -22,20 +22,17 @@ ARG KLAYOUT_COMMIT
 
 RUN mkdir -p /build
 
-RUN yum install -y ruby-devel\
-	qt5-qtmultimedia-devel\
-	qt5-qtxmlpatterns-devel\
-	qt5-qtsvg-devel\
-	qt5-qttools-devel
-
 WORKDIR /klayout
-RUN curl -L ${KLAYOUT_REPO}/tarball/${KLAYOUT_COMMIT} | tar -xzC . --strip-components=1 && \
-    ./build.sh -prefix /build -j$(nproc)
+RUN curl -L ${KLAYOUT_REPO}/tarball/${KLAYOUT_COMMIT} | tar -xzC . --strip-components=1
+
+COPY ./build_klayout.sh ./build_klayout.sh
+
+RUN bash ./build_klayout.sh
 
 RUN mkdir -p /build/version/
 
 RUN date +"Build Timestamp: %Y-%m-%d_%H-%M-%S" > /build/version/klayout.version
-RUN echo "klayout-${KLAYOUT_VERSION}.x86_64" >> /build/version/klayout.version
+RUN echo ${KLAYOUT_COMMIT} >> /build/version/klayout.version
 RUN tar -czf /build.tar.gz /build
 
 # ---

--- a/docker/klayout/build_klayout.sh
+++ b/docker/klayout/build_klayout.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+set -e
+set -x
+
+bininstdir="./tmp/bin" 
+builddir="./tmp/build" 
+
+# destination folders
+bindir="/build/bin"
+libdir="/build/lib/klayout"
+
+distpackdir="/build/lib/python3/dist-packages"
+pylibdir="$distpackdir/klayout"
+
+# clean bin directory
+rm -rf $bininstdir
+
+# do the actual build
+./build.sh -j$(nproc) \
+           -bin $bininstdir \
+           -build $builddir \
+           -rpath $libdir 
+
+echo "Copying files .."
+
+mkdir -p ${libdir}/db_plugins
+mkdir -p ${libdir}/lay_plugins
+mkdir -p ${pylibdir}
+mkdir -p ${bindir}
+
+cp -pd $bininstdir/strm* ${bindir}
+cp -pd $bininstdir/klayout ${bindir}
+cp -pd $bininstdir/lib*so* ${libdir}
+cp -pd $bininstdir/db_plugins/lib*so* ${libdir}/db_plugins
+cp -pd $bininstdir/lay_plugins/lib*so* ${libdir}/lay_plugins
+cp -pd $bininstdir/pymod/klayout/*so ${pylibdir}
+cp -pd $bininstdir/pymod/klayout/*py ${pylibdir}
+for d in db tl rdb lib; do
+  mkdir -p ${pylibdir}/$d
+  cp -pd $bininstdir/pymod/klayout/$d/*py ${pylibdir}/$d
+done
+
+echo "Stripping..."
+strip ${bindir}/*
+strip ${pylibdir}/*.so
+strip ${libdir}/db_plugins/*.so*
+strip ${libdir}/lay_plugins/*.so*

--- a/docker/klayout/build_klayout.sh
+++ b/docker/klayout/build_klayout.sh
@@ -15,13 +15,18 @@ pylibdir="$distpackdir/klayout"
 # clean bin directory
 rm -rf $bininstdir
 
-# do the actual build
-./build.sh -j$(nproc) \
-           -bin $bininstdir \
-           -build $builddir \
-           -rpath $libdir 
+sed -i 's/-O2 -g/-O2/' /usr/lib64/qt5/mkspecs/linux-g++/qmake.conf
 
-echo "Copying files .."
+# do the actual build
+./build.sh\
+    -qt5 \
+    -j$(nproc) \
+    -without-qtbinding \
+    -bin $bininstdir \
+    -build $builddir \
+    -rpath $libdir
+
+echo "Copying files..."
 
 mkdir -p ${libdir}/db_plugins
 mkdir -p ${libdir}/lay_plugins
@@ -36,8 +41,8 @@ cp -pd $bininstdir/lay_plugins/lib*so* ${libdir}/lay_plugins
 cp -pd $bininstdir/pymod/klayout/*so ${pylibdir}
 cp -pd $bininstdir/pymod/klayout/*py ${pylibdir}
 for d in db tl rdb lib; do
-  mkdir -p ${pylibdir}/$d
-  cp -pd $bininstdir/pymod/klayout/$d/*py ${pylibdir}/$d
+    mkdir -p ${pylibdir}/$d
+    cp -pd $bininstdir/pymod/klayout/$d/*py ${pylibdir}/$d
 done
 
 echo "Stripping..."

--- a/docs/source/local_installs.md
+++ b/docs/source/local_installs.md
@@ -14,7 +14,10 @@ You can invoke `python3 ./env.py local-install`. This tool copies the skeleton a
 
 The tools will all be installed with `./install` as a prefix. You'll find all the repos in `./install/build/repos` and a list of versions in `./install/build/versions`.
 
-**DO NOTE:** We expect you to bring your own OpenROAD. This installer will make no attempt to install OpenROAD. It's too complex to build in an automated fashion.
+**DO NOTE:** We expect you to get some tools on your own, because said tools are too complex to build in an automated fashion. Namely:
+* OpenROAD
+* Klayout
+* Git 2.34+
 
 After the installer is done, you can simply invoke `./flow.tcl` outside of Docker and it should work okay.
 


### PR DESCRIPTION
+ Klayout is now a proper OpenLane tool

---

This PR gets rid of the last x86-64 exclusive package in OpenLane.
