### PR TITLE
Remove Hard-coded Paths in Sample Designs

### DIFF
--- a/designs/gcd/config.tcl
+++ b/designs/gcd/config.tcl
@@ -16,7 +16,7 @@ set ::env(FP_IO_VTHICKNESS_MULT) ""
 set ::env(FP_IO_HTHICKNESS_MULT) ""
 set ::env(FP_IO_MIN_DISTANCE) ""
 
-set filename ./designs/$::env(DESIGN_NAME)/$::env(PDK)_$::env(STD_CELL_LIBRARY)_config.tcl
+set filename $::env(DESIGN_DIR)/$::env(PDK)_$::env(STD_CELL_LIBRARY)_config.tcl
 if { [file exists $filename] == 1} {
 	source $filename
 }

--- a/designs/spm/config.tcl
+++ b/designs/spm/config.tcl
@@ -8,7 +8,7 @@ set ::env(CLOCK_PORT) "clk"
 
 set ::env(FP_PIN_ORDER_CFG) $::env(DESIGN_DIR)/pin_order.cfg
 
-set filename ./designs/$::env(DESIGN_NAME)/$::env(PDK)_$::env(STD_CELL_LIBRARY)_config.tcl
+set filename $::env(DESIGN_DIR)/$::env(PDK)_$::env(STD_CELL_LIBRARY)_config.tcl
 if { [file exists $filename] == 1} {
 	source $filename
 }


### PR DESCRIPTION
PART1

Avoid hardcoded path in the setups of the sample designs.
Design configs should be consistent regarding issues with path hard-coding.

---

A sample effort of system-wide OpenLane distributable [is available here](https://gist.github.com/cbalint13/1de29fbe77e8dedddd3861b5f49a1835).

The structure of distributables:

```
$ rpm -ql openlane
/usr/bin/openlane-flow
/usr/share/openlane/flow.tcl
/usr/share/openlane/configuration/{..}
/usr/share/openlane/scripts/{..}
/usr/share/tcl8.6/openlane-tcl_commands/*
/usr/share/tcl8.6/openlane-utils/*
/usr/share/doc/openlane/{..}

$ rpm -ql openlane-designs
/usr/share/openlane/designs/{..,}

$ rpm -ql efabless-open-pdks-sky130_fd_sc_hd
/usr/share/pdk/sky130{A,B}/{...}
```

1. The ```/usr/bin/openlane-flow``` is **system-wide** wrap to ```flow.tcl``` (the ```openlane-``` suffix avoids confusion).
2. Modules in ```/usr/share/tcl8.6/``` are by default in system reach on ```any distro```, they are picked up anytime.
3. The ```/usr/share/openlane/``` is also system wide and picked up by  ```/usr/bin/openlane-flow``` itself.
4. The PDK (separate packages) is also in standard stystem path of ```/usr/share/pdk/sky130{A,B}``` 


Details of packaging: 
  * [openlane.spec](https://copr-dist-git.fedorainfracloud.org/cgit/rezso/VLSI/openlane.git/tree/openlane.spec?h=HEAD)
  * [efabless-open-pdks.spec](https://copr-dist-git.fedorainfracloud.org/cgit/rezso/VLSI/efabless-open-pdks.git/tree/efabless-open-pdks.spec?h=HEAD) builded out from [open-pdk-skywater.spec](https://copr-dist-git.fedorainfracloud.org/cgit/rezso/VLSI/open-pdk-skywater.git/tree/open-pdk-skywater.spec?h=HEAD)
  * The numerous rest of required tooling are all [holded in this repo](https://copr.fedorainfracloud.org/coprs/rezso/VLSI/) as individual packages.

Thank you,
~Cristian

@donn @vvbandeira @proppy
Cc @maliberty
