### PR TITLE
Don't require `click` for Docker platform extraction

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ OPENLANE_DIR ?= $(shell pwd)
 
 DOCKER_OPTIONS = $(shell $(PYTHON_BIN) ./env.py docker-config)
 
-DOCKER_ARCH ?= $(shell $(PYTHON_BIN) ./docker/utils.py current-docker-platform)
+DOCKER_ARCH ?= $(shell $(PYTHON_BIN) ./docker/current_platform.py)
 
 # Allow Configuring Memory Limits
 ifneq (,$(DOCKER_SWAP)) # Set to -1 for unlimited

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -9,7 +9,7 @@ PYTHON_BIN ?= python3
 OS_NAME := centos-7
 OS_IMAGE := centos:centos7
 BASE_HASH := $(shell $(PYTHON_BIN) ../dependencies/hash_for.py $(OS_NAME))
-BUILD_ARCH ?= $(shell $(PYTHON_BIN) ./utils.py current-docker-platform)
+BUILD_ARCH ?= $(shell $(PYTHON_BIN) ./current_platform.py)
 
 export BUILD_BASE_TAG := build-base-$(BASE_HASH)-$(OS_NAME)-$(BUILD_ARCH)
 export RUN_BASE_TAG := run-base-$(BASE_HASH)-$(OS_NAME)-$(BUILD_ARCH)

--- a/docker/current_platform.py
+++ b/docker/current_platform.py
@@ -1,0 +1,23 @@
+import sys
+import platform
+
+
+def current_docker_platform() -> str:
+    arch = platform.machine()
+
+    if arch in ["x86_64", "amd64"]:
+        return "amd64"
+    elif arch in ["aarch64", "arm64"]:
+        return "arm64v8"
+    elif arch in ["ppc64le"]:
+        return "ppc64le"
+    else:
+        print(
+            f"Unsupported architecture '{platform.machine()}' Falling back to x86-64 for Docker.",
+            file=sys.stderr,
+        )
+        return "amd64"
+
+
+if __name__ == "__main__":
+    print(current_docker_platform(), end="")

--- a/docker/utils.py
+++ b/docker/utils.py
@@ -29,25 +29,6 @@ CI_ARCHITECTURES = {"amd64", "arm64v8"}
 SUPPORTED_OPERATING_SYSTEMS = {"centos-7"}
 
 
-def current_docker_platform() -> str:
-    import platform
-
-    arch = platform.machine()
-
-    if arch in ["x86_64", "amd64"]:
-        return "amd64"
-    elif arch in ["aarch64", "arm64"]:
-        return "arm64v8"
-    elif arch in ["ppc64le"]:
-        return "ppc64le"
-    else:
-        print(
-            f"Unsupported architecture '{platform.machine()}' Falling back to x86-64 for Docker.",
-            file=sys.stderr,
-        )
-        return "amd64"
-
-
 def test_manifest_exists(repository, tag) -> str:
     url = f"https://index.docker.io/v1/repositories/{repository}/tags/{tag}"
     req = urllib.request.Request(url, headers={"Accept": "application/json"})
@@ -358,14 +339,6 @@ def fetch_submodules_from_tarballs(filter, repository, commit):
 
 
 cli.add_command(fetch_submodules_from_tarballs)
-
-
-@click.command("current-docker-platform")
-def current_docker_platform_cmd():
-    print(current_docker_platform(), end="")
-
-
-cli.add_command(current_docker_platform_cmd)
 
 if __name__ == "__main__":
     cli()


### PR DESCRIPTION
~ `docker/utils.py current-docker-platform` isolated into standalone `docker/current_platform.py` script that does not require any non-default Python libraries

---
Resolves #1200.
