### PR TITLE
flow: use env to resolve tclsh

### DIFF
--- a/flow.tcl
+++ b/flow.tcl
@@ -1,4 +1,4 @@
-#!/usr/bin/tclsh
+#!/usr/bin/env tclsh
 # Copyright 2020-2021 Efabless Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
This allows resolving tclsh on environment where it's not installed in `/usr/bin` but still is in the path.