### PR TITLE
Update OpenROAD + Cleanup Fallout 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,10 @@ all: get-openlane pdk
 openlane: venv/created
 	@PYTHON_BIN=$(PWD)/venv/bin/$(PYTHON_BIN) $(MAKE) -C docker openlane
 
+.PHONY: openlane-and-push
+openlane-and-push: venv/created
+	@PYTHON_BIN=$(PWD)/venv/bin/$(PYTHON_BIN) BUILD_IF_CANT_PULL=1 BUILD_IF_CANT_PULL_THEN_PUSH=1 $(MAKE) -C docker openlane
+
 pull-openlane:
 	@docker pull "$(OPENLANE_IMAGE_NAME)"
 

--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ openlane: venv/created
 	@PYTHON_BIN=$(PWD)/venv/bin/$(PYTHON_BIN) $(MAKE) -C docker openlane
 
 .PHONY: openlane-and-push
-openlane-and-push: venv/created
+openlane-and-push-tools: venv/created
 	@PYTHON_BIN=$(PWD)/venv/bin/$(PYTHON_BIN) BUILD_IF_CANT_PULL=1 BUILD_IF_CANT_PULL_THEN_PUSH=1 $(MAKE) -C docker openlane
 
 pull-openlane:

--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ all: get-openlane pdk
 openlane: venv/created
 	@PYTHON_BIN=$(PWD)/venv/bin/$(PYTHON_BIN) $(MAKE) -C docker openlane
 
-.PHONY: openlane-and-push
+.PHONY: openlane-and-push-tools
 openlane-and-push-tools: venv/created
 	@PYTHON_BIN=$(PWD)/venv/bin/$(PYTHON_BIN) BUILD_IF_CANT_PULL=1 BUILD_IF_CANT_PULL_THEN_PUSH=1 $(MAKE) -C docker openlane
 

--- a/dependencies/tool_metadata.yml
+++ b/dependencies/tool_metadata.yml
@@ -58,7 +58,7 @@
   in_install: false
 - name: openroad_app
   repo: https://github.com/The-OpenROAD-Project/OpenROAD
-  commit: d409db6c1a1671c3fb538946ec5f6e1aaf79ac2a
+  commit: 475ff5e827b8937f4810ecae75973ee74e457816
   build: ""
   in_install: false
 - name: git

--- a/dependencies/tool_metadata.yml
+++ b/dependencies/tool_metadata.yml
@@ -58,7 +58,7 @@
   in_install: false
 - name: openroad_app
   repo: https://github.com/The-OpenROAD-Project/OpenROAD
-  commit: 0b8b7ae255f8fbbbefa57d443949b84e73eed757
+  commit: d409db6c1a1671c3fb538946ec5f6e1aaf79ac2a
   build: ""
   in_install: false
 - name: git

--- a/scripts/extract_antenna_count.py
+++ b/scripts/extract_antenna_count.py
@@ -3,4 +3,4 @@ import re
 import sys
 
 in_data = sys.stdin.read()
-print(re.findall(r"[Aa]ntenna violations:\s*(\d+)", in_data)[-1], end="")
+print(re.findall(r"s*(\d+) antenna violations.", in_data)[-1], end="")

--- a/scripts/openroad/antenna_check.tcl
+++ b/scripts/openroad/antenna_check.tcl
@@ -23,4 +23,4 @@ if {[catch {read_def $::env(CURRENT_DEF)} errmsg]} {
 }
 
 # start checking antennas and generate a detail report
-check_antennas -report_file $::env(_tmp_antenna_checker_rpt)
+check_antennas -verbose

--- a/scripts/openroad/droute.tcl
+++ b/scripts/openroad/droute.tcl
@@ -34,8 +34,9 @@ if { [info exists ::env(DRT_MAX_LAYER)] } {
     set max_layer $::env(DRT_MAX_LAYER)
 }
 
+read_guides $::env(CURRENT_GUIDE)
+
 detailed_route\
-    -guide $::env(CURRENT_GUIDE)\
     -bottom_routing_layer $min_layer\
     -top_routing_layer $max_layer\
     -output_guide $::env(TRITONROUTE_FILE_PREFIX).guide\

--- a/scripts/tcl_commands/all.tcl
+++ b/scripts/tcl_commands/all.tcl
@@ -1042,7 +1042,7 @@ proc run_or_antenna_check {args} {
 
     try_catch $::env(OPENROAD_BIN) -python $::env(SCRIPTS_DIR)/extract_antenna_violators.py\
         --output $antenna_violators_rpt\
-        $antenna_checker_rpt
+        $log
 
     set ::env(ANTENNA_VIOLATOR_LIST) $antenna_violators_rpt
 


### PR DESCRIPTION
+ new `openlane-and-push-tools` target added to root Makefile to enable easier updating of tools
~ antenna check results now extracted from log
~ `droute.tcl` updates to read guides before `detailed_route`

Original PR body follows:

---

This PR updates to the new ```check_antennas``` behaviour.

---
- Beggining with [OR#1979](https://github.com/The-OpenROAD-Project/OpenROAD/pull/1979) ```-report_file``` is now gone, see [ant docs](https://github.com/The-OpenROAD-Project/OpenROAD/blob/master/src/ant/README.md)
- Report is now parsable from the ```antenna.log``` instead of ```antenna.rpt```

Thanks,
~Cristian.