### PR TITLE
scripts/checkers: fix report_file_relative scope

### DIFF
--- a/scripts/tcl_commands/checkers.tcl
+++ b/scripts/tcl_commands/checkers.tcl
@@ -121,8 +121,8 @@ proc check_slew_violations {args} {
 
     set checker [catch {exec grep "VIOLATED" $report_file }]
     if { ! $checker } {
+        set report_file_relative [relpath . $report_file]
         if { $quit_on_vios } {
-            set report_file_relative [relpath . $report_file]
             puts_err "There are max slew violations in the design at the $corner corner. Please refer to '$report_file_relative'."
             flow_fail
         } else {


### PR DESCRIPTION
Without this openlane will crash with the following error when setting `QUIT_ON_LVS_ERROR` to `0`:
```
can't read "report_file_relative": no such variable
    while executing
"puts_warn "There are max slew violations in the design at the $corner corner. Please refer to '$report_file_relative'.""
    (procedure "check_slew_violations" line 20)
    invoked from within
"check_slew_violations -report_file $slew_report -corner "typical""
    (procedure "check_timing_violations" line 14)
    invoked from within
"check_timing_violations"
    (procedure "run_non_interactive_mode" line 86)
    invoked from within
"run_non_interactive_mode {*}$argv"
    invoked from within
"if { [info exists flags_map(-interactive)] || [info exists flags_map(-it)] } {
	puts_info "Running interactively"
	puts_info "Note, that post_run_hook..."
    (file "/content/OpenLane/flow.tcl" line 412)
```