### PR TITLE
Added missing -log to scrot_klayout call

### DIFF
--- a/scripts/tcl_commands/floorplan.tcl
+++ b/scripts/tcl_commands/floorplan.tcl
@@ -386,7 +386,7 @@ proc run_floorplan {args} {
 
     tap_decap_or
 
-    scrot_klayout -layout $::env(CURRENT_DEF) $::env(floorplan_logs)/screenshot.log
+    scrot_klayout -layout $::env(CURRENT_DEF) -log $::env(floorplan_logs)/screenshot.log
 
     run_power_grid_generation
 }


### PR DESCRIPTION
This caused a crash when running with `TAKE_LAYOUT_SCROT`. All other usages of `scrot_klayout` seem to already set the `-log` arg correctly, just this occurrence was missed.