### PR TITLE
Replace -slack_margin with -setup_margin/-hold_margin

### DIFF
--- a/scripts/openroad/resizer_routing_timing.tcl
+++ b/scripts/openroad/resizer_routing_timing.tcl
@@ -60,12 +60,13 @@ estimate_parasitics -global_routing
 
 # Resize
 repair_timing -setup \
-    -slack_margin $::env(GLB_RESIZER_SETUP_SLACK_MARGIN) \
+    -setup_margin $::env(GLB_RESIZER_SETUP_SLACK_MARGIN) \
     -max_buffer_percent $::env(GLB_RESIZER_SETUP_MAX_BUFFER_PERCENT)
 
 set arg_list [list]
 lappend arg_list -hold
-lappend arg_list -slack_margin $::env(GLB_RESIZER_HOLD_SLACK_MARGIN)
+lappend arg_list -setup_margin $::env(GLB_RESIZER_SETUP_SLACK_MARGIN)
+lappend arg_list -hold_margin $::env(GLB_RESIZER_HOLD_SLACK_MARGIN)
 lappend arg_list -max_buffer_percent $::env(GLB_RESIZER_HOLD_MAX_BUFFER_PERCENT)
 if { $::env(GLB_RESIZER_ALLOW_SETUP_VIOS) == 1 } {
     lappend arg_list -allow_setup_violations

--- a/scripts/openroad/resizer_timing.tcl
+++ b/scripts/openroad/resizer_timing.tcl
@@ -48,12 +48,13 @@ estimate_parasitics -placement
 
 # Resize
 repair_timing -setup \
-    -slack_margin $::env(PL_RESIZER_SETUP_SLACK_MARGIN) \
+    -setup_margin $::env(PL_RESIZER_SETUP_SLACK_MARGIN) \
     -max_buffer_percent $::env(PL_RESIZER_SETUP_MAX_BUFFER_PERCENT)
 
 set arg_list [list]
 lappend arg_list -hold
-lappend arg_list -slack_margin $::env(PL_RESIZER_HOLD_SLACK_MARGIN)
+lappend arg_list -setup_margin $::env(PL_RESIZER_SETUP_SLACK_MARGIN)
+lappend arg_list -hold_margin $::env(PL_RESIZER_HOLD_SLACK_MARGIN)
 lappend arg_list -max_buffer_percent $::env(PL_RESIZER_HOLD_MAX_BUFFER_PERCENT)
 if { $::env(PL_RESIZER_ALLOW_SETUP_VIOS) == 1 } {
     lappend arg_list -allow_setup_violations


### PR DESCRIPTION
After the recent OpenROAD update, -slack_margin is now deprecated.