### PR TITLE
Fix Antenna Checkers, Magic Script Enhancements

### DIFF
--- a/designs/inverter/config.tcl
+++ b/designs/inverter/config.tcl
@@ -20,8 +20,6 @@ set ::env(FP_PDN_HPITCH) 25.0
 set ::env(FP_PDN_VOFFSET) 5.0
 set ::env(FP_PDN_HOFFSET) 5.0
 
-set ::env(DIODE_INSERTION_STRATEGY) 3
-
 set filename $::env(DESIGN_DIR)/$::env(PDK)_$::env(STD_CELL_LIBRARY)_config.tcl
 if { [file exists $filename] == 1} {
 	source $filename

--- a/docs/source/openlane_commands.md
+++ b/docs/source/openlane_commands.md
@@ -82,7 +82,7 @@ Most of the following commands' implementation exists in this [file][0]
 | `extract_core_dims` | | Extracts the core dimensions based on the existing set environment variables. The results are set into `CORE_WIDTH` and `CORE_HEIGHT`. |
 |    | `-log_path <path>` | The path to write the logs into. |
 | `run_spef_extraction` | | Runs SPEF extraction on the `::env(CURRENT_DEF)` file followed by Static Timing Analysis using OpenSTA. The results are reported under `<run_path>/reports/<step>/opensta_spef_*`. |
-| `run_antenna_check` | | Runs antenna checks based on the value of `::env(USE_ARC_ANTENNA_CHECK)` either calling `run_or_antenna_check` or `run_magic_antenna_check`. |
+| `run_antenna_check` | | Runs antenna checks based on the value of `::env(USE_ARC_ANTENNA_CHECK)`, either calling `run_or_antenna_check` or `run_magic_antenna_check`. |
 | `run_or_antenna_check` | | Runs antenna checks using OpenROAD's Antenna Rule Checker on the `::env(CURRENT_DEF)`, the result is saved in `<run_path>/reports/signoff/antenna.rpt`|
 | `save_state` | | Saves environment variables to  `<run_path>/config.tcl`, needed for -from -to|
 | `run_sta` | | Runs OpenSTA timing analysis on the current design, and produces a log under `/<run_path>/logs/<step>/` and timing reports under `/<run_path>/reports/<step>/`. |

--- a/docs/source/using_or_issue.md
+++ b/docs/source/using_or_issue.md
@@ -1,13 +1,13 @@
 # `or_issue.py`
-This script creates a reproducible, self-contained package of files to demonstrate OpenROAD behavior in a vaccum, suitable for filing issues.
+This script creates a reproducible, self-contained package of files to demonstrate Magic or OpenROAD behavior in a vaccum, suitable for filing issues.
 
-It creates a folder with all the needed files that you can inspect, then zip or tarball and pass on to https://github.com/The-OpenROAD-Project/OpenROAD.
+It creates a folder with all the needed files that you can inspect, then zip or tarball and pass on to https://github.com/RTimothyEdwards/magic or https://github.com/The-OpenROAD-Project/OpenROAD.
 
 # Warning about proprietary files
 When working with a proprietary PDK, also inspect the folder and ensure no proprietary data resulting ends up in there. This is *critical*, if something leaks, this scripts' authors take no responsibility and you are very much on your own. We will try our best to output warnings for your own good if something looks like a part of a proprietary PDK, but the absence of this message does not necessarily indicate that your folder is free of confidential material. 
 
 # Usage
-If you're using OpenLane 2021.12.17_05.07.41 or later, chances are, `or_issue.py` was automatically run for you if OpenROAD failed. You'll find a message in the log that says something along the lines of: `Reproducible packaged: Please tarball and upload <PATH> if you're going to submit an issue.` The path will be under the current run_path, i.e., ./designs/<design>/runs/<run_tag>/openroad_issue_reproducible. You can then tarball/zip and upload that file.
+If you're using OpenLane 2021.12.17 or later (OpenLane 2022.06.21 or later for Magic,) chances are, `or_issue.py` was automatically run for you if Magic or OpenROAD fail. You'll find a message in the log that says something along the lines of: `Reproducible packaged: Please tarball and upload <PATH> if you're going to submit an issue.` The path will be under the current run_path, i.e., ./designs/<design>/runs/<run_tag>/issue_reproducible. You can then tarball/zip and upload that file.
 
 ## Running or_issue.py manually
 You'll have to extract three key elements from the **verbose** logs (i.e. ./flow.tcl must be run with `-verbose`):
@@ -35,7 +35,8 @@ The three elements would be:
 Then you'd want to run this script as follows, from the root of the OpenLane Repo:
 ```sh
     python3 ./scripts/or_issue.py\
-        -s  ./scripts/openroad/droute.tcl\
+        --tool openroad\
+        --script ./scripts/openroad/droute.tcl\
         designs/spm/runs/RUN_2022.03.01_19.21.10/tmp/routing/17-fill.def
         # run path is implicitly specified by input def
 ```
@@ -45,12 +46,12 @@ Which will create a folder called `_build`, with a single subfolder. Ensure that
 You can then verify that the script worked by running:
 ```sh
     cd _build/<name of folder>
-    ./run
+    sh ./run.sh
 ```
 
-You can override the OpenROAD binary used as follows:
+You can override the Magic/OpenROAD binary used as follows:
 
 ```sh
     cd _build/config_TEST_fastestTestSet1_or_groute_packaged
-    OPENROAD_BIN=/usr/local/bin/whatever ./run
+    TOOL_BIN=/usr/local/bin/whatever sh ./run.sh
 ```

--- a/scripts/extract_antenna_violators.py
+++ b/scripts/extract_antenna_violators.py
@@ -12,42 +12,40 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import argparse
 import re
-
-parser = argparse.ArgumentParser(
-    description="extracts the list of violating nets from an ARC report file"
-)
-
-parser.add_argument("--report", "-i", required=True, help="report file")
-
-parser.add_argument(
-    "--output", "-o", required=True, help="output file to store results"
-)
-
-args = parser.parse_args()
-report_file_name = args.report
-out_file_name = args.output
-
-pattern = re.compile(r"\s*([\S+]+)\s*\([\S+]+\)\s*[\S+]+")
-
-vios_list = []
-current_net = ""
-printed = False
-
-with open(report_file_name, "r") as f:
-    for line in f:
-        m = pattern.match(line)
-        if m:
-            current_net = m.group(1)
-            printed = False
-
-        if "*" in line and not printed:
-            print(current_net)
-            vios_list.append(current_net + " ")
-            printed = True
+import click
 
 
-outFileOpener = open(out_file_name, "w")
-outFileOpener.write(" ".join(vios_list))
-outFileOpener.close()
+@click.command()
+@click.option("-o", "--output", required=True, help="Output file to store results.")
+@click.argument("report", nargs=1)
+def extract_antenna_violators(output, report):
+    """
+    Usage: extract_antenna_violators.py -o <output text file> <input ARC report>
+    Extracts the list of violating nets from an ARC report file"
+    """
+
+    pattern = re.compile(r"\s*([\S+]+)\s*\([\S+]+\)\s*[\S+]+")
+
+    vios_list = []
+    current_net = ""
+    printed = False
+
+    with open(report, "r") as f:
+        for line in f:
+            m = pattern.match(line)
+            if m is not None:
+                current_net = m.group(1)
+                printed = False
+
+            if "*" in line and not printed:
+                print(current_net)
+                vios_list.append(current_net + " ")
+                printed = True
+
+    with open(output, "w") as f:
+        f.write(" ".join(vios_list))
+
+
+if __name__ == "__main__":
+    extract_antenna_violators()

--- a/scripts/extract_antenna_violators.py
+++ b/scripts/extract_antenna_violators.py
@@ -44,7 +44,7 @@ def extract_antenna_violators(output, report):
                 printed = True
 
     with open(output, "w") as f:
-        f.write(" ".join(vios_list))
+        f.write("\n".join(vios_list))
 
 
 if __name__ == "__main__":

--- a/scripts/magic/antenna_check.tcl
+++ b/scripts/magic/antenna_check.tcl
@@ -21,23 +21,22 @@ if {  [info exist ::env(EXTRA_LEFS)] } {
 }
 def read $::env(CURRENT_DEF)
 load $::env(DESIGN_NAME) -dereference
-cd $::env(signoff_tmpfiles)
-select top cell
 
-# for now, do extraction anyway; can be optimized by reading the maglef ext
-# but getting many warnings
-if { ! [file exists $::env(DESIGN_NAME).ext] } {
-    extract do local
-    extract no capacitance
-    extract no coupling
-    extract no resistance
-    extract no adjust
-    if { ! $::env(LVS_CONNECT_BY_LABEL) } {
-        extract unique
-    }
-    # extract warn all
-    extract
-    feedback save $feedback_file
+set extdir $::env(signoff_tmpfiles)/magic_antenna_ext
+file mkdir $extdir
+cd $extdir
+
+select top cell
+extract do local
+extract no capacitance
+extract no coupling
+extract no resistance
+extract no adjust
+if { ! $::env(LVS_CONNECT_BY_LABEL) } {
+    extract unique
 }
+extract
+feedback save $::env(_tmp_feedback_file)
+
 antennacheck debug
 antennacheck

--- a/scripts/magic/extract_spice.tcl
+++ b/scripts/magic/extract_spice.tcl
@@ -25,7 +25,11 @@ if { [info exist ::env(MAGIC_EXT_USE_GDS)] && $::env(MAGIC_EXT_USE_GDS) } {
     def read $::env(CURRENT_DEF)
 }
 load $::env(DESIGN_NAME) -dereference
-cd $::env(signoff_results)/
+
+set extdir $::env(signoff_tmpfiles)/magic_spice_ext
+file mkdir $extdir
+cd $extdir
+
 extract do local
 extract no capacitance
 extract no coupling

--- a/scripts/odbpy/apply_def_template.py
+++ b/scripts/odbpy/apply_def_template.py
@@ -17,31 +17,30 @@ import click
 import defutil
 import shutil
 
+from reader import click_odb
+
 
 @click.command()
-@click.option("-t", "--def-template", "templatedef", required=True, help="Template DEF")
-@click.option("-l", "--lef", "lef", required=True, help="LEF file")
+@click.option("-t", "--def-template", required=True, help="Template DEF")
 @click.option("--log", "logfile", required=True, help="Log output file")
-@click.argument("userdef")
-def cli(templatedef, userdef, lef, logfile):
-    userDEF = userdef
-    templateDEF = templatedef
+@click_odb
+def cli(output, input_lef, input_def, def_template, logfile):
 
     defutil.replace_pins(
-        input_lef=lef,
+        input_lef=input_lef,
+        template_def=def_template,
+        source_def=input_def,
+        output_def=f"{input_def}.replace_pins.tmp",
         logpath=logfile,
-        template_def=templateDEF,
-        source_def=userDEF,
-        output_def=f"{userDEF}.replace_pins.tmp",
     )
 
     defutil.move_diearea(
-        template_def=templateDEF,
-        output_def=f"{userDEF}.replace_pins.tmp",
-        input_lef=lef,
+        input_lef=input_lef,
+        template_def=def_template,
+        output_def=f"{input_def}.replace_pins.tmp",
     )
 
-    shutil.copy(f"{userDEF}.replace_pins.tmp", userDEF)
+    shutil.copy(f"{input_def}.replace_pins.tmp", output)
 
 
 if __name__ == "__main__":

--- a/scripts/odbpy/diodes.py
+++ b/scripts/odbpy/diodes.py
@@ -418,5 +418,7 @@ def replace_fake(fake_diode, true_diode, violations_file, output, input_lef, inp
     assert odb.write_def(reader.block, output) == 1
 
 
+cli.add_command(replace_fake)
+
 if __name__ == "__main__":
     cli()

--- a/scripts/openroad/antenna_check.tcl
+++ b/scripts/openroad/antenna_check.tcl
@@ -23,4 +23,4 @@ if {[catch {read_def $::env(CURRENT_DEF)} errmsg]} {
 }
 
 # start checking antennas and generate a detail report
-check_antennas -report_file $::env(ANTENNA_CHECKER_REPORT)
+check_antennas -report_file $::env(_tmp_antenna_checker_rpt)

--- a/scripts/openroad/antenna_check.tcl
+++ b/scripts/openroad/antenna_check.tcl
@@ -22,8 +22,5 @@ if {[catch {read_def $::env(CURRENT_DEF)} errmsg]} {
     exit 1
 }
 
-# load layers' antenna rules into ARC
-#load_antenna_rules
-
 # start checking antennas and generate a detail report
-check_antennas -report_file $::env(signoff_reports)/antenna.rpt
+check_antennas -report_file $::env(ANTENNA_CHECKER_REPORT)

--- a/scripts/or_issue.py
+++ b/scripts/or_issue.py
@@ -22,398 +22,402 @@ import os
 import re
 import sys
 import glob
+import click
 import shutil
 import pathlib
-import argparse
+import textwrap
 from typing import List
 from collections import deque
 from os.path import join, abspath, dirname, basename, isdir, relpath
 
 openlane_path = abspath(dirname(dirname(__file__)))
 
-parser = argparse.ArgumentParser(description="OpenROAD Issue Packager")
-parser.add_argument(
-    "--or-script",
+
+@click.command()
+@click.option(
+    "--script",
     "-s",
     required=True,
-    help="Path to the OpenROAD script causing the failure: i.e. ./scripts/openroad/antenna_check.tcl, ./scripts/openroad/pdn.tcl, etc. [required]",
+    help="Path to the Tcl script causing the failure: i.e. ./scripts/openroad/antenna_check.tcl, ./scripts/magic/drc.tcl, etc. [required]",
 )
-parser.add_argument(
+@click.option(
     "--pdk-root",
     required=(os.getenv("PDK_ROOT") is None),
     default=os.getenv("PDK_ROOT"),
     help="Path to the PDK root [required if environment variable PDK_ROOT is not set]",
 )
-parser.add_argument(
+@click.option(
     "--run-path",
     "-r",
     default=None,
     help="The run path. If not specified, the script will attempt to discern it from the input_def path.",
 )
-parser.add_argument(
+@click.option(
     "--output",
     "-o",
+    "save_def",
     default="./out.def",
     help="Name of def file to be generated [default: ./out.def]",
 )
-parser.add_argument(
-    "--verbose",
-    action="store_true",
+@click.option(
+    "--verbose/--not-verbose",
     default=False,
     help="Verbose output of all found environment variables.",
 )
-parser.add_argument(
-    "--netlist",
-    "-n",
-    action="store_true",
+@click.option(
+    "--netlist/--def",
+    "-n/-D",
     default=False,
     help="Use the netlist as an input instead of a def file. Useful for evaluating some scripts such as floorplan.tcl.",
 )
-parser.add_argument("--output-dir", default=None, help="Output to this directory.")
-parser.add_argument(
-    "input",
-    help="Name of input into the OR script (usually denoted by environment variable CURRENT_NETLIST or CURRENT_DEF: get it from the logs) [required]",
+@click.option("--output-dir", default=None, help="Output to this directory.")
+@click.option(
+    "--tool",
+    type=click.Choice(["openroad", "magic"]),
+    help="The tool used for the desired Tcl script. [required]",
 )
-args = parser.parse_args()
-
-OPEN_SOURCE_PDKS = ["sky130A"]
-print(
+@click.argument("input_file")
+def issue(
+    script, pdk_root, run_path, save_def, verbose, netlist, output_dir, tool, input_file
+):
     """
-or_issue.py OpenROAD Issue Packager
+    Issue packager for Tcl-based tools (currently: OpenROAD, Magic)
 
-EFABLESS CORPORATION AND ALL AUTHORS OF THE OPENLANE PROJECT SHALL NOT BE HELD
-LIABLE FOR ANY LEAKS THAT MAY OCCUR TO ANY PROPRIETARY DATA AS A RESULT OF USING
-THIS SCRIPT. THIS SCRIPT IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OR
-CONDITIONS OF ANY KIND.
+    The or_ prefix is an artifact name because this used to only work with OpenROAD.
 
-BY USING THIS SCRIPT, YOU ACKNOWLEDGE THAT YOU FULLY UNDERSTAND THIS DISCLAIMER
-AND ALL IT ENTAILS.
-""",
-    file=sys.stderr,
-)
+    Usage: or_issue.py [OPTIONS] <input_file>
 
-script_path = abspath(args.or_script)
-pdk_root = abspath(args.pdk_root)
-or_scripts_path = join(openlane_path, "scripts", "openroad")
-use_netlist = args.netlist
-input_file = abspath(args.input)
-run_path = None
-if args.run_path is not None:
-    run_path = abspath(args.run_path)
-else:
-    current_dir = dirname(input_file)
-    while current_dir != "/":
-        if "config.tcl" in os.listdir(current_dir):
-            run_path = current_dir
-            break
-        current_dir = dirname(current_dir)
+    input_file: Name of input into the script (usually denoted by environment variable CURRENT_NETLIST or CURRENT_DEF: get it from the logs)
+    """
 
-    if run_path is None:
-        print(
-            f"[ERR] No run path provided and {input_file} is not in the run path.",
-            file=sys.stderr,
-        )
-        exit(os.EX_USAGE)
-    else:
-        print(f"[INF] Resolved run path to {run_path}.")
-
-save_def = args.output
-verbose = args.verbose
-
-if not os.path.exists(input_file):
-    print(f"[ERR] {input_file} not found.", file=sys.stderr)
-    exit(os.EX_NOINPUT)
-
-if not script_path.startswith(or_scripts_path):
+    OPEN_SOURCE_PDKS = ["sky130A", "sky130B"]
     print(
-        f"[ERR] The OpenROAD script {script_path} does not appear to be in {or_scripts_path}.",
+        textwrap.dedent(
+            """\
+            OpenLane TCL Issue Packager
+
+            EFABLESS CORPORATION AND ALL AUTHORS OF THE OPENLANE PROJECT SHALL NOT BE HELD
+            LIABLE FOR ANY LEAKS THAT MAY OCCUR TO ANY PROPRIETARY DATA AS A RESULT OF USING
+            THIS SCRIPT. THIS SCRIPT IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OR
+            CONDITIONS OF ANY KIND.
+
+            BY USING THIS SCRIPT, YOU ACKNOWLEDGE THAT YOU FULLY UNDERSTAND THIS DISCLAIMER
+            AND ALL IT ENTAILS.
+            """
+        ),
         file=sys.stderr,
     )
-    exit(os.EX_CONFIG)
 
-if not os.path.exists(run_path) and os.path.isdir(run_path):
-    print(f"[ERR] The run path {run_path} is not a valid folder.", file=sys.stderr)
-    exit(os.EX_CONFIG)
+    scripts_path = join(openlane_path, "scripts", tool)
+    if run_path is not None:
+        run_path = abspath(run_path)
+    else:
+        current_dir = dirname(input_file)
+        while current_dir != "/":
+            if "config.tcl" in os.listdir(current_dir):
+                run_path = current_dir
+                break
+            current_dir = dirname(current_dir)
 
-run_name = basename(run_path)
+        if run_path is None:
+            print(
+                f"[ERR] No run path provided and {input_file} is not in the run path.",
+                file=sys.stderr,
+            )
+            exit(os.EX_USAGE)
+        else:
+            print(f"[INF] Resolved run path to {run_path}.")
 
-# Phase 1: Read All Environment Variables
-# pdk_config = join(args.pdk_root, "sky130A", "libs.tech", "openlane", "config.tcl")
-print("Parsing config file(s)…", file=sys.stderr)
-run_config = join(run_path, "config.tcl")
-
-env = {}
-
-
-def read_env(config_path: str, from_path: str, input_env={}) -> dict:
-    rx = r"\s*set\s*::env\((.+?)\)\s*(.+)"
-    env = input_env.copy()
-    string_data = ""
-    try:
-        string_data = open(config_path).read()
-    except FileNotFoundError:
-        print(
-            f"[ERR] File {config_path} not found. The path {from_path} may have been specified incorrectly.",
-            file=sys.stderr,
-        )
+    if not os.path.exists(input_file):
+        print(f"[ERR] {input_file} not found.", file=sys.stderr)
         exit(os.EX_NOINPUT)
 
-    # Process \ at ends of lines, remove semicolons
-    entries = string_data.split("\n")
-    i = 0
-    while i < len(entries):
-        if not entries[i].endswith("\\"):
-            if entries[i].endswith(";"):
-                entries[i] = entries[i][:-1]
-            i += 1
-            continue
-        entries[i] = entries[i][:-1] + entries[i + 1]
-        del entries[i + 1]
-
-    for entry in entries:
-        match = re.match(rx, entry)
-        if match is None:
-            continue
-        name = match[1]
-        value = match[2]
-        # remove double quotes/{}
-        value = value.strip('"')
-        value = value.strip("{}")
-        env[name] = value
-
-    return env
-
-
-env = read_env(run_config, "Run Path")  # , read_env(pdk_config, "PDK Root"))
-
-# Cannot be reliably read from config.tcl
-input_key = "CURRENT_DEF"
-if use_netlist:
-    input_key = "CURRENT_NETLIST"
-env[input_key] = input_file
-env["SAVE_DEF"] = save_def
-
-
-# Phase 2: Set up destination folder
-script_basename = basename(args.or_script)[:-4]
-destination_folder = args.output_dir or abspath(
-    join(".", "_build", f"{run_name}_{script_basename}_packaged")
-)
-print(f"Setting up {destination_folder}…", file=sys.stderr)
-
-
-def mkdirp(path):
-    return pathlib.Path(path).mkdir(parents=True, exist_ok=True)
-
-
-try:
-    shutil.rmtree(destination_folder)
-except FileNotFoundError:
-    pass
-
-mkdirp(destination_folder)
-
-# Phase 3: Process TCL Scripts To Find Full List Of Files
-tcls_to_process = deque([script_path])
-
-
-def shift(deque):
-    try:
-        return deque.popleft()
-    except Exception:
-        return None
-
-
-or_script_counter = 0
-
-
-def get_or_script():
-    global or_script_counter
-    value = f"OR_SCRIPT_{or_script_counter}"
-    or_script_counter += 1
-    return value
-
-
-env_keys_used = set()
-tcls = set()
-current = shift(tcls_to_process)
-while current is not None:
-    env_key = get_or_script()
-    env_keys_used.add(env_key)
-    env[env_key] = current
-
-    try:
-        script = open(current).read()
-
-        for key, value in env.items():
-            key_accessor = re.compile(rf"((\$::env\({re.escape(key)}\))([/\-\w\.]*))")
-            for use in key_accessor.findall(script):
-                use: List[str]
-                full, accessor, extra = use
-                env_keys_used.add(key)
-
-                value_substituted = full.replace(accessor, value)
-
-                if value_substituted.endswith(".tcl") or value_substituted.endswith(
-                    ".sdc"
-                ):
-                    if value_substituted not in tcls:
-                        tcls.add(value_substituted)
-                        tcls_to_process.append(value_substituted)
-    except Exception:
+    if not script.startswith(scripts_path):
         print(
-            f"[WRN] {current} was not found, might be a product. Skipping",
+            f"[ERR] The {tool} script {script} does not appear to be in {scripts_path}.",
             file=sys.stderr,
         )
+        exit(os.EX_CONFIG)
 
-    current = shift(tcls_to_process)
+    if not os.path.exists(run_path) and os.path.isdir(run_path):
+        print(f"[ERR] The run path {run_path} is not a valid folder.", file=sys.stderr)
+        exit(os.EX_CONFIG)
 
-# Phase 4: Copy The Files
-final_env = {}
+    run_name = basename(run_path)
 
-pdk_path = join(destination_folder, "pdk")
-openlane_misc_path = join(destination_folder, "openlane")
+    # Phase 1: Read All Environment Variables
+    # pdk_config = join(args.pdk_root, "sky130A", "libs.tech", "openlane", "config.tcl")
+    print("Parsing config file(s)…", file=sys.stderr)
+    run_config = join(run_path, "config.tcl")
 
-warnings = []
+    env = {}
 
+    def read_env(config_path: str, from_path: str, input_env={}) -> dict:
+        rx = r"\s*set\s*::env\((.+?)\)\s*(.+)"
+        env = input_env.copy()
+        string_data = ""
+        try:
+            string_data = open(config_path).read()
+        except FileNotFoundError:
+            print(
+                f"[ERR] File {config_path} not found. The path {from_path} may have been specified incorrectly.",
+                file=sys.stderr,
+            )
+            exit(os.EX_NOINPUT)
 
-def copy(frm, to):
-    parents = dirname(to)
-    mkdirp(parents)
+        # Process \ at ends of lines, remove semicolons
+        entries = string_data.split("\n")
+        i = 0
+        while i < len(entries):
+            if not entries[i].endswith("\\"):
+                if entries[i].endswith(";"):
+                    entries[i] = entries[i][:-1]
+                i += 1
+                continue
+            entries[i] = entries[i][:-1] + entries[i + 1]
+            del entries[i + 1]
 
-    def do_copy():
-        if isdir(frm):
-            shutil.copytree(frm, to)
-        else:
-            shutil.copyfile(frm, to)
+        for entry in entries:
+            match = re.match(rx, entry)
+            if match is None:
+                continue
+            name = match[1]
+            value = match[2]
+            # remove double quotes/{}
+            value = value.strip('"')
+            value = value.strip("{}")
+            env[name] = value
+
+        return env
+
+    env = read_env(run_config, "Run Path")  # , read_env(pdk_config, "PDK Root"))
+
+    # Cannot be reliably read from config.tcl
+    input_key = "CURRENT_DEF"
+    if netlist:
+        input_key = "CURRENT_NETLIST"
+    env[input_key] = input_file
+    env["SAVE_DEF"] = save_def
+
+    # Phase 2: Set up destination folder
+    script_basename = basename(script)[:-4]
+    destination_folder = output_dir or abspath(
+        join(".", "_build", f"{run_name}_{script_basename}_packaged")
+    )
+    print(f"Setting up {destination_folder}…", file=sys.stderr)
+
+    def mkdirp(path):
+        return pathlib.Path(path).mkdir(parents=True, exist_ok=True)
 
     try:
-        incomplete_matches = glob.glob(frm + "*")
+        shutil.rmtree(destination_folder)
+    except FileNotFoundError:
+        pass
 
-        if len(incomplete_matches) == 0:
-            raise Exception()
-        elif len(incomplete_matches) != 1 or incomplete_matches[0] != frm:
-            # Prefix For Other Files
-            for match in incomplete_matches:
-                if match == frm:
-                    # If it's both a file AND a prefix for other files
-                    do_copy()
-                else:
-                    new_frm = match
-                    new_to = to + new_frm[len(frm) :]
-                    copy(new_frm, new_to)
-        else:
-            do_copy()
-    except Exception as e:
-        warnings.append(f"[WRN] Couldn't copy {frm}: {e}. Skipped.")
+    mkdirp(destination_folder)
 
+    # Phase 3: Process TCL Scripts To Find Full List Of Files
+    tcls_to_process = deque([script])
 
-if verbose:
-    print("\nProcessing environment variables…\n---", file=sys.stderr)
-for key in env_keys_used:
-    value = env[key]
-    if verbose:
-        print(f"{key}: {value}")
-    if value == input_file:
-        final_path = join(destination_folder, "in.def")
-        from_path = value
-        copy(from_path, final_path)
+    def shift(deque):
+        try:
+            return deque.popleft()
+        except Exception:
+            return None
 
-        final_env[input_key] = "./in.def"
-    elif value.startswith(run_path):
-        relative = relpath(value, run_path)
-        final_value = join(".", relative)
-        final_path = join(destination_folder, final_value)
-        from_path = value
-        copy(from_path, final_path)
+    script_counter = 0
 
-        final_env[key] = final_value
-    elif value.startswith(pdk_root):
-        nonfree_warning = True
-        value_components = value.split(os.path.sep)
-        for pdk in OPEN_SOURCE_PDKS:
-            if pdk in value_components:
-                nonfree_warning = False
-        if nonfree_warning:
-            warnings.append(
-                f"[WRN] {value} appears to be a confidential PDK file. ENSURE THAT YOU INSPECT THE RESULTS."
+    def get_script():
+        nonlocal script_counter
+        value = f"PACKAGED_SCRIPT_{script_counter}"
+        script_counter += 1
+        return value
+
+    env_keys_used = set()
+    tcls = set()
+    current = shift(tcls_to_process)
+    while current is not None:
+        env_key = get_script()
+        env_keys_used.add(env_key)
+        env[env_key] = current
+
+        try:
+            script = open(current).read()
+
+            for key, value in env.items():
+                key_accessor = re.compile(
+                    rf"((\$::env\({re.escape(key)}\))([/\-\w\.]*))"
+                )
+                for use in key_accessor.findall(script):
+                    use: List[str]
+                    full, accessor, extra = use
+                    env_keys_used.add(key)
+
+                    value_substituted = full.replace(accessor, value)
+
+                    if value_substituted.endswith(".tcl") or value_substituted.endswith(
+                        ".sdc"
+                    ):
+                        if value_substituted not in tcls:
+                            tcls.add(value_substituted)
+                            tcls_to_process.append(value_substituted)
+        except Exception:
+            print(
+                f"[WRN] {current} was not found, might be a product. Skipping",
+                file=sys.stderr,
             )
-        relative = relpath(value, pdk_root)
-        final_value = join("pdk", relative)
-        final_path = join(destination_folder, final_value)
-        copy(value, final_path)
-        final_env[key] = final_value
-    elif value.startswith("/openlane"):
-        relative = relpath(value, "/openlane")
-        final_value = join("openlane", relative)
-        final_path = join(destination_folder, final_value)
-        from_path = value.replace("/openlane", openlane_path)
-        if value != "/openlane/scripts":  # Too many files to copy otherwise
+
+        current = shift(tcls_to_process)
+
+    # Phase 4: Copy The Files
+    final_env = {}
+
+    warnings = []
+
+    def copy(frm, to):
+        parents = dirname(to)
+        mkdirp(parents)
+
+        def do_copy():
+            if isdir(frm):
+                shutil.copytree(frm, to)
+            else:
+                shutil.copyfile(frm, to)
+
+        try:
+            incomplete_matches = glob.glob(frm + "*")
+
+            if len(incomplete_matches) == 0:
+                raise Exception()
+            elif len(incomplete_matches) != 1 or incomplete_matches[0] != frm:
+                # Prefix For Other Files
+                for match in incomplete_matches:
+                    if match == frm:
+                        # If it's both a file AND a prefix for other files
+                        do_copy()
+                    else:
+                        new_frm = match
+                        new_to = to + new_frm[len(frm) :]
+                        copy(new_frm, new_to)
+            else:
+                do_copy()
+        except Exception as e:
+            warnings.append(f"[WRN] Couldn't copy {frm}: {e}. Skipped.")
+
+    if verbose:
+        print("\nProcessing environment variables…\n---", file=sys.stderr)
+    for key in env_keys_used:
+        value = env[key]
+        if verbose:
+            print(f"{key}: {value}")
+        if value == input_file:
+            final_path = join(destination_folder, "in.def")
+            from_path = value
             copy(from_path, final_path)
-        final_env[key] = final_value
-    elif value.startswith("/"):
-        final_value = value[1:]
-        final_path = join(destination_folder, final_value)
-        copy(value, final_path)
-        final_env[key] = final_value
-    else:
-        final_env[key] = value
-if verbose:
-    print("---\n", file=sys.stderr)
 
-for warning in warnings:
-    print(warning)
-print("\n")
+            final_env[input_key] = "./in.def"
+        elif value.startswith(run_path):
+            relative = relpath(value, run_path)
+            final_value = join(".", relative)
+            final_path = join(destination_folder, final_value)
+            from_path = value
+            copy(from_path, final_path)
 
-# Phase 5: Create Environment Set/Run Files
-run_shell = join(destination_folder, "run.sh")
-with open(run_shell, "w") as f:
-    env_list = "\n".join(
-        [f"export {key}='{value}';" for key, value in final_env.items()]
-    )
-    f.write(
-        f"""\
-#!/bin/sh
-dir=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
-cd $dir;
-{env_list}
-OPENROAD_BIN=${{OPENROAD_BIN:-openroad}}
-$OPENROAD_BIN -exit $OR_SCRIPT_0
-    """
-    )
-os.chmod(run_shell, 0o755)
+            final_env[key] = final_value
+        elif value.startswith(pdk_root):
+            nonfree_warning = True
+            value_components = value.split(os.path.sep)
+            for pdk in OPEN_SOURCE_PDKS:
+                if pdk in value_components:
+                    nonfree_warning = False
+            if nonfree_warning:
+                warnings.append(
+                    f"[WRN] {value} appears to be a confidential PDK file. ENSURE THAT YOU INSPECT THE RESULTS."
+                )
+            relative = relpath(value, pdk_root)
+            final_value = join("pdk", relative)
+            final_path = join(destination_folder, final_value)
+            copy(value, final_path)
+            final_env[key] = final_value
+        elif value.startswith("/openlane"):
+            relative = relpath(value, "/openlane")
+            final_value = join("openlane", relative)
+            final_path = join(destination_folder, final_value)
+            from_path = value.replace("/openlane", openlane_path)
+            if value != "/openlane/scripts":  # Too many files to copy otherwise
+                copy(from_path, final_path)
+            final_env[key] = final_value
+        elif value.startswith("/"):
+            final_value = value[1:]
+            final_path = join(destination_folder, final_value)
+            copy(value, final_path)
+            final_env[key] = final_value
+        else:
+            final_env[key] = value
+    if verbose:
+        print("---\n", file=sys.stderr)
 
-run_tcl = join(destination_folder, "run.tcl")
-with open(run_tcl, "w") as f:
-    env_list = "\n".join(
-        [f"set ::env({key}) {{{value}}};" for key, value in final_env.items()]
-    )
-    f.write(
-        f"""\
-#!/usr/bin/env openroad
-{env_list}
-source $::env(OR_SCRIPT_0)
-    """
-    )
-os.chmod(run_tcl, 0o755)
+    for warning in warnings:
+        print(warning)
+    print("\n")
 
-gdb_env = join(destination_folder, "env.gdb")
-with open(gdb_env, "w") as f:
-    env_list = "\n".join([f"set env {key} {value}" for key, value in final_env.items()])
-    f.write(
-        f"""\
-{env_list}
-    """
-    )
+    # Phase 5: Create Environment Set/Run Files
+    run_shell = join(destination_folder, "run.sh")
+    with open(run_shell, "w") as f:
+        env_list = "\n                ".join(
+            [f"export {key}='{value}';" for key, value in final_env.items()]
+        )
+        run_cmd = None
+        if tool == "openroad":
+            run_cmd = "$TOOL_BIN -exit $PACKAGED_SCRIPT_0"
+        elif tool == "magic":
+            run_cmd = "$TOOL_BIN -dnull -noconsole < $PACKAGED_SCRIPT_0"
+        f.write(
+            textwrap.dedent(
+                f"""\
+                #!/bin/sh
+                dir=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
+                cd $dir;
+                {env_list}
+                TOOL_BIN=${{TOOL_BIN:-{tool}}}
+                {run_cmd}
+                """
+            )
+        )
+    os.chmod(run_shell, 0o755)
 
-lldb_env = join(destination_folder, "env.lldb")
-with open(lldb_env, "w") as f:
-    env_list = "\n".join([f"env {key}={value}" for key, value in final_env.items()])
-    f.write(
-        f"""\
-{env_list}
-    """
-    )
+    if tool == "openroad":
+        run_tcl = join(destination_folder, "run.tcl")
+        with open(run_tcl, "w") as f:
+            env_list = "\n                    ".join(
+                [f"set ::env({key}) {{{value}}};" for key, value in final_env.items()]
+            )
+            f.write(
+                textwrap.dedent(
+                    f"""\
+                    #!/usr/bin/env openroad
+                    {env_list}
+                    source $::env(PACKAGED_SCRIPT_0)
+                    """
+                )
+            )
+        os.chmod(run_tcl, 0o755)
 
-print("Done.", file=sys.stderr)
-print(destination_folder)
+    gdb_env = join(destination_folder, "env.gdb")
+    with open(gdb_env, "w") as f:
+        env_list = "\n".join(
+            [f"set env {key} {value}" for key, value in final_env.items()]
+        )
+        f.write(env_list)
+
+    lldb_env = join(destination_folder, "env.lldb")
+    with open(lldb_env, "w") as f:
+        env_list = "\n".join([f"env {key}={value}" for key, value in final_env.items()])
+        f.write(env_list)
+
+    print("Done.", file=sys.stderr)
+    print(destination_folder)
+
+
+if __name__ == "__main__":
+    issue()

--- a/scripts/tcl_commands/all.tcl
+++ b/scripts/tcl_commands/all.tcl
@@ -1000,14 +1000,19 @@ proc run_or_antenna_check {args} {
     puts_info "Running OpenROAD Antenna Rule Checker..."
 
     set log [index_file $::env(signoff_logs)/antenna.log]
-    set ::env(ANTENNA_CHECKER_REPORT) [index_file $::env(signoff_reports)/antenna.rpt]
-    set ::env(ANTENNA_VIOLATOR_LIST) [index_file $::env(signoff_reports)/antenna_violators.rpt]
 
+    set antenna_checker_rpt [index_file $::env(signoff_reports)/antenna.rpt]
+    set antenna_violators_rpt [index_file $::env(signoff_reports)/antenna_violators.rpt]
+
+    set ::env(_tmp_antenna_checker_rpt) $antenna_checker_rpt
     run_openroad_script $::env(SCRIPTS_DIR)/openroad/antenna_check.tcl -indexed_log $log
+    unset ::env(_tmp_antenna_checker_rpt)
 
     try_catch $::env(OPENROAD_BIN) -python $::env(SCRIPTS_DIR)/extract_antenna_violators.py\
-        --output $::env(ANTENNA_VIOLATOR_LIST)\
-        $::env(ANTENNA_CHECKER_REPORT)
+        --output $antenna_violators_rpt\
+        $antenna_checker_rpt
+
+    set ::env(ANTENNA_VIOLATOR_LIST) $antenna_violators_rpt
 
     TIMER::timer_stop
     exec echo "[TIMER::get_runtime]" | python3 $::env(SCRIPTS_DIR)/write_runtime.py "antenna check - openroad"

--- a/scripts/tcl_commands/checkers.tcl
+++ b/scripts/tcl_commands/checkers.tcl
@@ -124,9 +124,9 @@ proc check_slew_violations {args} {
 
     set check_slew [catch {exec grep "slew violation count 0" $report_file}]
     if { $check_slew } {
+        set violated 1
         if { $quit_on_vios } {
             puts_err "There are max slew violations in the design at the $corner corner. Please refer to '$report_file_relative'."
-            set violated 1
         } else {
             puts_warn "There are max slew violations in the design at the $corner corner. Please refer to '$report_file_relative'."
         }
@@ -134,9 +134,9 @@ proc check_slew_violations {args} {
 
     set check_fanout [catch {exec grep "fanout violation count 0" $report_file}]
     if { $check_fanout } {
+        set violated 1
         if { $quit_on_vios } {
             puts_err "There are max fanout violations in the design at the $corner corner. Please refer to '$report_file_relative'."
-            set violated 1
         } else {
             puts_warn "There are max fanout violations in the design at the $corner corner. Please refer to '$report_file_relative'."
         }
@@ -144,16 +144,18 @@ proc check_slew_violations {args} {
 
     set check_capacitance [catch {exec grep "cap violation count 0" $report_file}]
     if { $check_capacitance } {
+        set violated 1
         if { $quit_on_vios } {
             puts_err "There are max capacitance violations in the design at the $corner corner. Please refer to '$report_file_relative'."
-            set violated 1
         } else {
             puts_warn "There are max capacitance violations in the design at the $corner corner. Please refer to '$report_file_relative'."
         }
     }
 
     if { $violated } {
-        flow_fail
+        if { $quit_on_vios } {
+            flow_fail
+        }
     } else {
         puts_info "There are no max slew, max fanout or max capacitance violations in the design at the $corner corner."
     }

--- a/scripts/tcl_commands/floorplan.tcl
+++ b/scripts/tcl_commands/floorplan.tcl
@@ -145,6 +145,7 @@ proc place_io_ol {args} {
     set_if_unset arg_values(-extra_args) ""
 
     try_catch $::env(OPENROAD_BIN) -python $::env(SCRIPTS_DIR)/odbpy/io_place.py\
+        --output $arg_values(-output_def)\
         --input-lef $arg_values(-lef)\
         --config $arg_values(-cfg)\
         --hor-layer $arg_values(-horizontal_layer)\
@@ -155,7 +156,6 @@ proc place_io_ol {args} {
         --ver-extension $arg_values(-vertical_ext)\
         --length $arg_values(-length)\
         {*}$flags_map(-unmatched_error)\
-        -o $arg_values(-output_def)\
         {*}$arg_values(-extra_args)\
         $arg_values(-def) |& tee [index_file $::env(floorplan_logs)/place_io_ol.log] $::env(TERMINAL_OUTPUT)
 
@@ -200,7 +200,6 @@ proc place_contextualized_io {args} {
         --input-lef $::env(MERGED_LEF_UNPADDED) \
         --top-def $::env(placement_tmpfiles)/top_level.def \
         --top-lef $::env(placement_tmpfiles)/top_level.lef \
-        -o $::env(SAVE_DEF) \
         $prev_def |& tee [index_file $::env(floorplan_logs)/io.contextualize.log]
 
     puts_info "Custom floorplan created."
@@ -257,9 +256,10 @@ proc apply_def_template {args} {
         set def [index_file $::env(floorplan_tmpfiles)/apply_def_template.def]
         puts_info "Applying DEF template. See log: $log"
         try_catch $::env(OPENROAD_BIN) -python $::env(SCRIPTS_DIR)/odbpy/apply_def_template.py\
-            --lef $::env(MERGED_LEF) \
+            --output $::env(CURRENT_DEF)\
+            --log $log\
             --def-template $::env(FP_DEF_TEMPLATE)\
-            --log $log \
+            --input-lef $::env(MERGED_LEF) \
             $::env(CURRENT_DEF)
     }
 

--- a/scripts/tcl_commands/magic.tcl
+++ b/scripts/tcl_commands/magic.tcl
@@ -28,13 +28,9 @@ proc run_magic {args} {
     # Generate GDS and MAG views
     set ::env(MAGIC_GDS) $::env(signoff_results)/$::env(DESIGN_NAME).magic.gds
 
-    try_catch magic \
-        -noconsole \
-        -dnull \
-        -rcfile $::env(MAGIC_MAGICRC) \
-        $::env(SCRIPTS_DIR)/magic/mag_gds.tcl \
-        </dev/null \
-        |& tee $::env(TERMINAL_OUTPUT) [index_file $::env(signoff_logs)/gdsii.log]
+    run_magic_script\
+        -indexed_log [index_file $::env(signoff_logs)/gdsii.log]\
+        $::env(SCRIPTS_DIR)/magic/mag_gds.tcl
 
     if { $::env(PRIMARY_SIGNOFF_TOOL) == "magic" } {
         set ::env(CURRENT_GDS) $::env(signoff_results)/$::env(DESIGN_NAME).gds
@@ -50,13 +46,10 @@ proc run_magic {args} {
 
         # Generate mag file that includes GDS pointers
         set ::env(MAGTYPE) mag
-        try_catch magic \
-            -noconsole \
-            -dnull \
-            -rcfile $::env(MAGIC_MAGICRC) \
-            $::env(SCRIPTS_DIR)/magic/gds_pointers.tcl \
-            </dev/null \
-            |& tee $::env(TERMINAL_OUTPUT) [index_file $::env(signoff_logs)/gds_ptrs.log]
+        run_magic_script\
+            -indexed_log [index_file $::env(signoff_logs)/gds_ptrs.log]\
+            $::env(SCRIPTS_DIR)/magic/gds_pointers.tcl
+
         # Only keep the properties section in the file
         try_catch sed -i -n "/^<< properties >>/,/^<< end >>/p" $::env(signoff_tmpfiles)/gds_ptrs.mag
     }
@@ -69,23 +62,18 @@ proc run_magic {args} {
     if { $::env(MAGIC_GENERATE_LEF) } {
         # Generate LEF view
         set ::env(MAGTYPE) maglef
-        try_catch magic \
-            -noconsole \
-            -dnull \
-            -rcfile $::env(MAGIC_MAGICRC) \
-            $::env(SCRIPTS_DIR)/magic/lef.tcl \
-            </dev/null \
-            |& tee $::env(TERMINAL_OUTPUT) [index_file $::env(signoff_logs)/lef.log]
+        run_magic_script\
+            -indexed_log [index_file $::env(signoff_logs)/lef.log]\
+            $::env(SCRIPTS_DIR)/magic/lef.tcl
+
         if { $::env(MAGIC_GENERATE_MAGLEF) } {
             # Generate MAGLEF view
             set ::env(MAGTYPE) maglef
-            try_catch magic \
-                -noconsole \
-                -dnull \
-                -rcfile $::env(MAGIC_MAGICRC) \
-                $::env(SCRIPTS_DIR)/magic/maglef.tcl \
-                </dev/null \
-                |& tee $::env(TERMINAL_OUTPUT) [index_file $::env(signoff_logs)/maglef.log]
+
+            run_magic_script\
+                -indexed_log [index_file $::env(signoff_logs)/maglef.log]\
+                $::env(SCRIPTS_DIR)/magic/maglef.tcl
+
             # By default, copy the GDS properties into the maglef/ view
             copy_gds_properties $::env(signoff_tmpfiles)/gds_ptrs.mag $::env(signoff_results)/$::env(DESIGN_NAME).lef.mag
         }
@@ -104,13 +92,9 @@ proc run_magic_drc {args} {
     # Has to be maglef for DRC Checking
     set ::env(MAGTYPE) maglef
 
-    try_catch magic \
-        -noconsole \
-        -dnull \
-        -rcfile $::env(MAGIC_MAGICRC) \
-        $::env(SCRIPTS_DIR)/magic/drc.tcl \
-        </dev/null \
-        |& tee $::env(TERMINAL_OUTPUT) [index_file $::env(signoff_logs)/drc.log]
+    run_magic_script\
+        -indexed_log [index_file $::env(signoff_logs)/drc.log]\
+        $::env(SCRIPTS_DIR)/magic/drc.tcl
 
     puts_info "Converting Magic DRC Violations to Magic Readable Format..."
     try_catch $::env(OPENROAD_BIN) -python $::env(SCRIPTS_DIR)/drc_rosetta.py magic to_tcl\
@@ -159,13 +143,11 @@ proc run_magic_spice_export {args} {
     # otherwise underlying device circuits would be considered
     set ::env(_tmp_magic_extract_type) $extract_type
     set ::env(MAGTYPE) maglef
-    try_catch magic \
-        -noconsole \
-        -dnull \
-        -rcfile $::env(MAGIC_MAGICRC) \
-        $::env(SCRIPTS_DIR)/magic/extract_spice.tcl \
-        </dev/null \
-        |& tee $::env(TERMINAL_OUTPUT) [index_file $::env(signoff_logs)/$extract_type.log]
+
+    run_magic_script\
+        -indexed_log [index_file $::env(signoff_logs)/$extract_type.log]\
+        $::env(SCRIPTS_DIR)/magic/extract_spice.tcl
+
     unset ::env(_tmp_magic_extract_type)
 
     if { $extract_type == "spice" } {
@@ -196,13 +178,9 @@ proc export_magic_view {args} {
     set ::env(_tmp_save_mag) $arg_values(-output)
     set ::env(_tmp_def_in) $arg_values(-def)
 
-    try_catch magic \
-        -noconsole \
-        -dnull \
-        -rcfile $::env(MAGIC_MAGICRC) \
-        $script_dir \
-        </dev/null \
-        |& tee $::env(TERMINAL_OUTPUT) [index_file $::env(signoff_logs)/save_mag.log]
+    run_magic_script\
+        -indexed_log [index_file $::env(signoff_logs)/save_mag.log]\
+        $script_dir
 
     unset ::env(_tmp_save_mag)
     unset ::env(_tmp_def_in)
@@ -224,13 +202,11 @@ proc run_magic_antenna_check {args} {
     set antenna_log [index_file $::env(signoff_logs)/antenna.log]
 
     set ::env(_tmp_feedback_file) $feedback_file
-    try_catch magic \
-        -noconsole \
-        -dnull \
-        -rcfile $::env(MAGIC_MAGICRC) \
-        $::env(SCRIPTS_DIR)/magic/antenna_check.tcl \
-        </dev/null \
-        |& tee $::env(TERMINAL_OUTPUT) $antenna_log
+
+    run_magic_script\
+        -indexed_log $antenna_log\
+        $::env(SCRIPTS_DIR)/magic/antenna_check.tcl
+
     unset ::env(_tmp_feedback_file)
 
     set antenna_rpt [index_file $::env(signoff_reports)/antenna.rpt]
@@ -238,7 +214,7 @@ proc run_magic_antenna_check {args} {
     # process the log
     try_catch awk "/Cell:/ {print \$2}" $antenna_log > $antenna_rpt
 
-    set ::env(ANTENNA_CHECKER_REPORT) $antenna_rpt
+    set ::env(ANTENNA_VIOLATOR_LIST) $antenna_rpt
 
     TIMER::timer_stop
     exec echo "[TIMER::get_runtime]" | python3 $::env(SCRIPTS_DIR)/write_runtime.py "antenna check - magic"

--- a/scripts/tcl_commands/routing.tcl
+++ b/scripts/tcl_commands/routing.tcl
@@ -56,7 +56,7 @@ proc groute_antenna_extract {args} {
 
     set value [exec python3 $::env(SCRIPTS_DIR)/extract_antenna_count.py < $arg_values(-from_log)]
 
-    return value
+    return $value
 }
 
 proc global_routing_fastroute {args} {
@@ -84,6 +84,7 @@ proc global_routing_fastroute {args} {
             set ::env(SAVE_GUIDE) [index_file $::env(routing_tmpfiles)/global_$iter.guide]
             set saveLOG [index_file $::env(routing_logs)/global_$iter.log]
             set replaceWith "INSDIODE$iter"
+            puts_info "Starting antenna repair iteration $iter with $prevAntennaVal violations..."
 
             try_catch $::env(OPENROAD_BIN) -python $::env(SCRIPTS_DIR)/odbpy/defutil.py replace_instance_prefixes\
                 --output $::env(CURRENT_DEF)\
@@ -92,11 +93,11 @@ proc global_routing_fastroute {args} {
                 --input-lef $::env(MERGED_LEF)\
                 $::env(CURRENT_DEF)
 
-            puts_info "FastRoute Iteration $iter"
-            puts_info "Antenna Violations Previous: $prevAntennaVal"
             run_openroad_script $::env(SCRIPTS_DIR)/openroad/groute.tcl -indexed_log $saveLOG
+
             set currAntennaVal [groute_antenna_extract -from_log $saveLOG]
-            puts_info "Antenna Violations Current: $currAntennaVal"
+            puts_info "Reduced violations to $currAntennaVal."
+
             if { $currAntennaVal >= $prevAntennaVal } {
                 set iter [expr $iter - 1]
                 set ::env(SAVE_DEF) $prevDEF1

--- a/scripts/tcl_commands/routing.tcl
+++ b/scripts/tcl_commands/routing.tcl
@@ -89,6 +89,7 @@ proc global_routing_fastroute {args} {
                 --output $::env(CURRENT_DEF)\
                 --original-prefix "ANTENNA"\
                 --new-prefix $replaceWith\
+                --input-lef $::env(MERGED_LEF)\
                 $::env(CURRENT_DEF)
 
             puts_info "FastRoute Iteration $iter"


### PR DESCRIPTION
+ `run_magic_script` added, replacing all individual magic invocations and supporting `or_issue`
~ Fix max capacitance/fanout violations being misreported as slew violations
~ `extract_antenna_violators.py`, `or_issue.py` rewritten in click
~ Fix issue where `diodes.py` doesn't expose `replace_fake`
~ Fix various odbpy script invocations broken by #864
~ Fix issue where entire run folder was not deleted on overwrite (again, #864)
~ `spice_extract.tcl`, `antenna_check.tcl` both now attempt their own extraction to avoid maglef/mag confusion scenarios
~ Fix long-standing issue with diode insertion strategy 3
~ Rewrite diode insertion strategy 5

---
Resolves #1147, Resolves #1148