### PR TITLE
Revert Power Ring Order

### DIFF
--- a/scripts/openroad/pdn_cfg.tcl
+++ b/scripts/openroad/pdn_cfg.tcl
@@ -53,26 +53,24 @@ if { $::env(FP_PDN_ENABLE_MACROS_GRID) == 1 &&
 
 set secondary []
 
-foreach net $::env(VDD_NETS) {
-    if { $net != $::env(VDD_NET)} {
-        lappend secondary $net
+foreach vdd $::env(VDD_NETS) gnd $::env(GND_NETS) {
+    if { $vdd != $::env(VDD_NET)} {
+        lappend secondary $vdd
 
-        set db_net [[ord::get_db_block] findNet $net]
+        set db_net [[ord::get_db_block] findNet $vdd]
         if {$db_net == "NULL"} {
-            set net [odb::dbNet_create [ord::get_db_block] $net]
+            set net [odb::dbNet_create [ord::get_db_block] $vdd]
             $net setSpecial
             $net setSigType "POWER"
         }
     }
-}
 
-foreach net $::env(GND_NETS) {
-    if { $net != $::env(GND_NET)} {
-        lappend secondary $net
+    if { $gnd != $::env(GND_NET)} {
+        lappend secondary $gnd
 
-        set db_net [[ord::get_db_block] findNet $net]
+        set db_net [[ord::get_db_block] findNet $gnd]
         if {$db_net == "NULL"} {
-            set net [odb::dbNet_create [ord::get_db_block] $net]
+            set net [odb::dbNet_create [ord::get_db_block] $gnd]
             $net setSpecial
             $net setSigType "GROUND"
         }


### PR DESCRIPTION
As per Discussion with @Matt Liberty] , Requesting for Pull request to align the PDN Power Ring Order as in MPW5 Shuttle.
During Previous Shuttle (MPW5) Power Ring order was <vssa2><vdda2><vssa1><vdda1><vssd2><vccd2><vssd1><vccd1> i.e alternative ground and vdd,  
Where as in new PDN ring order is
<vssa2><vssa1><vssd2><vdda2><vdda2><vccd2><vssd1><vccd1>, i,e secondary ground, secondary vdd, Primary gnd and vcc.

This file change is reverting the Power Ring Order as in MPW-5