### PR TITLE
`repair_timing` improvements

### DIFF
--- a/scripts/openroad/resizer_routing_timing.tcl
+++ b/scripts/openroad/resizer_routing_timing.tcl
@@ -59,28 +59,18 @@ source $::env(SCRIPTS_DIR)/openroad/set_rc.tcl
 estimate_parasitics -global_routing
 
 # Resize
-if { [catch {repair_timing -setup \
-        -slack_margin $::env(GLB_RESIZER_SETUP_SLACK_MARGIN) \
-        -max_buffer_percent $::env(GLB_RESIZER_SETUP_MAX_BUFFER_PERCENT)}
-]} {
-    puts "Setup utilization limit is reached. Continuing the flow... "
-}
+repair_timing -setup \
+    -slack_margin $::env(GLB_RESIZER_SETUP_SLACK_MARGIN) \
+    -max_buffer_percent $::env(GLB_RESIZER_SETUP_MAX_BUFFER_PERCENT)
 
-if { $::env(GLB_RESIZER_ALLOW_SETUP_VIOS) == 1} {
-    if { [catch {repair_timing -hold -allow_setup_violations \
-            -slack_margin $::env(GLB_RESIZER_HOLD_SLACK_MARGIN) \
-            -max_buffer_percent $::env(GLB_RESIZER_HOLD_MAX_BUFFER_PERCENT)}
-    ]} {
-        puts "Hold utilization limit is reached. Continuing the flow... "
-    }
-} else {
-    if { [catch {repair_timing -hold \
-            -slack_margin $::env(GLB_RESIZER_HOLD_SLACK_MARGIN) \
-            -max_buffer_percent $::env(GLB_RESIZER_HOLD_MAX_BUFFER_PERCENT)}
-    ]} {
-        puts "Hold utilization limit is reached. Continuing the flow... "
-    }
+set arg_list [list]
+lappend arg_list -hold
+lappend arg_list -slack_margin $::env(GLB_RESIZER_HOLD_SLACK_MARGIN)
+lappend arg_list -max_buffer_percent $::env(GLB_RESIZER_HOLD_MAX_BUFFER_PERCENT)
+if { $::env(GLB_RESIZER_ALLOW_SETUP_VIOS) == 1 } {
+    lappend arg_list -allow_setup_violations
 }
+repair_timing {*}$arg_list
 
 # set_placement_padding -global -right $::env(CELL_PAD)
 # set_placement_padding -masters $::env(CELL_PAD_EXCLUDE) -right 0 -left 0

--- a/scripts/openroad/resizer_timing.tcl
+++ b/scripts/openroad/resizer_timing.tcl
@@ -47,28 +47,18 @@ source $::env(SCRIPTS_DIR)/openroad/set_rc.tcl
 estimate_parasitics -placement
 
 # Resize
-if { [catch {repair_timing -setup \
-        -slack_margin $::env(PL_RESIZER_SETUP_SLACK_MARGIN) \
-        -max_buffer_percent $::env(PL_RESIZER_SETUP_MAX_BUFFER_PERCENT)}
-]} {
-    puts "Setup utilization limit is reached. Continuing the flow... "
-}
+repair_timing -setup \
+    -slack_margin $::env(PL_RESIZER_SETUP_SLACK_MARGIN) \
+    -max_buffer_percent $::env(PL_RESIZER_SETUP_MAX_BUFFER_PERCENT)
 
-if { $::env(PL_RESIZER_ALLOW_SETUP_VIOS) == 1} {
-    if { [catch {repair_timing -hold -allow_setup_violations \
-            -slack_margin $::env(PL_RESIZER_HOLD_SLACK_MARGIN) \
-            -max_buffer_percent $::env(PL_RESIZER_HOLD_MAX_BUFFER_PERCENT)}
-    ]} {
-        puts "Hold utilization limit is reached. Continuing the flow... "
-    }
-} else {
-    if { [catch {repair_timing -hold \
-            -slack_margin $::env(PL_RESIZER_HOLD_SLACK_MARGIN) \
-            -max_buffer_percent $::env(PL_RESIZER_HOLD_MAX_BUFFER_PERCENT)}
-    ]} {
-        puts "Hold utilization limit is reached. Continuing the flow... "
-    }
+set arg_list [list]
+lappend arg_list -hold
+lappend arg_list -slack_margin $::env(PL_RESIZER_HOLD_SLACK_MARGIN)
+lappend arg_list -max_buffer_percent $::env(PL_RESIZER_HOLD_MAX_BUFFER_PERCENT)
+if { $::env(PL_RESIZER_ALLOW_SETUP_VIOS) == 1 } {
+    lappend arg_list -allow_setup_violations
 }
+repair_timing {*}$arg_list
 
 set_placement_padding -global -right $::env(CELL_PAD)
 if { $::env(CELL_PAD_EXCLUDE) != "" } {


### PR DESCRIPTION
~ Don't catch errors from repair_timing. There are many reasons it might
  fail and reporting "utilization limit is reached" is just confusing.
~ Handle arguments with an arg_list
Suggested by @jjcherry56