### PR TITLE
Reimplement support for multiple power domains

### DIFF
--- a/configuration/README.md
+++ b/configuration/README.md
@@ -72,7 +72,7 @@ These variables are optional that can be specified in the design configuration f
 | `FP_PDN_CORE_RING` | Enables adding a core ring around the design. More details on the control variables in the pdk configurations documentation. 0=Disable 1=Enable. <br> (Default: `0`) |
 | `FP_PDN_ENABLE_RAILS` | Enables the creation of rails in the power grid. 0=Disable 1=Enable. <br> (Default: `1`) |
 | `FP_PDN_ENABLE_MACROS_GRID` | Enables the connection of macros to the top level power grid. 0=Disable 1=Enable. <br> (Default: `1`) |
-| `FP_PDN_MACRO_HOOKS` | Specifies explicit power connections of internal macros to the top level power grid. Comma separated list of macro instance names and power domain vdd and ground net names: `<instance_name> <vdd_net> <gnd_net>` |
+| `FP_PDN_MACRO_HOOKS` | Specifies explicit power connections of internal macros to the top level power grid. Comma separated list of macro instance names, power domain vdd and ground net names, and macro vdd and ground power pin names: `<instance_name> <vdd_net> <gnd_net> <vdd_pin> <gnd_pin>` |
 | `FP_PDN_CHECK_NODES` | Enables checking for unconnected nodes in the power grid. 0=Disable 1=Enable. <br> (Default: `1`) |
 | `FP_TAP_HORIZONTAL_HALO` | Specify the horizontal halo size around macros during tap insertion. The value provided is in microns. <br> Default: `10` |
 | `FP_TAP_VERTICAL_HALO` | Specify the vertical halo size around macros during tap insertion. The value provided is in microns. <br> Default: set to the value of `FP_TAP_HORIZONTAL_HALO` |

--- a/configuration/README.md
+++ b/configuration/README.md
@@ -72,7 +72,7 @@ These variables are optional that can be specified in the design configuration f
 | `FP_PDN_CORE_RING` | Enables adding a core ring around the design. More details on the control variables in the pdk configurations documentation. 0=Disable 1=Enable. <br> (Default: `0`) |
 | `FP_PDN_ENABLE_RAILS` | Enables the creation of rails in the power grid. 0=Disable 1=Enable. <br> (Default: `1`) |
 | `FP_PDN_ENABLE_MACROS_GRID` | Enables the connection of macros to the top level power grid. 0=Disable 1=Enable. <br> (Default: `1`) |
-| `FP_PDN_MACRO_HOOKS` | Specifies explicit power connections of internal macros to the top level power grid. Comma separated list of macro instance names, power domain vdd and ground net names, and macro vdd and ground power pin names: `<instance_name> <vdd_net> <gnd_net> <vdd_pin> <gnd_pin>` |
+| `FP_PDN_MACRO_HOOKS` | Specifies explicit power connections of internal macros to the top level power grid. Comma separated list of macro instance names, power domain vdd and ground net names, and macro vdd and ground pin names: `<instance_name> <vdd_net> <gnd_net> <vdd_pin> <gnd_pin>` |
 | `FP_PDN_CHECK_NODES` | Enables checking for unconnected nodes in the power grid. 0=Disable 1=Enable. <br> (Default: `1`) |
 | `FP_TAP_HORIZONTAL_HALO` | Specify the horizontal halo size around macros during tap insertion. The value provided is in microns. <br> Default: `10` |
 | `FP_TAP_VERTICAL_HALO` | Specify the vertical halo size around macros during tap insertion. The value provided is in microns. <br> Default: set to the value of `FP_TAP_HORIZONTAL_HALO` |

--- a/designs/caravel_upw/config.tcl
+++ b/designs/caravel_upw/config.tcl
@@ -87,8 +87,8 @@ set ::env(CLOCK_PERIOD) "10"
 ## Internal Macros
 ### Macro PDN Connections
 set ::env(FP_PDN_MACRO_HOOKS) "\
-    mprj1 vccd1 vssd1,\
-    mprj2 vccd2 vssd2"
+    mprj1 vccd1 vssd1 vccd1 vssd1,\
+    mprj2 vccd2 vssd2 vccd2 vssd2"
 
 ### Macro Placement
 set ::env(MACRO_PLACEMENT_CFG) $script_dir/macro.cfg

--- a/scripts/openroad/pdn_cfg.tcl
+++ b/scripts/openroad/pdn_cfg.tcl
@@ -1,3 +1,5 @@
+source $::env(SCRIPTS_DIR)/utils/utils.tcl
+
 # Power nets
 if { [info exists ::env(FP_PDN_ENABLE_GLOBAL_CONNECTIONS)] } {
     if { $::env(FP_PDN_ENABLE_GLOBAL_CONNECTIONS) == 1 } {
@@ -25,10 +27,15 @@ if { $::env(FP_PDN_ENABLE_MACROS_GRID) == 1 &&
         set instance_name [lindex $pdn_hook 0]
         set power_net [lindex $pdn_hook 1]
         set ground_net [lindex $pdn_hook 2]
-        set power_pin [lindex $pdn_hook 1]
-        set ground_pin [lindex $pdn_hook 2]
+        set power_pin [lindex $pdn_hook 3]
+        set ground_pin [lindex $pdn_hook 4]
         # This assumes the power pin and the power net have the same name.
         # The macro hooks only give an instance name and not power pin names.
+
+        if { $power_pin == "" || $ground_pin == "" } {
+            puts_err "FP_PDN_MACRO_HOOKS missing power and ground pin names"
+            return -code error
+        }
 
         add_global_connection \
             -net $power_net \

--- a/scripts/openroad/pdn_cfg.tcl
+++ b/scripts/openroad/pdn_cfg.tcl
@@ -25,19 +25,21 @@ if { $::env(FP_PDN_ENABLE_MACROS_GRID) == 1 &&
         set instance_name [lindex $pdn_hook 0]
         set power_net [lindex $pdn_hook 1]
         set ground_net [lindex $pdn_hook 2]
+        set power_pin [lindex $pdn_hook 1]
+        set ground_pin [lindex $pdn_hook 2]
         # This assumes the power pin and the power net have the same name.
         # The macro hooks only give an instance name and not power pin names.
 
         add_global_connection \
             -net $power_net \
             -inst_pattern $instance_name \
-            -pin_pattern $power_net \
+            -pin_pattern $power_pin \
             -power
 
         add_global_connection \
             -net $ground_net \
             -inst_pattern $instance_name \
-            -pin_pattern $ground_net \
+            -pin_pattern $ground_pin \
             -ground
     }
 }


### PR DESCRIPTION
`FP_PDN_MACRO_HOOKS` now takes the power and ground pin names in addition to instance name, power and ground nets.

This fix will enable pdn to connect to multiple power domains to internal macros with different power and ground pin names