### PR TITLE
Enhancements + Bugfixes to Multi-PDK Support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,8 +65,10 @@ export PDK_ROOT := $(shell $(PYTHON_BIN) -c "import os; print(os.path.realpath('
 PDK_OPTS = -v $(PDK_ROOT):$(PDK_ROOT) -e PDK_ROOT=$(PDK_ROOT)
 endif
 
+export PDK ?= sky130A
 export STD_CELL_LIBRARY ?= sky130_fd_sc_hd
-STD_CELL_OPTS := -e STD_CELL_LIBRARY=$(STD_CELL_LIBRARY)
+
+PDK_OPTS += -e PDK=$(PDK) -e STD_CELL_LIBRARY=$(STD_CELL_LIBRARY)
 
 # ./designs is mounted over ./install so env.tcl is not found inside the Docker
 # container if the user had previously installed it.

--- a/configuration/README.md
+++ b/configuration/README.md
@@ -1,15 +1,13 @@
 # Variables information
-
-This page describes configuration variables and their default values.
-
+This page describes user-configurable variables and their default values.
 ## Required variables
 
-| Variable      | Description                                           |
-|---------------|-------------------------------------------------------|
+|Variable|Description|
+|-|-|
 | `DESIGN_NAME`   | The name of the top level module of the design        |
-| `VERILOG_FILES` | The path of the design's verilog files |
-| `CLOCK_PERIOD`  | The clock period for the design in ns       |
-| `CLOCK_NET` | The name of the Net input to root clock buffer used in Clock Tree Synthesis. |
+| `VERILOG_FILES` | The path of the design's verilog files, space-delimited. |
+| `CLOCK_PERIOD`  | The clock period for the design in nanoseconds. |
+| `CLOCK_NET` | The name of the net input to root clock buffer used in Clock Tree Synthesis. |
 | `CLOCK_PORT`    | The name of the design's clock port used in Static Timing Analysis.   |
 
 ## Optional variables
@@ -18,12 +16,9 @@ These variables are optional that can be specified in the design configuration f
 
 ### Synthesis
 
-| Variable      | Description                                                   |
-|---------------|---------------------------------------------------------------|
+|Variable|Description|
+|-|-|
 | `SYNTH_BIN` | The yosys binary used in the flow. <br> (Default: `yosys`) |
-| `LIB_SYNTH` | The library used for synthesis by yosys. <br> (Default: `$::env(PDK_ROOT)/$::env(PDK)/libs.ref/$::env(STD_CELL_LIBRARY)/lib/sky130_fd_sc_hd__tt_025C_1v80.lib`)|
-| `SYNTH_DRIVING_CELL`  | The cell to drive the input ports. <br>(Default: `sky130_fd_sc_hd__inv_1`)|
-| `SYNTH_DRIVING_CELL_PIN`  | The name of the SYNTH_DRIVING_CELL output pin. <br>(Default: `Y`)|
 | `SYNTH_CAP_LOAD` | The capacitive load on the output ports in femtofarads. <br> (Default: `33.5` ff)|
 | `SYNTH_MAX_FANOUT`  | The max load that the output ports can drive. <br> (Default: `5` cells) |
 | `SYNTH_MAX_TRAN` | The max transition time (slew) from high to low or low to high on cell inputs in ns. Used in synthesis <br> (Default: Calculated at runtime as `10%` of the provided clock period, unless this exceeds a set DEFAULT_MAX_TRAN, in which case it will be used as is). |
@@ -39,14 +34,7 @@ These variables are optional that can be specified in the design configuration f
 | `SYNTH_ADDER_TYPE` | Adder type to which the $add and $sub operators are mapped to. <br> Possible values are `YOSYS/FA/RCA/CSA`; where `YOSYS` refers to using Yosys internal adder definition, `FA` refers to full-adder structure, `RCA` refers to ripple carry adder structure, and `CSA` refers to carry select adder. <br> (Default: `YOSYS`)|
 | `SYNTH_EXTRA_MAPPING_FILE` | Points to extra techmap file for yosys that runs right after yosys `synth` before generic techmap. <br> (Default: `""`)|
 | `SYNTH_PARAMETERS` | Space-separated key value pairs to be `chparam`ed in Yosys. In the format `key1=value1 key2=value2` <br> Default: None.  |
-| `LIB_FASTEST` | Points to the lib file, corresponding to the slowest corner, for max delay calculation during STA. <br> (Default: `$::env(PDK_ROOT)/$::env(PDK)/libs.ref/$::env(STD_CELL_LIBRARY)/lib/sky130_fd_sc_hd__ff_n40C_1v95.lib`) |
-| `LIB_SLOWEST` | Points to the lib file, corresponding to the fastest corner, for min delay calculation during STA. <br> (Default: `$::env(PDK_ROOT)/$::env(PDK)/libs.ref/$::env(STD_CELL_LIBRARY)/lib/sky130_fd_sc_hd__ss_100C_1v60.lib`) |
-| `LIB_TYPICAL` | Library used for typical delay calculation during STA. <br> (Default`LIB_SYNTH`) |
 | `CLOCK_BUFFER_FANOUT` | Fanout of clock tree buffers. <br> (Default: `16`) |
-| `ROOT_CLK_BUFFER` | Root clock buffer of the clock tree. <br> (Default: `sky130_fd_sc_hd__clkbuf_16`) |
-| `CLK_BUFFER` | Clock buffer used for inner nodes of the clock tree. <br> (Default: `sky130_fd_sc_hd__clkbuf_4`) |
-| `CLK_BUFFER_INPUT` | Input pin of the clock tree buffer. <br> (Default: `A`) |
-| `CLK_BUFFER_OUTPUT` | Output pin of the clock tree buffer. <br> (Default: `X`) |
 | `BASE_SDC_FILE` | Specifies the base sdc file to source before running Static Timing Analysis. <br> (Default: `$::env(OPENLANE_ROOT)/scripts/base.sdc`) |
 | `VERILOG_INCLUDE_DIRS` | Specifies the verilog includes directories. <br> Optional. |
 | `SYNTH_FLAT_TOP` | Specifies whether or not the top level should be flattened during elaboration. 1 = True, 0= False <br> Default: `0`. |
@@ -55,8 +43,8 @@ These variables are optional that can be specified in the design configuration f
 
 ### Floorplanning
 
-| Variable      | Description                                                   |
-|---------------|---------------------------------------------------------------|
+|Variable|Description|
+|-|-|
 | `FP_CORE_UTIL`  | The core utilization percentage. <br> (Default: `50` percent)|
 | `FP_ASPECT_RATIO`  | The core's aspect ratio (height / width). <br> (Default: `1`)|
 | `FP_SIZING`  | Whether to use relative sizing by making use of `FP_CORE_UTIL` or absolute one using `DIE_AREA`. <br> (Default: `"relative"` - accepts "absolute" as well)|
@@ -104,16 +92,16 @@ These variables are optional that can be specified in the design configuration f
 #### Deprecated I/O Layer variables
 These variables worked initially, but they were too sky130 specific and will be removed. Currently, if you define them in your design, they'll be used, but it's recommended to update your configuration to use `FP_IO_HLAYER` and `FP_IO_VLAYER`, which are defined in the PDK.
 
-| Variable      | Description                                                   |
-|---------------|---------------------------------------------------------------|
+|Variable|Description|
+|-|-|
 | `FP_IO_HMETAL`  | The metal layer on which to place the io pins horizontally (top and bottom of the die). <br>(Default: `4`)|
 | `FP_IO_VMETAL`  | The metal layer on which to place the io pins vertically (sides of the die) <br> (Default: `3`)|
 
 
 ### Placement
 
-| Variable      | Description                                                   |
-|---------------|---------------------------------------------------------------|
+|Variable|Description|
+|-|-|
 | `PL_TARGET_DENSITY` | The desired placement density of cells. It reflects how spread the cells would be on the core area. 1 = closely dense. 0 = widely spread <br> (Default: `0.55`)|
 | `PL_TIME_DRIVEN` | Specifies whether the placer should use time driven placement. 0 = false, 1 = true <br> (Default: `1`)|
 | `PL_LIB` | Specifies the library for time driven placement <br> (Default: `LIB_TYPICAL`)|
@@ -144,16 +132,11 @@ These variables worked initially, but they were too sky130 specific and will be 
 | `PL_MACRO_HALO` | Macro placement halo. Format: `{Horizontal} {Vertical}` <br> (Default: `0 0`um). |
 | `PL_MACRO_CHANNEL` | Channel widths between macros. Format: `{Horizontal} {Vertical}` <br> (Default: `0 0`um). |
 | `MACRO_PLACEMENT_CFG` | Specifies the path a file specifying how openlane should place certain macros |
-| `LIB_OPT` | **Removed**: Points to the lib file, corresponding to the slowest corner, for max delay calculation during OpenPhySyn optimizations. This is usually a trimmed version of `LIB_SYNTH`. <br> Default: `$::env(TMP_DIR)/opt.lib` |
-| `PL_DIAMOND_SEARCH_HEIGHT` | **Removed: Use PL_MAX_DISPLACEMENT_(X/Y) instead**: Specifies the diamond search height used for legalizing the cells during detailed placement. The search width is calculated internally as `heigh*5`. For designs that contain big macros, increasing this value to above 400 will allow for more search space and more potentail for successful legalization. <br> (Default: `100`) |
-| `PL_OPENPHYSYN_OPTIMIZATIONS` | **Removed**: Specifies whether OpenPhySyn should be used to perform timing optimizations or not. 0 = false, 1 = true <br> (Default: `0`) |
-| `PSN_ENABLE_RESIZING` | **Removed**: Enables driver resizing by OpenPhySyn. 0 = Disabled, 1 = Enabled <br> (Default: `1`)|
-| `PSN_ENABLE_PIN_SWAP` | **Removed**: Enables pin swapping for timing optimization by OpenPhySyn. 0 = Disabled, 1 = Enabled <br> (Default: `1`)|
 
 ### CTS
 
-| Variable      | Description                                                   |
-|---------------|---------------------------------------------------------------|
+|Variable|Description|
+|-|-|
 | `CTS_TARGET_SKEW` | The target clock skew in picoseconds. <br> (Default: `200`ps)|
 | `CTS_ROOT_BUFFER`| The name of cell inserted at the root of the clock tree. |
 | `CLOCK_TREE_SYNTH` | Enable clock tree synthesis. <br> (Default: `1`)|
@@ -170,8 +153,8 @@ These variables worked initially, but they were too sky130 specific and will be 
 
 ### Routing
 
-| Variable      | Description                                                   |
-|---------------|---------------------------------------------------------------|
+|Variable|Description|
+|-|-|
 | `GLOBAL_ROUTER` | Specifies which global router to use. Values: `fastroute`. (`cugr` is deprecated and fastroute will be used instead.) <br> (Default: `fastroute`) |
 | `DETAILED_ROUTER` | Specifies which detailed router to use. Values: `tritonroute`. (`drcu`/`tritonroute_or` are both deprecated and tritonroute will be used instead.) <br> (Default: `tritonroute`)|
 | `ROUTING_CORES` | Specifies the number of threads to be used in TritonRoute. Can be overriden via environment variable. <br> (Default: `2`) |
@@ -203,8 +186,8 @@ These variables worked initially, but they were too sky130 specific and will be 
 #### Deprecated Layer Adjustment Variables
 These variables worked initially, but they were too sky130 specific and will be removed. Currently, if you define them in your design, they'll be concatenated into GLB_RT_LAYER_ADJUSTMENTS, but it's recommended to update your configuration to use `GLB_RT_LAYER_ADJUSTMENTS`, which is defined in the PDK.
 
-| Variable      | Description                                                   |
-|---------------|---------------------------------------------------------------|
+|Variable|Description|
+|-|-|
 | `GLB_RT_L1_ADJUSTMENT` | **Deprecated**: Reduction in the routing capacity of the edges between the cells in the global routing graph but specific to li1 layer in sky130A. Values range from 0 to 1 <br> (Default: `0.99`) |
 | `GLB_RT_L2_ADJUSTMENT` | **Deprecated**: Reduction in the routing capacity of the edges between the cells in the global routing graph but specific to met1 in sky130A. Values range from 0 to 1 <br> (Default: `0`) |
 | `GLB_RT_L3_ADJUSTMENT` | **Deprecated**: Reduction in the routing capacity of the edges between the cells in the global routing graph but specific to met2 in sky130A. Values range from 0 to 1 <br> (Default: `0`) |
@@ -215,8 +198,8 @@ These variables worked initially, but they were too sky130 specific and will be 
 #### Deprecated Min/Max Layer Variables
 These variables worked initially, but they were too sky130 specific and will be removed. Currently, if you define them in your design, they'll be translated to the correct variables, `RT_{MIN/MAX}_LAYER` and `RT_CLOCK_{MIN/MAX}_LAYER`.
 
-| Variable      | Description                                                   |
-|---------------|---------------------------------------------------------------|
+|Variable|Description|
+|-|-|
 | `GLB_RT_MINLAYER` | **Deprecated**: The number of lowest layer to be used in routing. <br> (Default: `1`)|
 | `GLB_RT_MAXLAYER` | **Deprecated**: The number of highest layer to be used in routing. <br> (Default: `6`)|
 | `GLB_RT_CLOCK_MINLAYER` | **Deprecated**: The number of lowest layer to be used in routing the clock net. <br> (Default: `GLB_RT_MINLAYER`)|
@@ -224,28 +207,23 @@ These variables worked initially, but they were too sky130 specific and will be 
 
 #### Removed
 
-| Variable      | Description                                                   |
-|---------------|---------------------------------------------------------------|
+|Variable|Description|
+|-|-|
 | `GLB_RT_UNIDIRECTIONAL` | **Removed**: Allow unidirectional routing. 0 = false, 1 = true <br> (Default: `1`) |
 | `GLB_RT_TILES` | **Removed**: The size of the GCELL used by Fastroute during global routing. <br> (Default: `15`) |
 
 ### RC Extraction
 
-| Variable      | Description                                                   |
-|---------------|---------------------------------------------------------------|
+|Variable|Description|
+|-|-|
 | `SPEF_EXTRACTOR` | Specifies which spef extractor to use. Values: `openrcx` or (removed: `def2spef`). <br> (Default: `openrcx`) |
 | `RCX_MERGE_VIA_WIRE_RES` | Specifies whether to merge the via resistance with the wire resistance or separate it from the wire resistance. 1 = Merge via resistance, 0 = Separate via resistance <br> (Default: `1`)|
 | `SPEF_WIRE_MODEL` | Specifies the wire model used in SPEF extraction. Options are `L` or `Pi`  <br> (Default: `L`) |
 | `SPEF_EDGE_CAP_FACTOR` | Specifies the edge capacitance factor used in SPEF extraction. Ranges from 0 to 1 <br> (Default: `1`) |
-| `RCX_CORNER_COUNT` | **Removed**: Specifies the number of corners used during the parasitic extractions. <br> (Default: `1`)|
-| `RCX_MAX_RESISTANCE` | **Removed**: Specifies the maximum threshold value for combining resistors in series. Resistors in series are combined up to this value. Units in ohms <br> (Default: `50`)|
-| `RCX_COUPLING_THRESHOLD` | **Removed**: Specifies the maximum threshold value for grounding coupling values. Coupling values below this threshold are grounded. Units in fF <br> (Default: `0.1`)|
-| `RCX_CC_MODEL` | **Removed**: Specifies the maximum number of tracks on the same routing level. Coupling is calculated within the `RCX_CC_MODEL` distance. <br> (Default: `10`)|
-| `RCX_CONTEXT_DEPTH` | **Removed**: Specifies the number of levels considered when calculating the capacitance. <br> (Default: `5`)|
 
 ### Magic
-| Variable      | Description                                                   |
-|---------------|---------------------------------------------------------------|
+|Variable|Description|
+|-|-|
 | `MAGIC_PAD` |  A flag to pad the views generated by magic (.mag, .lef, .gds) with one site. 1 = Enabled, 0 = Disabled <br> (Default: `0` )|
 | `MAGIC_ZEROIZE_ORIGIN` | A flag to move the layout such that it's origin in the lef generated by magic is 0,0. 1 = Enabled, 0 = Disabled  <br> (Default: `1` )|
 | `MAGIC_GENERATE_GDS` | A flag to generate gds view via magic . 1 = Enabled, 0 = Disabled  <br> (Default: `1` )|
@@ -261,16 +239,16 @@ These variables worked initially, but they were too sky130 specific and will be 
 
 ### LVS
 
-| Variable      | Description                                                   |
-|---------------|---------------------------------------------------------------|
+|Variable|Description|
+|-|-|
 | `LVS_INSERT_POWER_PINS` |  Enables power pins insertion before running lvs. 1 = Enabled, 0 = Disabled <br> (Default: `1` )|
 | `LVS_CONNECT_BY_LABEL` | Enables connections by label in LVS by skipping `extract unique` in magic extractions. <br> Default: `0` |
 | `YOSYS_REWRITE_VERILOG` | Enables yosys to rewrite the verilog before LVS producing a canonical verilog netlist with verbose wire declarations. This flag will be ignored if `LEC_ENABLE` is 1, and it will be rewritten anyways. 1 = Enabled, 0 = Disabled <br> (Default: `0` ) |
 
 ### Misc
 
-| Variable      | Description                                                   |
-|---------------|---------------------------------------------------------------|
+|Variable|Description|
+|-|-|
 | `PDK` | Specifies the process design kit (PDK). <br> (Default: `sky130A` )|
 | `STD_CELL_LIBRARY` | Specifies the standard cell library to be used under the specified PDK. <br> (Default: `sky130_fd_sc_hd` )|
 | `STD_CELL_LIBRARY_OPT` | Specifies the standard cell library to be used during resizer optimizations. <br> (Default: `$STD_CELL_LIBRARY` )|
@@ -289,8 +267,8 @@ These variables worked initially, but they were too sky130 specific and will be 
 
 ### Flow control
 
-| Variable      | Description                                                   |
-|---------------|---------------------------------------------------------------|
+|Variable|Description|
+|-|-|
 | `USE_GPIO_PADS` | Decides whether or not to use the gpio pads in routing by merging their LEF file set in `::env(USE_GPIO_ROUTING_LEF)` and blackboxing their verilog modules set in `::env(GPIO_PADS_VERILOG)`. 1=Enabled, 0=Disabled. <br> (Default: `0`) |
 | `LEC_ENABLE` | Enables logic verification using yosys, for comparing each netlist at each stage of the flow with the previous netlist and verifying that they are logically equivalent. Warning: this will increase the runtime significantly. 1 = Enabled, 0 = Disabled <br> (Default: `0`)|
 | `RUN_ROUTING_DETAILED` | Enables detailed routing. 1 = Enabled, 0 = Disabled <br> (Default: `1`)|
@@ -317,8 +295,8 @@ These variables worked initially, but they were too sky130 specific and will be 
 
 ### Checkers
 
-| Variable      | Description                                                   |
-|---------------|---------------------------------------------------------------|
+|Variable|Description|
+|-|-|
 | `CHECK_UNMAPPED_CELLS` | Checks if there are unmapped cells after synthesis and aborts if any was found. 1 = Enabled, 0 = Disabled <br> (Default: `1`)|
 | `CHECK_ASSIGN_STATEMENTS` | Checks for assign statement in the generated gate level netlist and aborts of any was found.1 = Enabled, 0 = Disabled <br> (Default: `0`)|
 | `QUIT_ON_TR_DRC` | Checks for DRC violations after routing and exits the flow if any was found. 1 = Enabled, 0 = Disabled <br> (Default: `1`)|

--- a/dependencies/tool_metadata.yml
+++ b/dependencies/tool_metadata.yml
@@ -9,7 +9,7 @@
     make install
 - name: magic
   repo: https://github.com/rtimothyedwards/magic
-  commit: a205a0e9419f973346740171618956afe08b2d74
+  commit: 085131b090cb511d785baf52a10cf6df8a657d44
   build: |
     ./configure --prefix=$PREFIX $MAGIC_CONFIG_OPTS
     make clean
@@ -59,7 +59,7 @@
 - name: openroad_app
   repo: https://github.com/The-OpenROAD-Project/OpenROAD
   commit: 0b8b7ae255f8fbbbefa57d443949b84e73eed757
-  build: ''
+  build: ""
   in_install: false
 - name: git
   repo: https://github.com/git/git

--- a/dependencies/verify_versions.py
+++ b/dependencies/verify_versions.py
@@ -65,7 +65,7 @@ def verify_versions(
             if not os.getenv("PDK_ROOT"):
                 pdk_root = join(openlane_dir, "pdks")
 
-            if pdk is not None:
+            if pdk.startswith("sky130"):
                 pdk_dir = join(pdk_root, pdk)
 
                 if not pathlib.Path(pdk_dir).is_dir():

--- a/docs/source/pdk_structure.md
+++ b/docs/source/pdk_structure.md
@@ -1,6 +1,5 @@
 # Porting a PDK
-
-This readme describes how to port a PDK to openlane.
+This readme describes how to structure a PDK for use with OpenLane.
 
 ## Folder structure
 This is the expected folder structure for a PDK:
@@ -29,8 +28,7 @@ This is the expected folder structure for a PDK:
 
 
 ## PDK Variables
-
-This section defines the neccessary variables for PDK configuration file. Note that all defaults are for sky130A.
+This section defines the neccessary variables for PDK configuration file. Note that all examples given are for sky130A.
 
 | Variable      | Description                                                   |
 |---------------|---------------------------------------------------------------|
@@ -51,27 +49,27 @@ This section defines the neccessary variables for PDK configuration file. Note t
 | `NETGEN_SETUP_FILE` | Points to the setup file for netgen(lvs), that can exclude certain cells etc.. |
 | `FP_TAPCELL_DIST` | The distance between tapcell columns. Used in floorplanning in tapcell insertion. |
 | `DEFAULT_MAX_TRAN` | Defines the default maximum transition value, used in CTS & synthesis. |
-| `FP_PDN_RAIL_OFFSET` | Defines the rail offset for met1 used in PDN. <br> Default: `0`. |
-| `FP_PDN_VWIDTH` | Defines the strap width for the vertical layer used in PDN. <br> Default: `1.6`. |
-| `FP_PDN_HWIDTH` | Defines the strap width for the horizontal layer used in PDN. <br> Default: `1.6`. |
-| `FP_PDN_CORE_RING_VWIDTH` | Defines the vertical width for the vertical layer used to create the core ring in the PDN. <br> Default: `20`. |
-| `FP_PDN_CORE_RING_HWIDTH` | Defines the horizontal width for the horizontal layer used to create the core ring in the PDN. <br> Default: `20`. |
-| `FP_PDN_CORE_RING_VSPACING` | Defines the spacing for the vertical layer used to create the core ring in the PDN. <br> Default: `5`. |
-| `FP_PDN_CORE_RING_HSPACING` | Defines the spacing for the horizontal layer used to create the core ring in the PDN. <br> Default: `5`. |
-| `FP_PDN_CORE_RING_VOFFSET` | Defines the offset for the vertical layer used to create the core ring in the PDN. <br> Default: `20`. |
-| `FP_PDN_CORE_RING_HOFFSET` | Defines the offset for the horizontal layer used to create the core ring in the PDN. <br> Default: `20`. |
-| `WIRE_RC_LAYER` | The metal layer used in estimate parastics `set_wire_rc`. <br> Default: `met1`.|
-| `GLB_RT_LAYER_ADJUSTMENTS` | Layer-specific reductions in the routing capacity of the edges between the cells in the global routing graph, delimited by commas. Values range from 0 to 1. <br> (Default: `0.99,0,0,0,0,0`)
-| `FP_IO_HLAYER`  | The metal layer on which to place the io pins horizontally (top and bottom of the die). <br>(Default: `met3`)|
-| `FP_IO_VLAYER`  | The metal layer on which to place the io pins vertically (sides of the die) <br> (Default: `met2`)|
-| `RT_MIN_LAYER`  | The lowest metal layer to route on. <br>(Default: `met1`)|
-| `RT_MAX_LAYER`  | The highest metal layer to route on. <br> (Default: `met5`)|
+| `FP_PDN_RAIL_OFFSET` | Defines the rail offset for met1 used in PDN. <br> (Example: `0`) | |
+| `FP_PDN_VWIDTH` | Defines the strap width for the vertical layer used in PDN. <br> (Example: `1.6`) | |
+| `FP_PDN_HWIDTH` | Defines the strap width for the horizontal layer used in PDN. <br> (Example: `1.6`) | |
+| `FP_PDN_CORE_RING_VWIDTH` | Defines the vertical width for the vertical layer used to create the core ring in the PDN. <br> (Example: `20`) | |
+| `FP_PDN_CORE_RING_HWIDTH` | Defines the horizontal width for the horizontal layer used to create the core ring in the PDN. <br> (Example: `20`) | |
+| `FP_PDN_CORE_RING_VSPACING` | Defines the spacing for the vertical layer used to create the core ring in the PDN. <br> (Example: `5`) | |
+| `FP_PDN_CORE_RING_HSPACING` | Defines the spacing for the horizontal layer used to create the core ring in the PDN. <br> (Example: `5`) | |
+| `FP_PDN_CORE_RING_VOFFSET` | Defines the offset for the vertical layer used to create the core ring in the PDN. <br> (Example: `20`) | |
+| `FP_PDN_CORE_RING_HOFFSET` | Defines the offset for the horizontal layer used to create the core ring in the PDN. <br> (Example: `20`) | |
+| `WIRE_RC_LAYER` | The metal layer used in estimate parastics `set_wire_rc`. <br> (Example: `met1`) ||
+| `GLB_RT_LAYER_ADJUSTMENTS` | Layer-specific reductions in the routing capacity of the edges between the cells in the global routing graph, delimited by commas. Values range from 0 to 1. <br> (Example: `0.99,0,0,0,0,0`)
+| `FP_IO_HLAYER`  | The metal layer on which to place the io pins horizontally (top and bottom of the die). <br>(Example: `met3`)|
+| `FP_IO_VLAYER`  | The metal layer on which to place the io pins vertically (sides of the die) <br> (Example: `met2`)|
+| `RT_MIN_LAYER`  | The lowest metal layer to route on. <br>(Example: `met1`)|
+| `RT_MAX_LAYER`  | The highest metal layer to route on. <br> (Example: `met5`)|
 | `RCX_RULES_MIN` | OpenRCX rules at the minimum corner. (Optional) |
 | `RCX_RULES` | OpenRCX rules at the nominal corner. |
 | `RCX_RULES_MAX` | OpenRCX rules at the maximum corner. (Optional) |
 
 
-## Standard cell library-specific variables
+## SCL-specific variables
 
 This section defines the necessary variables to configure a standard cell library for use with OpenLane:
 
@@ -87,12 +85,14 @@ This section defines the necessary variables to configure a standard cell librar
 | `PLACE_SITE_HEIGHT` | Defines the main site height. Used during floorplanning to generate the rows. |
 | `FP_WELLTAP_CELL` | Defines the tapcell to be used in tapcell insertion. <br> If this is not defined then tapcell insertion will be skipped but the flow will resume normally |
 | `FP_ENDCAP_CELL` | Defines the decapcell. Inserted during floorplanning at the sides of the design. |
-| `SYNTH_DRIVING_CELL` | Defines the cell to drive the input ports. Used in synthesis |
-| `SYNTH_DRIVING_CELL_PIN` | Defines the driving cell output pin. Used in synthesis |
+| `SYNTH_DRIVING_CELL`  | The cell to drive the input ports, used in synthesis and static timing analysis. <br>(Example: `sky130_fd_sc_hd__inv_1`)|
+| `SYNTH_DRIVING_CELL_PIN`  | The name of the `SYNTH_DRIVING_CELL`'s output pin. <br>(Default: `Y`)|
+| `SYNTH_CLK_DRIVING_CELL`  | An alternative cell with which to drive clock inputs. Can be left empty, where the SDC script will use `SYNTH_DRIVING_CELL` for clock inputs as well. |
+| `SYNTH_CLK_DRIVING_CELL_PIN`  | The name of the SYNTH_CLK_DRIVING_CELL output pin. Can be left empty, where the SDC script will use `SYNTH_DRIVING_CELL_PIN`. |
 | `SYNTH_CAP_LOAD` | Defines the capacitive load on the output ports in femtofarads. Used in synthesis |
-| `SYNTH_MIN_BUF_PORT` | Defines the buffer, followed by its input port and output port to be used by `ins_buf` statements by yosys. It inserts buffer cells into the design for directly connected wires. Example: `sky130_fd_sc_hd__buf_2 A X`  |
-| `SYNTH_TIEHI_PORT` | Defines the tie high cell followed by the port that implements the tie high functionality. Used in synthesis. Example: `sky130_fd_sc_hd__conb_1 HI` |
-| `SYNTH_TIELO_PORT` | Defines the tie low cell followed by the port that implements the tie high functionality. Used in synthesis. Example: `sky130_fd_sc_hd__conb_1 LO` |
+| `SYNTH_MIN_BUF_PORT` | Defines the buffer, followed by its input port and output port to be used by `ins_buf` statements by yosys. It inserts buffer cells into the design for directly connected wires. <br> (Example: `sky130_fd_sc_hd__buf_2 A X`  )|
+| `SYNTH_TIEHI_PORT` | Defines the tie high cell followed by the port that implements the tie high functionality. Used in synthesis. <br> (Example: `sky130_fd_sc_hd__conb_1 HI`)|
+| `SYNTH_TIELO_PORT` | Defines the tie low cell followed by the port that implements the tie high functionality. Used in synthesis. <br> (Example: `sky130_fd_sc_hd__conb_1 LO`)|
 | `CELL_CLK_PORT` | Defines the name of clk port of the flip flops and other cells. Used in CTS. |
 | `PL_LIB` | Points to the lib view used in time driven placement.  |
 | `FILL_CELL` | Defines the fill cell. Used in fill insertion. Can use a wild card to define a class of cells. Example `sky130_fd_sc_hd__fill_*` |
@@ -100,9 +100,10 @@ This section defines the necessary variables to configure a standard cell librar
 | `CELL_PAD` | Defines the number of sites to pad the cells lef views with. |
 | `CELL_PAD_EXCLUDE` | Defines the cells to exclude from padding. |
 | `CTS_ROOT_BUFFER` | Defines the cell inserted at the root of the clock tree. Used in CTS. |
-| `CLK_BUFFER` | Defines the clock buffer cell. Used in CTS. |
-| `CLK_BUFFER_INPUT` | Defines the clock buffer cell input port. Used in CTS. |
-| `CLK_BUFFER_OUTPUT` | Defines the clock buffer cell output port. Used in CTS. |
+| `ROOT_CLK_BUFFER` | Root clock buffer of the clock tree. <br> (Example: `sky130_fd_sc_hd__clkbuf_16`) |
+| `CLK_BUFFER` | Clock buffer used for inner nodes of the clock tree. <br> (Example: `sky130_fd_sc_hd__clkbuf_4`) |
+| `CLK_BUFFER_INPUT` | Input pin of the clock tree buffer. <br> (Example: `A`) |
+| `CLK_BUFFER_OUTPUT` | Output pin of the clock tree buffer. <br> (Example: `X`)|
 | `CTS_CLK_BUFFER_LIST` | Defines the list of clock buffers to be used in CTS. |
 | `CTS_MAX_CAP` | Defines the maximum capacitance, used in CTS. |
 | `FP_PDN_RAIL_WIDTH` | Defines the rail width for met1 used in PDN. |

--- a/env.py
+++ b/env.py
@@ -203,7 +203,7 @@ def issue_survey():
             status = "OK"
             try:
                 mismatches = verify_versions(
-                    no_tools=True, report_file=f, pdk="sky130A"
+                    no_tools=True, report_file=f, pdk=os.getenv("PDK") or "sky130A"
                 )
                 if mismatches:
                     status = "MISMATCH"

--- a/scripts/base.sdc
+++ b/scripts/base.sdc
@@ -1,4 +1,4 @@
-if {[info exists ::env(CLOCK_PORT)] && $::env(CLOCK_PORT) != ""} { 
+if {[info exists ::env(CLOCK_PORT)] && $::env(CLOCK_PORT) != ""} {
     create_clock [get_ports $::env(CLOCK_PORT)]  -name $::env(CLOCK_PORT)  -period $::env(CLOCK_PERIOD)
 } else {
     create_clock -name __VIRTUAL_CLK__ -period $::env(CLOCK_PERIOD)
@@ -11,20 +11,32 @@ puts "\[INFO\]: Setting input delay to: $input_delay_value"
 
 set_max_fanout $::env(SYNTH_MAX_FANOUT) [current_design]
 
-set clk_indx [lsearch [all_inputs] [get_port $::env(CLOCK_PORT)]]
-#set rst_indx [lsearch [all_inputs] [get_port resetn]]
-set all_inputs_wo_clk [lreplace [all_inputs] $clk_indx $clk_indx]
-#set all_inputs_wo_clk_rst [lreplace $all_inputs_wo_clk $rst_indx $rst_indx]
-set all_inputs_wo_clk_rst $all_inputs_wo_clk
+set clk_input [get_port $::env(CLOCK_PORT)]
+set clk_indx [lsearch [all_inputs] $clk_input]
+set all_inputs_wo_clk [lreplace [all_inputs] $clk_indx $clk_indx ""]
 
+#set rst_input [get_port resetn]
+#set rst_indx [lsearch [all_inputs] $rst_input]
+#set all_inputs_wo_clk_rst [lreplace $all_inputs_wo_clk $rst_indx $rst_indx ""]
+set all_inputs_wo_clk_rst $all_inputs_wo_clk
 
 # correct resetn
 set_input_delay $input_delay_value  -clock [get_clocks $::env(CLOCK_PORT)] $all_inputs_wo_clk_rst
 #set_input_delay 0.0 -clock [get_clocks $::env(CLOCK_PORT)] {resetn}
 set_output_delay $output_delay_value  -clock [get_clocks $::env(CLOCK_PORT)] [all_outputs]
 
-# TODO set this as parameter
-set_driving_cell -lib_cell $::env(SYNTH_DRIVING_CELL) -pin $::env(SYNTH_DRIVING_CELL_PIN) [all_inputs]
+if { ![info exists ::env(SYNTH_CLK_DRIVING_CELL)] } {
+    set ::env(SYNTH_CLK_DRIVING_CELL) $::env(SYNTH_DRIVING_CELL)
+}
+
+if { ![info exists ::env(SYNTH_CLK_DRIVING_CELL_PIN)] } {
+    set ::env(SYNTH_CLK_DRIVING_CELL_PIN) $::env(SYNTH_DRIVING_CELL_PIN)
+}
+
+set_driving_cell -lib_cell $::env(SYNTH_DRIVING_CELL) -pin $::env(SYNTH_DRIVING_CELL_PIN) $all_inputs_wo_clk_rst
+
+set_driving_cell -lib_cell $::env(SYNTH_CLK_DRIVING_CELL) -pin $::env(SYNTH_CLK_DRIVING_CELL_PIN) $clk_input
+
 set cap_load [expr $::env(SYNTH_CAP_LOAD) / 1000.0]
 puts "\[INFO\]: Setting load to: $cap_load"
 set_load  $cap_load [all_outputs]

--- a/scripts/libtrim.py
+++ b/scripts/libtrim.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python3
-# Copyright 2020-2021 Efabless Corporation
+# Copyright 2020-2022 Efabless Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -24,9 +24,7 @@ import click
 @click.option("-o", "--output", required=True, help="Output liberty file")
 @click.argument("input_lib_files", nargs=-1)
 def cli(cell_file, output, input_lib_files):
-    excluded_cells = list(
-        map(lambda x: x.strip(), open(cell_file).read().strip().split("\n"))
-    )
+    excluded_cells = [cell.strip() for cell in open(cell_file).read().strip().split("\n") if cell.strip() != ""]
 
     output_file_handle = open(output, "w")
 

--- a/scripts/libtrim.py
+++ b/scripts/libtrim.py
@@ -24,7 +24,11 @@ import click
 @click.option("-o", "--output", required=True, help="Output liberty file")
 @click.argument("input_lib_files", nargs=-1)
 def cli(cell_file, output, input_lib_files):
-    excluded_cells = [cell.strip() for cell in open(cell_file).read().strip().split("\n") if cell.strip() != ""]
+    excluded_cells = [
+        cell.strip()
+        for cell in open(cell_file).read().strip().split("\n")
+        if cell.strip() != ""
+    ]
 
     output_file_handle = open(output, "w")
 

--- a/scripts/openroad/pdn.tcl
+++ b/scripts/openroad/pdn.tcl
@@ -13,13 +13,13 @@
 # limitations under the License.
 #
 foreach lib $::env(LIB_SYNTH_COMPLETE) {
-	read_liberty $lib
+    read_liberty $lib
 }
 
 if { [info exists ::env(EXTRA_LIBS) ] } {
-	foreach lib $::env(EXTRA_LIBS) {
-		read_liberty $lib
-	}
+    foreach lib $::env(EXTRA_LIBS) {
+        read_liberty $lib
+    }
 }
 
 if {[catch {read_lef $::env(MERGED_LEF_UNPADDED)} errmsg]} {
@@ -52,7 +52,7 @@ if { $::env(FP_PDN_CHECK_NODES) } {
 
 if { $::env(FP_PDN_IRDROP) } {
     # set rc values
-    source $::env(SCRIPTS_DIR)/openroad/set_rc.tcl 
+    source $::env(SCRIPTS_DIR)/openroad/set_rc.tcl
     analyze_power_grid -net $::env(VDD_NET) -outfile $::env(PGA_RPT_FILE)
 }
 

--- a/scripts/openroad/pdn_cfg.tcl
+++ b/scripts/openroad/pdn_cfg.tcl
@@ -1,13 +1,4 @@
 # Power nets
-
-if { ! [info exists ::env(VDD_NET)] } {
-	set ::env(VDD_NET) $::env(VDD_PIN)
-}
-
-if { ! [info exists ::env(GND_NET)] } {
-	set ::env(GND_NET) $::env(GND_PIN)
-}
-
 if { [info exists ::env(FP_PDN_ENABLE_GLOBAL_CONNECTIONS)] } {
     if { $::env(FP_PDN_ENABLE_GLOBAL_CONNECTIONS) == 1 } {
         foreach power_pin $::env(STD_CELL_POWER_PINS) {
@@ -28,7 +19,7 @@ if { [info exists ::env(FP_PDN_ENABLE_GLOBAL_CONNECTIONS)] } {
 }
 
 if { $::env(FP_PDN_ENABLE_MACROS_GRID) == 1 &&
-     [info exists ::env(FP_PDN_MACRO_HOOKS)]} {
+    [info exists ::env(FP_PDN_MACRO_HOOKS)]} {
     set pdn_hooks [split $::env(FP_PDN_MACRO_HOOKS) ","]
     foreach pdn_hook $pdn_hooks {
         set instance_name [lindex $pdn_hook 0]
@@ -138,7 +129,7 @@ if { $::env(FP_PDN_ENABLE_RAILS) == 1 } {
     add_pdn_connect \
         -grid stdcell_grid \
         -layers "$::env(FP_PDN_RAILS_LAYER) $::env(FP_PDN_LOWER_LAYER)"
-} 
+}
 
 
 # Adds the core ring if enabled.

--- a/scripts/tcl_commands/routing.tcl
+++ b/scripts/tcl_commands/routing.tcl
@@ -258,6 +258,14 @@ proc gen_pdn {args} {
     set ::env(SAVE_DEF) [index_file $::env(floorplan_tmpfiles)/pdn.def]
     set ::env(PGA_RPT_FILE) [index_file $::env(floorplan_tmpfiles)/pdn.pga.rpt]
 
+    if { ! [info exists ::env(VDD_NET)] } {
+        set ::env(VDD_NET) $::env(VDD_PIN)
+    }
+
+    if { ! [info exists ::env(GND_NET)] } {
+        set ::env(GND_NET) $::env(GND_PIN)
+    }
+
     run_openroad_script $::env(SCRIPTS_DIR)/openroad/pdn.tcl \
         |& -indexed_log [index_file $::env(floorplan_logs)/pdn.log]
 

--- a/scripts/tcl_commands/synthesis.tcl
+++ b/scripts/tcl_commands/synthesis.tcl
@@ -51,6 +51,14 @@ proc run_yosys {args} {
         lappend ::env(LIB_SYNTH_COMPLETE_NO_PG) $lib_path
     }
 
+    set ::env(LIB_SYNTH_NO_PG) [list]
+    foreach lib $::env(LIB_SYNTH) {
+        set fbasename [file rootname [file tail $lib]]
+        set lib_path [index_file $::env(synthesis_tmpfiles)/$fbasename.no_pg.lib]
+        convert_pg_pins $lib $lib_path
+        lappend ::env(LIB_SYNTH_NO_PG) $lib_path
+    }
+
     try_catch $::env(SYNTH_BIN) \
         -c $::env(SYNTH_SCRIPT) \
         -l [index_file $::env(synthesis_logs)/synthesis.log] \

--- a/scripts/yosys/synth.tcl
+++ b/scripts/yosys/synth.tcl
@@ -334,7 +334,7 @@ proc run_strategy {output script ext} {
     insbuf -buf {*}$::env(SYNTH_MIN_BUF_PORT)
 
     tee -o "$::env(synth_report_prefix).$ext.chk.rpt" check
-    tee -o "$::env(synth_report_prefix).$ext.stat.rpt" stat -top $::env(DESIGN_NAME) -liberty [lindex $::env(LIB_SYNTH_COMPLETE_NO_PG) 0]
+    tee -o "$::env(synth_report_prefix).$ext.stat.rpt" stat -top $::env(DESIGN_NAME) -liberty [lindex $::env(LIB_SYNTH_NO_PG) 0]
     write_verilog -noattr -noexpr -nohex -nodec -defparam $output
     design -reset
 }

--- a/scripts/yosys/synth_top.tcl
+++ b/scripts/yosys/synth_top.tcl
@@ -58,7 +58,7 @@ if { [info exists ::env(VERILOG_FILES_BLACKBOX)] } {
 
 
 for { set i 0 } { $i < [llength $::env(VERILOG_FILES)] } { incr i } {
-  read_verilog {*}$vIdirsArgs [lindex $::env(VERILOG_FILES) $i]
+	read_verilog {*}$vIdirsArgs [lindex $::env(VERILOG_FILES) $i]
 }
 
 if { [info exists ::env(SYNTH_PARAMETERS) ] } {


### PR DESCRIPTION
+ Added two new variables: SYNTH_CLK_DRIVING_CELL, SYNTH_DRIVING_CELL_PIN, which are used in the sdc file so clocks specifically can be driven by a different cell
~ NO_PG now also generated for the excluded cells
~ Document PDK-specific variables properly
~ Magic -> 085131b
~ Fix verify_versions.py

---
These fixes are for asap7 and internal PDKs- I still can't get asap7 to work properly...