### PR TITLE
Add Git 2.35 to Requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ At a minimum:
 - Python 3.6+ with PIP
 - Click, Pyyaml: `python3 -m pip install pyyaml click>=7`
 
+For building Sky130 PDK you also need:
+- Git 2.35+
+
 ## Containerless Install
 Please see [here](./docs/source/local_installs.md).
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ At a minimum:
 - Click, Pyyaml: `python3 -m pip install pyyaml click>=7`
 
 For building Sky130 PDK you also need:
-- Git 2.35+
+- Git 2.35+: `git --version`
 
 ## Containerless Install
 Please see [here](./docs/source/local_installs.md).


### PR DESCRIPTION
Adds git 2.35+ as requirement for building PDK. As older versions dont work with current python scripts. Solves #963 