### PR TITLE
Add Commit-Based Docker Tags

### DIFF
--- a/.github/workflows/openlane_ci.yml
+++ b/.github/workflows/openlane_ci.yml
@@ -98,7 +98,7 @@ jobs:
             echo "::set-output name=matrix::$(python3 ./.github/test_sets/get_test_matrix.py fastest_test_set)"
           fi
           echo "::set-output name=issue_regression_matrix::$(python3 ./run_issue_regressions.py get_matrix)"
-  
+
   issue_regression_test:
     needs: docker_build
     runs-on: ubuntu-20.04
@@ -285,10 +285,12 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
-      - name: Docker Push (Branch Name)
+      - name: Docker Push (Branch)
         if: ${{ env.PUSHING == '1' && github.event_name == 'push' }}
         run: |
+          docker image tag ${{ env.OPENLANE_IMAGE_NAME }} ${{ secrets.DOCKER_IMAGE }}:${{ env.GITHUB_SHA }}
           docker image tag ${{ env.OPENLANE_IMAGE_NAME }} ${{ secrets.DOCKER_IMAGE }}:${{ env.BRANCH_NAME }}
+          docker push ${{ secrets.DOCKER_IMAGE }}:${{ env.GITHUB_SHA }}
           docker push ${{ secrets.DOCKER_IMAGE }}:${{ env.BRANCH_NAME }}
 
       - name: Docker Push (Tag) (If scheduled or dispatched)

--- a/.github/workflows/openlane_ci.yml
+++ b/.github/workflows/openlane_ci.yml
@@ -267,6 +267,10 @@ jobs:
         run: |
           echo "MAIN_BRANCH=${{ secrets.MAIN_BRANCH }}" >> $GITHUB_ENV
 
+      - name: Write Hash
+        run: |
+          echo "GIT_COMMIT_HASH=$(git rev-parse HEAD)" >> $GITHUB_ENV
+
       - name: Create Tag (If scheduled or dispatched)
         if: ${{ env.PUSHING == '1' && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && env.BRANCH_NAME == env.MAIN_BRANCH }}
         run: cd ${GITHUB_WORKSPACE}/ && python3 ${GITHUB_WORKSPACE}/.github/scripts/generate_tag.py
@@ -285,12 +289,16 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
+      - name: Docker Push (Hash)
+        if: ${{ env.PUSHING == '1' && github.event_name == 'push' && env.BRANCH_NAME == env.MAIN_BRANCH }}
+        run: |
+          docker image tag ${{ env.OPENLANE_IMAGE_NAME }} ${{ secrets.DOCKER_IMAGE }}:${{ env.GIT_COMMIT_HASH }}
+          docker push ${{ secrets.DOCKER_IMAGE }}:${{ env.GIT_COMMIT_HASH }}
+
       - name: Docker Push (Branch)
         if: ${{ env.PUSHING == '1' && github.event_name == 'push' }}
         run: |
-          docker image tag ${{ env.OPENLANE_IMAGE_NAME }} ${{ secrets.DOCKER_IMAGE }}:${{ env.GITHUB_SHA }}
           docker image tag ${{ env.OPENLANE_IMAGE_NAME }} ${{ secrets.DOCKER_IMAGE }}:${{ env.BRANCH_NAME }}
-          docker push ${{ secrets.DOCKER_IMAGE }}:${{ env.GITHUB_SHA }}
           docker push ${{ secrets.DOCKER_IMAGE }}:${{ env.BRANCH_NAME }}
 
       - name: Docker Push (Tag) (If scheduled or dispatched)

--- a/Makefile
+++ b/Makefile
@@ -43,9 +43,9 @@ DOCKER_OPTIONS += -e ROUTING_CORES=$(ROUTING_CORES)
 endif
 
 ifeq ($(OPENLANE_IMAGE_NAME),)
-OPENLANE_TAG ?= $(shell $(PYTHON_BIN) ./dependencies/get_tag.py)
-ifneq ($(OPENLANE_TAG),)
-export OPENLANE_IMAGE_NAME ?= efabless/openlane:$(OPENLANE_TAG)
+OPENLANE_DOCKER_TAG ?= $(shell $(PYTHON_BIN) ./dependencies/get_tag.py)
+ifneq ($(OPENLANE_DOCKER_TAG),)
+export OPENLANE_IMAGE_NAME ?= efabless/openlane:$(OPENLANE_DOCKER_TAG)
 endif
 endif
 

--- a/dependencies/get_tag.py
+++ b/dependencies/get_tag.py
@@ -53,13 +53,13 @@ def get_tag() -> str:
             return f"{branch_name}-dev"
 
         process_data: subprocess.CompletedProcess = subprocess.run(
-            ["git", "describe", "--tags", "--abbrev=0"],
+            ["git", "rev-parse", "HEAD"],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
         )
         if process_data.returncode != 0:
             raise NoGitException(
-                f"Failed to extract tags. You are either using a shallow clone or not using a Git repository at all. Please specify OPENLANE_IMAGE_NAME manually.\nFull output: {process_data.stderr.decode('utf8').strip()}"
+                f"Failed to get commit.  Please specify OPENLANE_IMAGE_NAME manually.\nFull output: {process_data.stderr.decode('utf8').strip()}"
             )
         return process_data.stdout.decode("utf8").strip()
     except NoGitException as e:


### PR DESCRIPTION
The git hash is also extracted and used as a docker image tag. This will A: allow openlane images to be referenced by commit: B: reduce the 24-hour tool-change time desync to like, 30 minutes.

Git tags will continue to be generated as milestones.

This is mostly a CI change with a minimal effect on the core OpenLane functionality.