### PR TITLE
tcl_commands: source install-wide config

### DIFF
--- a/scripts/tcl_commands/all.tcl
+++ b/scripts/tcl_commands/all.tcl
@@ -400,6 +400,11 @@ proc prep {args} {
 
     source $scl_config
 
+    # source install-wide config
+    if { [file exists $::env(OPENLANE_ROOT)/install/env.tcl ] } {
+        source $::env(OPENLANE_ROOT)/install/env.tcl
+    }
+
     # needs to be resourced to make sure it overrides the above
     source_config $::env(DESIGN_CONFIG)
 


### PR DESCRIPTION
Not sure if that's the best way to achieve this, but I find myself willing to override some of the config parameters system-wide to correspond to a specific OpenLane deployment, e.g:
```
RUN_KLAYOUT=0
RUN_CVC=0
```

It seems that the settings in `install/env.tcl/ are not currently into account by the flow since https://github.com/The-OpenROAD-Project/OpenLane/blob/386d6042ae514b2bb4a5032ee121f9ac6e4aecca/scripts/tcl_commands/all.tcl#L316 will override them with their respective default value.

Let me know what you think!