### PR TITLE
No need to check branch name in get_tag.py

### DIFF
--- a/dependencies/get_tag.py
+++ b/dependencies/get_tag.py
@@ -37,21 +37,6 @@ def get_tag() -> str:
                 "Cannot find the git binary. Please specify OPENLANE_IMAGE_NAME manually."
             )
 
-        branch_name_data: subprocess.CompletedProcess = subprocess.run(
-            ["git", "branch", "--show-current"],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-        )
-
-        if branch_name_data.returncode != 0:
-            raise NoGitException(
-                f"Cannot determine git branch. Please specify OPENLANE_IMAGE_NAME manually.\nFull output: {branch_name_data.stderr.decode('utf8').strip()}"
-            )
-
-        branch_name = branch_name_data.stdout.decode("utf8").strip()
-        if branch_name not in ["main", "master"]:
-            return f"{branch_name}-dev"
-
         process_data: subprocess.CompletedProcess = subprocess.run(
             ["git", "rev-parse", "HEAD"],
             stdout=subprocess.PIPE,


### PR DESCRIPTION
get_tag.py currently fails if you explicitly check out a commit (it
returns "-dev").

Now we are using commit based tags, there is no need to check for the
current branch.