### PR TITLE
`make pdk` no longer causes an error if the PDK is already installed

### DIFF
--- a/dependencies/pdk.mk
+++ b/dependencies/pdk.mk
@@ -36,7 +36,7 @@ pdk: skywater-pdk skywater-library open_pdks build-pdk gen-sources
 $(PDK_ROOT):
 	mkdir -p $(PDK_ROOT)
 
-$(PDK_ROOT)/skywater-pdk/LICENSE: $(PDK_ROOT)
+$(PDK_ROOT)/skywater-pdk/LICENSE: | $(PDK_ROOT)
 	git clone $(shell $(PYTHON_BIN) ./dependencies/tool.py sky130 -f repo) $(PDK_ROOT)/skywater-pdk
 
 .PHONY: skywater-pdk


### PR DESCRIPTION
This changes the recipe [here](https://github.com/The-OpenROAD-Project/OpenLane/blob/master/dependencies/pdk.mk#L39) to have an order-only, as opposed to normal, GNU make dependency.

---

Resolves #921.