### PR TITLE
Run hold repair after setup repair

### DIFF
--- a/scripts/openroad/resizer_routing_timing.tcl
+++ b/scripts/openroad/resizer_routing_timing.tcl
@@ -74,6 +74,13 @@ source $::env(SCRIPTS_DIR)/openroad/set_rc.tcl
 estimate_parasitics -global_routing
 
 # Resize
+if { [catch {repair_timing -setup \
+        -slack_margin $::env(GLB_RESIZER_SETUP_SLACK_MARGIN) \
+        -max_buffer_percent $::env(GLB_RESIZER_SETUP_MAX_BUFFER_PERCENT)}
+]} {
+    puts "Setup utilization limit is reached. Continuing the flow... "
+}
+
 if { $::env(GLB_RESIZER_ALLOW_SETUP_VIOS) == 1} {
     if { [catch {repair_timing -hold -allow_setup_violations \
             -slack_margin $::env(GLB_RESIZER_HOLD_SLACK_MARGIN) \
@@ -88,13 +95,6 @@ if { $::env(GLB_RESIZER_ALLOW_SETUP_VIOS) == 1} {
     ]} {
         puts "Hold utilization limit is reached. Continuing the flow... "
     }
-}
-
-if { [catch {repair_timing -setup \
-        -slack_margin $::env(GLB_RESIZER_SETUP_SLACK_MARGIN) \
-        -max_buffer_percent $::env(GLB_RESIZER_SETUP_MAX_BUFFER_PERCENT)}
-]} {
-    puts "Setup utilization limit is reached. Continuing the flow... "
 }
 
 # set_placement_padding -global -right $::env(CELL_PAD)

--- a/scripts/openroad/resizer_timing.tcl
+++ b/scripts/openroad/resizer_timing.tcl
@@ -47,6 +47,13 @@ source $::env(SCRIPTS_DIR)/openroad/set_rc.tcl
 estimate_parasitics -placement
 
 # Resize
+if { [catch {repair_timing -setup \
+        -slack_margin $::env(PL_RESIZER_SETUP_SLACK_MARGIN) \
+        -max_buffer_percent $::env(PL_RESIZER_SETUP_MAX_BUFFER_PERCENT)}
+]} {
+    puts "Setup utilization limit is reached. Continuing the flow... "
+}
+
 if { $::env(PL_RESIZER_ALLOW_SETUP_VIOS) == 1} {
     if { [catch {repair_timing -hold -allow_setup_violations \
             -slack_margin $::env(PL_RESIZER_HOLD_SLACK_MARGIN) \
@@ -61,13 +68,6 @@ if { $::env(PL_RESIZER_ALLOW_SETUP_VIOS) == 1} {
     ]} {
         puts "Hold utilization limit is reached. Continuing the flow... "
     }
-}
-
-if { [catch {repair_timing -setup \
-        -slack_margin $::env(PL_RESIZER_SETUP_SLACK_MARGIN) \
-        -max_buffer_percent $::env(PL_RESIZER_SETUP_MAX_BUFFER_PERCENT)}
-]} {
-    puts "Setup utilization limit is reached. Continuing the flow... "
 }
 
 set_placement_padding -global -right $::env(CELL_PAD)


### PR DESCRIPTION
ORFS runs hold repair after setup repair, which makes sense considering they
are more critical.