### PR TITLE
Load tech liberty file before any extra ones

### DIFF
--- a/scripts/openroad/basic_mp.tcl
+++ b/scripts/openroad/basic_mp.tcl
@@ -11,13 +11,19 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+foreach lib $::env(LIB_SYNTH) {
+    read_liberty $lib
+}
+
+if { [info exists ::env(EXTRA_LIBS) ] } {
+	foreach lib $::env(EXTRA_LIBS) {
+		read_liberty $lib
+	}
+}
+
 if {[catch {read_lef $::env(MERGED_LEF_UNPADDED)} errmsg]} {
     puts stderr $errmsg
     exit 1
-}
-
-foreach lib $::env(LIB_SYNTH) {
-    read_liberty $lib
 }
 
 if {[catch {read_def $::env(CURRENT_DEF)} errmsg]} {

--- a/scripts/openroad/cts.tcl
+++ b/scripts/openroad/cts.tcl
@@ -12,9 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if {[catch {read_lef $::env(MERGED_LEF_UNPADDED)} errmsg]} {
-    puts stderr $errmsg
-    exit 1
+foreach lib $::env(LIB_CTS) {
+    read_liberty $lib
 }
 
 if { [info exists ::env(EXTRA_LIBS) ] } {
@@ -23,8 +22,9 @@ if { [info exists ::env(EXTRA_LIBS) ] } {
 	}
 }
 
-foreach lib $::env(LIB_CTS) {
-    read_liberty $lib
+if {[catch {read_lef $::env(MERGED_LEF_UNPADDED)} errmsg]} {
+    puts stderr $errmsg
+    exit 1
 }
 
 if {[catch {read_def $::env(CURRENT_DEF)} errmsg]} {

--- a/scripts/openroad/eco.tcl
+++ b/scripts/openroad/eco.tcl
@@ -59,13 +59,19 @@ proc run_eco {args} {
 
 }
 
+foreach lib $::env(LIB_CTS) {
+    read_liberty $lib
+}
+
+if { [info exists ::env(EXTRA_LIBS) ] } {
+    foreach lib $::env(EXTRA_LIBS) {
+        read_liberty $lib
+    }
+}
+
 if {[catch {read_lef $::env(MERGED_LEF_UNPADDED)} errmsg]} {
     puts stderr $errmsg
     exit 1
-}
-
-foreach lib $::env(LIB_CTS) {
-    read_liberty $lib
 }
 
 set cur_iter [expr $::env(ECO_ITER) == 0 ? \

--- a/scripts/openroad/floorplan.tcl
+++ b/scripts/openroad/floorplan.tcl
@@ -16,6 +16,12 @@ foreach lib $::env(LIB_SYNTH_COMPLETE) {
 	read_liberty $lib
 }
 
+if { [info exists ::env(EXTRA_LIBS) ] } {
+	foreach lib $::env(EXTRA_LIBS) {
+		read_liberty $lib
+	}
+}
+
 if {[catch {read_lef $::env(MERGED_LEF_UNPADDED)} errmsg]} {
     puts stderr $errmsg
     exit 1

--- a/scripts/openroad/groute.tcl
+++ b/scripts/openroad/groute.tcl
@@ -12,14 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+foreach lib $::env(LIB_SYNTH_COMPLETE) {
+	read_liberty $lib
+}
+
 if { [info exists ::env(EXTRA_LIBS) ] } {
 	foreach lib $::env(EXTRA_LIBS) {
 		read_liberty $lib
 	}
-}
-
-foreach lib $::env(LIB_SYNTH_COMPLETE) {
-	read_liberty $lib
 }
 
 if {[catch {read_lef $::env(MERGED_LEF_UNPADDED)} errmsg]} {

--- a/scripts/openroad/pdn.tcl
+++ b/scripts/openroad/pdn.tcl
@@ -11,15 +11,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
+foreach lib $::env(LIB_SYNTH_COMPLETE) {
+	read_liberty $lib
+}
 
 if { [info exists ::env(EXTRA_LIBS) ] } {
 	foreach lib $::env(EXTRA_LIBS) {
 		read_liberty $lib
 	}
-}
-
-foreach lib $::env(LIB_SYNTH_COMPLETE) {
-	read_liberty $lib
 }
 
 if {[catch {read_lef $::env(MERGED_LEF_UNPADDED)} errmsg]} {

--- a/scripts/openroad/rcx.tcl
+++ b/scripts/openroad/rcx.tcl
@@ -12,14 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+foreach lib $::env(RCX_LIB) {
+    read_liberty $lib
+}
+
 if { [info exists ::env(EXTRA_LIBS) ] } {
     foreach lib $::env(EXTRA_LIBS) {
         read_liberty $lib
     }
-}
-
-foreach lib $::env(RCX_LIB) {
-    read_liberty $lib
 }
 
 if {[catch {read_lef $::env(RCX_LEF)} errmsg]} {

--- a/scripts/openroad/replace.tcl
+++ b/scripts/openroad/replace.tcl
@@ -12,6 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+foreach lib $::env(LIB_SYNTH_COMPLETE) {
+    read_liberty $lib
+}
+
+if { [info exists ::env(EXTRA_LIBS) ] } {
+	foreach lib $::env(EXTRA_LIBS) {
+		read_liberty $lib
+	}
+}
+
 if {[catch {read_lef $::env(MERGED_LEF_UNPADDED)} errmsg]} {
     puts stderr $errmsg
     exit 1
@@ -20,12 +30,6 @@ if {[catch {read_lef $::env(MERGED_LEF_UNPADDED)} errmsg]} {
 if {[catch {read_def $::env(CURRENT_DEF)} errmsg]} {
     puts stderr $errmsg
     exit 1
-}
-
-if { [info exists ::env(EXTRA_LIBS) ] } {
-	foreach lib $::env(EXTRA_LIBS) {
-		read_liberty $lib
-	}
 }
 
 set ::block [[[::ord::get_db] getChip] getBlock]
@@ -47,10 +51,6 @@ if { ! $free_insts_flag } {
 	puts "\[WARN] Skipping..."
 	file copy -force $::env(CURRENT_DEF) $::env(SAVE_DEF)
 	exit 0
-}
-
-foreach lib $::env(LIB_SYNTH_COMPLETE) {
-    read_liberty $lib
 }
 
 set arg_list [list]
@@ -93,9 +93,6 @@ write_def $::env(SAVE_DEF)
 
 if {[info exists ::env(CLOCK_PORT)]} {
 	if { $::env(PL_ESTIMATE_PARASITICS) == 1 } {
-		foreach lib $::env(LIB_SYNTH_COMPLETE) {
-			read_liberty $lib
-		}
 		read_sdc -echo $::env(CURRENT_SDC)
 		unset_propagated_clock [all_clocks]
 		# set rc values

--- a/scripts/openroad/sta.tcl
+++ b/scripts/openroad/sta.tcl
@@ -13,6 +13,16 @@
 # limitations under the License.
 
 if { $::env(RUN_STANDALONE) == 1 } {
+    foreach lib $::env(LIB_SYNTH_COMPLETE) {
+        read_liberty $lib
+    }
+
+    if { [info exists ::env(EXTRA_LIBS) ] } {
+        foreach lib $::env(EXTRA_LIBS) {
+            read_liberty $lib
+        }
+    }
+
     if {[catch {read_lef $::env(STA_LEF)} errmsg]} {
         puts stderr $errmsg
         exit 1
@@ -31,15 +41,6 @@ if { $::env(RUN_STANDALONE) == 1 } {
         link_design $::env(DESIGN_NAME)
     }
 
-    if { [info exists ::env(EXTRA_LIBS) ] } {
-        foreach lib $::env(EXTRA_LIBS) {
-            read_liberty $lib
-        }
-    }
-
-    foreach lib $::env(LIB_SYNTH_COMPLETE) {
-        read_liberty $lib
-    }
     read_sdc -echo $::env(CURRENT_SDC)
     if { $::env(STA_PRE_CTS) == 1 } {
         unset_propagated_clock [all_clocks]

--- a/scripts/openroad/sta_multi_corner.tcl
+++ b/scripts/openroad/sta_multi_corner.tcl
@@ -13,20 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if {[catch {read_lef $::env(STA_LEF)} errmsg]} {
-    puts stderr $errmsg
-    exit 1
-}
-
-if { $::env(CURRENT_DEF) != 0 } {
-    if {[catch {read_def $::env(CURRENT_DEF)} errmsg]} {
-        puts stderr $errmsg
-        exit 1
-    }
-}
-
-set_cmd_units -time ns -capacitance pF -current mA -voltage V -resistance kOhm -distance um
-
 define_corners ss tt ff
 
 foreach lib $::env(LIB_SLOWEST) {
@@ -46,6 +32,20 @@ foreach corner {ss tt ff} {
         }
     }
 }
+
+if {[catch {read_lef $::env(STA_LEF)} errmsg]} {
+    puts stderr $errmsg
+    exit 1
+}
+
+if { $::env(CURRENT_DEF) != 0 } {
+    if {[catch {read_def $::env(CURRENT_DEF)} errmsg]} {
+        puts stderr $errmsg
+        exit 1
+    }
+}
+
+set_cmd_units -time ns -capacitance pF -current mA -voltage V -resistance kOhm -distance um
 
 read_verilog $::env(CURRENT_NETLIST)
 link_design $::env(DESIGN_NAME)


### PR DESCRIPTION
The resizer use various parameters from the first liberty file read,
so make sure we always load the tech liberty file first.