### PR TITLE
Increase delay buffer estimate for the ECO flow

### DIFF
--- a/scripts/gen_insert_buffer.py
+++ b/scripts/gen_insert_buffer.py
@@ -126,7 +126,7 @@ if os.path.exists(input_file):
         eco_iter = os.environ["ECO_ITER"]
         for pin_unq in vio_dict.keys():
             insert_times = math.floor(
-                abs(min(vio_dict[pin_unq])) / 0.06
+                abs(min(vio_dict[pin_unq])) / 0.5
             )  # insert buffer conservatively
             if insert_times == 0:
                 vio_count += 1


### PR DESCRIPTION
When working out how many delay buffers to insert, the ECO flow uses a
very small hard coded value (0.06ns). At the tt corner, a better estimate
is around 0.5ns. This means we heavily over fix hold violations, and
quite possibly cause setup violations.

Setting a more realistic estimate for the buffer delay should have no
downsides. Since the ECO flow is iterative, any hold path that is not
completely fixed will be fixed in subsequent iterations.

This value (and the name of the buffer to use) should really end up
in the open_pdks config.tcl.