### PR TITLE
sta: report_units on a run

### DIFF
--- a/scripts/openroad/sta.tcl
+++ b/scripts/openroad/sta.tcl
@@ -50,6 +50,8 @@ if { $::env(RUN_STANDALONE) == 1 } {
 
 set_cmd_units -time ns -capacitance pF -current mA -voltage V -resistance kOhm -distance um
 
+report_units
+
 if { [info exists ::env(SPEF_TYPICAL)] } {
     read_spef $::env(SPEF_TYPICAL)
 } 

--- a/scripts/openroad/sta_multi_corner.tcl
+++ b/scripts/openroad/sta_multi_corner.tcl
@@ -27,6 +27,8 @@ if { $::env(CURRENT_DEF) != 0 } {
 
 set_cmd_units -time ns -capacitance pF -current mA -voltage V -resistance kOhm -distance um
 
+report_units
+
 define_corners ss tt ff
 
 foreach lib $::env(LIB_SLOWEST) {


### PR DESCRIPTION
In working with other tools, units are reported on every run in the logs
so that the user can look back in the logs to understand units.

This allows OpenROAD to have a similar feature.