### PR TITLE
Replaced `MISMATCHES_OK` with more granular variables

### DIFF
--- a/configuration/README.md
+++ b/configuration/README.md
@@ -281,7 +281,9 @@ These variables worked initially, but they were too sky130 specific and will be 
 | `DRC_EXCLUDE_CELL_LIST` | Specifies the file that contains the don't-use-cell-list to be excluded from the liberty file during synthesis and timing optimizations. If it's not defined, this path is searched `$::env(PDK_ROOT)/$::env(PDK)/libs.tech/openlane/$::env(STD_CELL_LIBRARY)/drc_exclude.cells` and if it's not found, then the original liberty will be used as is. In other words, `DRC_EXCLUDE_CELL_LIST` contain the only excluded cell list in timing optimizations. |
 | `EXTRA_LEFS` | Specifies LEF files of pre-hardened macros to be merged in the design currently getting hardened |
 | `EXTRA_GDS_FILES` | Specifies GDS files of pre-hardened macros to be merged in the design currently getting hardened |
-| `SAVE_FINAL_VIEWS` | Specifies whether OpenLane should save all final views to a specific folder or not. Default: `0` |
+| `SAVE_FINAL_VIEWS` | Specifies whether OpenLane should save all final views to a specific folder or not. (Default: `0`) |
+| `TEST_MISMATCHES` | Test for mismatches between the OpenLane tool versions and the current environment. `all` tests all mismatches. `tools` tests all except the PDK. `pdk` only tests the PDK. `none` disables the check.<br> (Default: `all`) |
+| `QUIT_ON_MISMATCHES` | Whether to halt the flow execution or not if mismatches are found. (Default: `1`) |
 
 ### Flow control
 

--- a/configuration/general.tcl
+++ b/configuration/general.tcl
@@ -22,6 +22,13 @@ if { ![info exists ::env(STD_CELL_LIBRARY)] } {
 
 set ::env(USE_GPIO_PADS) 0
 
+if { ![info exists ::env(QUIT_ON_MISMATCHES)] } {
+    set ::env(QUIT_ON_MISMATCHES) {1}
+}
+if { ![info exists ::env(TEST_MISMATCHES)] } {
+    set ::env(TEST_MISMATCHES) {all}
+}
+
 # Flow control defaults
 set ::env(RUN_LVS) 1
 
@@ -67,6 +74,8 @@ set ::env(RUN_SPEF_EXTRACTION) 1
 set ::env(RUN_CVC) 1
 
 set ::env(GENERATE_FINAL_SUMMARY_REPORT) 1
+
+
 # 0: no diodes
 # 1: spray inputs with diodes
 # 2: spray inputs with fake diodes first then fix up the violators with real ones
@@ -78,6 +87,7 @@ set ::env(DIODE_INSERTION_STRATEGY) 3
 set ::env(STA_REPORT_POWER) {1}
 set ::env(SAVE_FINAL_VIEWS) {1}
 
+## ECO Flow
 set ::env(ECO_ENABLE) {0}
 set ::env(ECO_STARTED) {0}
 set ::env(ECO_ITER) {0}

--- a/dependencies/verify_versions.py
+++ b/dependencies/verify_versions.py
@@ -168,7 +168,9 @@ def verify_versions(
                     open(join(installed_versions_path, tool)).read().split(":")
                 )
                 repo = f"{protocol}:{url}"
-                environment_manifest.append({"name": tool, "repo": repo, "commit": commit})
+                environment_manifest.append(
+                    {"name": tool, "repo": repo, "commit": commit}
+                )
         else:
             # 3b. Compare Container And Installation Manifests
             try:
@@ -179,9 +181,12 @@ def verify_versions(
                     "Container manifest not found. What this likely means is that the container is severely out of date."
                 )
 
-        tool_set_flow = set([element["name"] for element in manifest]) - pdk_manifest_names
+        tool_set_flow = (
+            set([element["name"] for element in manifest]) - pdk_manifest_names
+        )
         tool_set_container = (
-            set([element["name"] for element in environment_manifest]) - pdk_manifest_names
+            set([element["name"] for element in environment_manifest])
+            - pdk_manifest_names
         )
 
         unmatched_tools_flow = tool_set_flow - tool_set_container

--- a/dependencies/verify_versions.py
+++ b/dependencies/verify_versions.py
@@ -39,6 +39,7 @@ openlane_dir = abspath(dirname(dirname(__file__)))
 
 
 def verify_versions(
+    no_pdks: bool = False,
     no_tools: bool = False,
     report_file: io.TextIOBase = sys.stderr,
     pdk: Optional[str] = os.getenv("PDK"),
@@ -65,174 +66,186 @@ def verify_versions(
     }
     pdk_manifest_names = set(manifest_names_by_SOURCES_name.values())
 
-    try:
-        # 2. Check if the PDK is compatible with Flow Scripts
-        pdk_root = os.getenv("PDK_ROOT")
-        if not os.getenv("PDK_ROOT"):
-            pdk_root = join(openlane_dir, "pdks")
-
-        if pdk is not None:
-            pdk_dir = join(pdk_root, pdk)
-
-            if not pathlib.Path(pdk_dir).is_dir():
-                raise Exception(f"{pdk_dir} not found.")
-
-            tool_versions = []
-
-            sources_file = join(pdk_dir, "SOURCES")
-            config_file = join(pdk_dir, ".config", "nodeinfo.json")
-
-            if os.path.isfile(sources_file):
-                sources_str = None
-                try:
-                    sources_str = open(sources_file).read()
-                except FileNotFoundError:
-                    raise Exception(
-                        f"Could not find SOURCES file for the installed {pdk} PDK."
-                    )
-
-                sources_str = sources_str.strip()
-
-                # Format: {tool} {commit}
-                #
-                #   This regex also handles an issue where older versions used the
-                #   non-standard echo -ne command, where the format is -ne {tool}\n{commit}\n.
-                #
-                name_rx = re.compile(
-                    r"(?:\-ne\s+)?([\w\-]+)\s+([A-Fa-f0-9]+)", re.MULTILINE
-                )
-
-                for tool_match in name_rx.finditer(sources_str):
-                    name = tool_match[1]
-                    commit = tool_match[2]
-
-                    manifest_name = manifest_names_by_SOURCES_name.get(name)
-                    if manifest_name is None:
-                        continue
-
-                    tool_versions.append((manifest_name, commit))
-            elif os.path.isfile(config_file):
-                config_str = open(config_file).read()
-                try:
-                    config = json.loads(config_str)
-                    commit_set = config["commit"]
-                    if type(commit_set) == str:
-                        tool_versions.append(("open_pdks", commit_set))
-                    else:
-                        for key, value in commit_set.items():
-                            # Handle bug in some older versions of opdks where the magic commit field is empty.
-                            if value.strip() == "":
-                                continue
-                            tool_versions.append((key, value))
-                except json.decoder.JSONDecodeError:
-                    raise Exception("Malformed .config/nodeinfo.json.")
-
-            else:
-                raise Exception(
-                    "Neither SOURCES nor .config/nodeinfo.json exist in the PDK."
-                )
-
-            for name, commit in tool_versions:
-                manifest_commit = manifest_dict[name]["commit"]
-
-                if commit != manifest_commit:
-                    mismatches = True
-                    print(
-                        f"The version of {name} used in building the PDK does not match the version OpenLane was tested on (installed: {commit}, tested: {manifest_commit})",
-                        file=report_file,
-                    )
-                    print(
-                        "This may introduce some issues. You may want to re-install the PDK by invoking `make pdk`.",
-                        file=report_file,
-                    )
-
-                pdk_manifest_names.add(name)
-    except Exception as e:
-        print(e, file=report_file)
-        print(traceback.format_exc(), file=report_file)
-        raise Exception("Failed to compare PDKs.")
-
-    if no_tools:
-        return mismatches
-
-    installed = os.getenv("OPENLANE_LOCAL_INSTALL") == "1"
-    environment_manifest = None
-    if installed:
-        # 3a. Compare with installed versions
-        installed_versions_path = join(
-            os.environ["OL_INSTALL_DIR"], "build", "versions"
-        )
-        environment_manifest = []
-        for tool in os.listdir(installed_versions_path):
-            protocol, url, commit = (
-                open(join(installed_versions_path, tool)).read().split(":")
-            )
-            repo = f"{protocol}:{url}"
-            environment_manifest.append({"name": tool, "repo": repo, "commit": commit})
-    else:
-        # 3b. Compare Container And Installation Manifests
+    if not no_pdks:
         try:
-            container_manifest_path = join("/", "tool_metadata.yml")
-            environment_manifest = yaml.safe_load(open(container_manifest_path))
-        except FileNotFoundError:
-            raise Exception(
-                "Container manifest not found. What this likely means is that the container is severely out of date."
+            # 2. Check if the PDK is compatible with Flow Scripts
+            pdk_root = os.getenv("PDK_ROOT")
+            if not os.getenv("PDK_ROOT"):
+                pdk_root = join(openlane_dir, "pdks")
+
+            if pdk is not None:
+                pdk_dir = join(pdk_root, pdk)
+
+                if not pathlib.Path(pdk_dir).is_dir():
+                    raise Exception(f"{pdk_dir} not found.")
+
+                tool_versions = []
+
+                sources_file = join(pdk_dir, "SOURCES")
+                config_file = join(pdk_dir, ".config", "nodeinfo.json")
+
+                if os.path.isfile(sources_file):
+                    sources_str = None
+                    try:
+                        sources_str = open(sources_file).read()
+                    except FileNotFoundError:
+                        raise Exception(
+                            f"Could not find SOURCES file for the installed {pdk} PDK."
+                        )
+
+                    sources_str = sources_str.strip()
+
+                    # Format: {tool} {commit}
+                    #
+                    #   This regex also handles an issue where older versions used the
+                    #   non-standard echo -ne command, where the format is -ne {tool}\n{commit}\n.
+                    #
+                    name_rx = re.compile(
+                        r"(?:\-ne\s+)?([\w\-]+)\s+([A-Fa-f0-9]+)", re.MULTILINE
+                    )
+
+                    for tool_match in name_rx.finditer(sources_str):
+                        name = tool_match[1]
+                        commit = tool_match[2]
+
+                        manifest_name = manifest_names_by_SOURCES_name.get(name)
+                        if manifest_name is None:
+                            continue
+
+                        tool_versions.append((manifest_name, commit))
+                elif os.path.isfile(config_file):
+                    config_str = open(config_file).read()
+                    try:
+                        config = json.loads(config_str)
+                        commit_set = config["commit"]
+                        if type(commit_set) == str:
+                            tool_versions.append(("open_pdks", commit_set))
+                        else:
+                            for key, value in commit_set.items():
+                                # Handle bug in some older versions of opdks where the magic commit field is empty.
+                                if value.strip() == "":
+                                    continue
+                                tool_versions.append((key, value))
+                    except json.decoder.JSONDecodeError:
+                        raise Exception("Malformed .config/nodeinfo.json.")
+
+                else:
+                    raise Exception(
+                        "Neither SOURCES nor .config/nodeinfo.json exist in the PDK."
+                    )
+
+                for name, commit in tool_versions:
+                    manifest_commit = manifest_dict[name]["commit"]
+
+                    if commit != manifest_commit:
+                        mismatches = True
+                        print(
+                            f"The version of {name} used in building the PDK does not match the version OpenLane was tested on (installed: {commit}, tested: {manifest_commit})",
+                            file=report_file,
+                        )
+                        print(
+                            "This may introduce some issues. You may want to re-install the PDK by invoking `make pdk`.",
+                            file=report_file,
+                        )
+
+                    pdk_manifest_names.add(name)
+        except Exception as e:
+            print(e, file=report_file)
+            print(traceback.format_exc(), file=report_file)
+            raise Exception("Failed to compare PDKs.")
+
+    if not no_tools:
+        installed = os.getenv("OPENLANE_LOCAL_INSTALL") == "1"
+        environment_manifest = None
+        if installed:
+            # 3a. Compare with installed versions
+            installed_versions_path = join(
+                os.environ["OL_INSTALL_DIR"], "build", "versions"
             )
+            environment_manifest = []
+            for tool in os.listdir(installed_versions_path):
+                protocol, url, commit = (
+                    open(join(installed_versions_path, tool)).read().split(":")
+                )
+                repo = f"{protocol}:{url}"
+                environment_manifest.append({"name": tool, "repo": repo, "commit": commit})
+        else:
+            # 3b. Compare Container And Installation Manifests
+            try:
+                container_manifest_path = join("/", "tool_metadata.yml")
+                environment_manifest = yaml.safe_load(open(container_manifest_path))
+            except FileNotFoundError:
+                raise Exception(
+                    "Container manifest not found. What this likely means is that the container is severely out of date."
+                )
 
-    tool_set_flow = set([element["name"] for element in manifest]) - pdk_manifest_names
-    tool_set_container = (
-        set([element["name"] for element in environment_manifest]) - pdk_manifest_names
-    )
-
-    unmatched_tools_flow = tool_set_flow - tool_set_container
-    for tool in unmatched_tools_flow:
-        tool_object = manifest_dict[tool]
-        if (
-            tool_object.get("in_container") is not None
-            and not tool_object["in_container"]
-        ):
-            continue
-        if (
-            installed
-            and tool_object.get("in_install") is not None
-            and not tool_object["in_install"]
-        ):
-            continue
-        print(
-            f"Tool {tool} is required by the flow scripts being used, but appears to not be installed in the environment.",
-            file=report_file,
+        tool_set_flow = set([element["name"] for element in manifest]) - pdk_manifest_names
+        tool_set_container = (
+            set([element["name"] for element in environment_manifest]) - pdk_manifest_names
         )
-        mismatches = True
 
-    unmatched_tools_container = tool_set_container - tool_set_flow
-    for tool in unmatched_tools_container:
-        print(
-            f"Tool {tool} is installed in the environment, but has no corresponding entry in the flow scripts.",
-            file=report_file,
-        )
-        mismatches = True
-
-    for tool in environment_manifest:
-        if tool["name"] in pdk_manifest_names:
-            continue  # PDK Stuff Already Checked
-        flow_script_counterpart = manifest_dict.get(tool["name"])
-        if flow_script_counterpart is None:
-            continue
-        container_commit = tool["commit"]
-        flow_script_commit = flow_script_counterpart["commit"]
-        if container_commit != flow_script_commit:
+        unmatched_tools_flow = tool_set_flow - tool_set_container
+        for tool in unmatched_tools_flow:
+            tool_object = manifest_dict[tool]
+            if (
+                tool_object.get("in_container") is not None
+                and not tool_object["in_container"]
+            ):
+                continue
+            if (
+                installed
+                and tool_object.get("in_install") is not None
+                and not tool_object["in_install"]
+            ):
+                continue
             print(
-                f"The version of {tool['name']} installed in the environment does not match the one required by the OpenLane flow scripts (installed: {container_commit}, expected: {flow_script_commit})",
+                f"Tool {tool} is required by the flow scripts being used, but appears to not be installed in the environment.",
                 file=report_file,
             )
             mismatches = True
+
+        unmatched_tools_container = tool_set_container - tool_set_flow
+        for tool in unmatched_tools_container:
+            print(
+                f"Tool {tool} is installed in the environment, but has no corresponding entry in the flow scripts.",
+                file=report_file,
+            )
+            mismatches = True
+
+        for tool in environment_manifest:
+            if tool["name"] in pdk_manifest_names:
+                continue  # PDK Stuff Already Checked
+            flow_script_counterpart = manifest_dict.get(tool["name"])
+            if flow_script_counterpart is None:
+                continue
+            container_commit = tool["commit"]
+            flow_script_commit = flow_script_counterpart["commit"]
+            if container_commit != flow_script_commit:
+                print(
+                    f"The version of {tool['name']} installed in the environment does not match the one required by the OpenLane flow scripts (installed: {container_commit}, expected: {flow_script_commit})",
+                    file=report_file,
+                )
+                mismatches = True
 
     return mismatches
 
 
 if __name__ == "__main__":
     try:
-        mismatches = verify_versions(no_tools=False)
+        no_tools = False
+        no_pdks = False
+        mismatches = os.getenv("TEST_MISMATCHES") or "all"
+        if mismatches == "none":
+            no_tools = True
+            no_pdks = True
+        elif mismatches == "pdk":
+            no_tools = True
+        elif mismatches == "tools":
+            no_pdks = True
+        elif mismatches != "all":
+            print(f"Unknown mismatch test '{mismatches}'.", file=sys.stderr)
+            sys.exit(-1)
+        mismatches = verify_versions(no_tools=no_tools, no_pdks=no_pdks)
         sys.exit(os.EX_CONFIG if mismatches else os.EX_OK)
     except Exception as e:
         print(f"{e}")

--- a/scripts/tcl_commands/all.tcl
+++ b/scripts/tcl_commands/all.tcl
@@ -677,13 +677,14 @@ proc prep {args} {
 
 
     if [catch {exec python3 $::env(OPENLANE_ROOT)/dependencies/verify_versions.py} ::env(VCHECK_OUTPUT)] {
-        if { [info exists ::env(MISMATCHES_OK)] && $::env(MISMATCHES_OK) == "1" } {
-            puts_warn "OpenLane may not function properly: $::env(VCHECK_OUTPUT)"
-        } else {
+        if { $::env(QUIT_ON_MISMATCHES) == "1" } {
             puts_err $::env(VCHECK_OUTPUT)
             puts_err "Please update your environment. OpenLane will now quit."
             flow_fail
+            return -code error
         }
+        
+        puts_warn "OpenLane may not function properly: $::env(VCHECK_OUTPUT)"
     }
 
     TIMER::timer_stop


### PR DESCRIPTION
+ Added TEST_MISMATCHES, that can be set to all, tools, pdk, or none
~ MISMATCHES_OK is now QUIT_ON_MISMATCHES (inverted,) and documented

---

Caravel can add `-e TEST_MISMATCHES=tools` to continue being able to bundle PDKs of different versions.