### PR TITLE
scripts/tcl_commands/scrot_klayout: add missing -log arguments

### DIFF
--- a/scripts/tcl_commands/cts.tcl
+++ b/scripts/tcl_commands/cts.tcl
@@ -86,7 +86,7 @@ proc run_cts {args} {
 		if { $::env(LEC_ENABLE) } {
 			logic_equiv_check -rhs $::env(PREV_NETLIST) -lhs $::env(CURRENT_NETLIST)
 		}
-		scrot_klayout -layout $::env(CURRENT_DEF) $::env(cts_logs)/screenshot.log
+		scrot_klayout -layout $::env(CURRENT_DEF) -log $::env(cts_logs)/screenshot.log
 	} elseif { $::env(RUN_SIMPLE_CTS) } {
 		increment_index
 		exec echo "Simple CTS was run earlier." >> [index_file $::env(cts_logs)/cts.log]

--- a/scripts/tcl_commands/floorplan.tcl
+++ b/scripts/tcl_commands/floorplan.tcl
@@ -432,7 +432,7 @@ proc run_power_grid_generation {args} {
 
 		tap_decap_or
 
-		scrot_klayout -layout $::env(CURRENT_DEF) $::env(floorplan_logs)/screenshot.log
+		scrot_klayout -layout $::env(CURRENT_DEF) -log $::env(floorplan_logs)/screenshot.log
 
 		run_power_grid_generation
 	}

--- a/scripts/tcl_commands/klayout.tcl
+++ b/scripts/tcl_commands/klayout.tcl
@@ -159,7 +159,7 @@ proc run_klayout_gds_xor {args} {
 					try_catch $::env(OPENROAD_BIN) -python $::env(SCRIPTS_DIR)/parse_klayout_xor_log.py \
 						-l [index_file $::env(finishing_logs)/xor.log] \
 						-o [index_file $::env(finishing_reports)/xor.rpt]
-					scrot_klayout -layout $arg_values(-output_gds)
+					scrot_klayout -layout $arg_values(-output_gds) -log $::env(finishing_logs)/screenshot.klayout.xor.log
 				}
 
 				if { $::env(KLAYOUT_XOR_XML) } {


### PR DESCRIPTION
This currently fails when `TAKE_LAYOUT_SCROT` is set to `1` with the following error:
```
[ERROR]: scrot_klayout missing required -log

    while executing
"parse_key_args "scrot_klayout" args arg_values $options"
    (procedure "scrot_klayout" line 11)
    invoked from within
"scrot_klayout -layout $::env(CURRENT_DEF) $::env(floorplan_logs)/screenshot.log"
    (procedure "run_floorplan" line 53)
    invoked from within
"[lindex $step_exe 0] [lindex $step_exe 1] "
    (procedure "run_non_interactive_mode" line 55)
    invoked from within
"run_non_interactive_mode {*}$argv"
    invoked from within
"if { [info exists flags_map(-interactive)] || [info exists flags_map(-it)] } {
	puts_info "Running interactively"
	puts_info "Note, that post_run_hook..."
    (file "/content/OpenLane/flow.tcl" line 412)
```