### PR TITLE
Avoid off-grid errors in FP_PDN_AUTO_ADJUST

### DIFF
--- a/scripts/openroad/pdn_cfg.tcl
+++ b/scripts/openroad/pdn_cfg.tcl
@@ -24,7 +24,7 @@ if { [info exists ::env(FP_PDN_ENABLE_GLOBAL_CONNECTIONS)] } {
 
 set_voltage_domain -name CORE -power $::env(VDD_NET) -ground $::env(GND_NET)
 
-# Assesses whether the deisgn is the core of the chip or not based on the 
+# Assesses whether the design is the core of the chip or not based on the 
 # value of $::env(DESIGN_IS_CORE) and uses the appropriate stdcell section
 if { $::env(DESIGN_IS_CORE) == 1 } {
     # Used if the design is the core of the chip

--- a/scripts/tcl_commands/floorplan.tcl
+++ b/scripts/tcl_commands/floorplan.tcl
@@ -69,11 +69,11 @@ proc init_floorplan {args} {
 			$core_height <= [expr {$::env(FP_PDN_HOFFSET) + $::env(FP_PDN_HPITCH)}]} {
 				puts_warn "Current core area is too small for a power grid. The power grid will be minimized."
 
-			set ::env(FP_PDN_VOFFSET) [expr {$core_width/6.0}]
-			set ::env(FP_PDN_HOFFSET) [expr {$core_height/6.0}]
+			set ::env(FP_PDN_VOFFSET) [expr {$core_width/8.0}]
+			set ::env(FP_PDN_HOFFSET) [expr {$core_height/8.0}]
 
-			set ::env(FP_PDN_VPITCH) [expr {$core_width/3.0}]
-			set ::env(FP_PDN_HPITCH) [expr {$core_height/3.0}]
+			set ::env(FP_PDN_VPITCH) [expr {$core_width/4.0}]
+			set ::env(FP_PDN_HPITCH) [expr {$core_height/4.0}]
 		}
 
 	}


### PR DESCRIPTION
Change /3 -> /4 and /6 -> /8 to help avoid offgrid errors.  Really
whatever is used should be snapped to the manufacturing grid. This should
be done inside openroad where the LEF data is available.  This is just
less likely to cause an error.

Signed-off-by: Matt Liberty <mliberty@eng.ucsd.edu>