### PR TITLE
Switch to the new PDN from OpenROAD.

### DIFF
--- a/scripts/openroad/pdn.tcl
+++ b/scripts/openroad/pdn.tcl
@@ -32,7 +32,14 @@ if {[catch {read_def $::env(CURRENT_DEF)} errmsg]} {
     exit 1
 }
 
-if {[catch {pdngen $::env(PDN_CFG) -verbose} errmsg]} {
+# load the grid definitions
+if {[catch {source $::env(PDN_CFG)} errmsg]} {
+    puts stderr $errmsg
+    exit 1
+}
+
+# run PDNGEN
+if {[catch {pdngen} errmsg]} {
     puts stderr $errmsg
     exit 1
 }


### PR DESCRIPTION
This PR fixes issue #1037 related to ```openroad``` new PDN behaviour.

~~(1) By two decimal rounding it fixes the error:~~
```
[ERROR PDN-0175] Pitch 28.8270 is too small for, must be atleast 28.8300
```

(2) Final conversion to new PDN part fixes the error:
```
Consider using "convert_pdn_config /home/cbalint/{...}/pdn_cfg.tcl" to convert the legacy configuration.
[INFO PDN-9008] Design name is spm.
[INFO PDN-9009] Reading technology data.
[ERROR PDN-9017] No stdcell grid specification found - no rails can be inserted.
```
---

This now pass latest openlane [builds & regression](https://copr.fedorainfracloud.org/coprs/rezso/VLSI/build/4144274/) .
~~Q: do we need discriminate within ```pdn.tcl``` the **old** vs **new** PDN or just lets go with it forward (drop old) ?~~


Cc @arlpetergadfort , @maliberty

Thanks,
~cristian.


