### PR TITLE
New Tagging Scheme + Issue Features

### DIFF
--- a/.github/scripts/generate_tag.py
+++ b/.github/scripts/generate_tag.py
@@ -25,7 +25,9 @@ print("Getting the latest tag…")
 
 latest_tag = None
 latest_tag_commit = None
-for tag in gh.openlane.tags:
+commits_with_tags = gh.openlane.tags
+tags = [tag for _, tag in commits_with_tags]
+for tag in commits_with_tags:
     commit, name = tag
     latest_tag = name
     latest_tag_commit = commit
@@ -41,7 +43,12 @@ if commit_count == 0:
 else:
     now = datetime.datetime.now()
 
-    new_tag = now.strftime("%Y.%m.%d_%H.%M.%S")
+    time = now.strftime("%Y.%m.%d")
+    new_tag = time
+    release_counter = 0
+    while new_tag in tags:
+        release_counter += 1
+        new_tag = f"{time}r{release_counter}"
 
     print("Naming new tag %s." % new_tag)
 

--- a/.github/scripts/gh.py
+++ b/.github/scripts/gh.py
@@ -105,7 +105,7 @@ if os.getenv("GITHUB_ACTIONS") != "true":
         )[:-1]
 
     repo_url = git_command("remote", "get-url", "origin")
-    branch = git_command("branch", "rev-parse", "--abbrev-ref", "HEAD")
+    branch = git_command("rev-parse", "--abbrev-ref", "HEAD")
 
     os.environ["REPO_URL"] = repo_url
     os.environ["BRANCH_NAME"] = branch

--- a/docs/source/using_or_issue.md
+++ b/docs/source/using_or_issue.md
@@ -7,9 +7,26 @@ It creates a folder with all the needed files that you can inspect, then zip or 
 When working with a proprietary PDK, also inspect the folder and ensure no proprietary data resulting ends up in there. This is *critical*, if something leaks, this scripts' authors take no responsibility and you are very much on your own. We will try our best to output warnings for your own good if something looks like a part of a proprietary PDK, but the absence of this message does not necessarily indicate that your folder is free of confidential material. 
 
 # Usage
-If you're using OpenLane 2021.12.17 or later (OpenLane 2022.06.21 or later for Magic,) chances are, `or_issue.py` was automatically run for you if Magic or OpenROAD fail. You'll find a message in the log that says something along the lines of: `Reproducible packaged: Please tarball and upload <PATH> if you're going to submit an issue.` The path will be under the current run_path, i.e., ./designs/<design>/runs/<run_tag>/issue_reproducible. You can then tarball/zip and upload that file.
+## Failures
+If you're using OpenLane 2021.12.17 or later (OpenLane 2022.06.21 or later for Magic,) chances, `or_issue.py` will **automatically** be run for you if Magic or OpenROAD exit with a non-zero code. 
 
-## Running or_issue.py manually
+You'll find a message in the log that says something along the lines of: `Reproducible packaged: Please tarball and upload <PATH> if you're going to submit an issue.` The path will be under the current run_path, i.e., ./designs/<design>/runs/<run_tag>/issue_reproducible. You can then tarball/zip and upload that file.
+
+## Odd Behavior
+If the Tcl-based script doesn't fail outright, but simply exhibits weird behavior, starting OpenLane 2022.07.20, you can have the flow simply stop execution and package a reproducible instead.
+
+If you know the name of the script causing the issue, you can set the environment variable `CREATE_REPRODUCIBLE_FROM_SCRIPT` to the name of the script. For example, to quit on Magic's DRC script, you can set the variable as follows:
+
+```bash
+export CREATE_REPRODUCIBLE_FROM_SCRIPT=magic/drc.tcl
+./flow.tcl [...]
+```
+
+The flow will automatically quit right before executing any script matching `CREATE_REPRODUCIBLE_FROM_SCRIPT`. The last message printed will be something among the lines of `[INFO]: Reproducible packaged at '<PATH>'.`
+
+## Manually
+If neither option above works for you for some reason, there's always the hard way, and the hard way involves invoking the script manually.
+
 You'll have to extract three key elements from the **verbose** logs (i.e. ./flow.tcl must be run with `-verbose`):
 * The Script Where The Failure Occurred -> script
 * The Final Layout Before The Failure Occurred -> input

--- a/env.py
+++ b/env.py
@@ -86,7 +86,7 @@ def issue_survey():
     final_report += textwrap.dedent(
         """\
         Kernel: %s v%s
-    """
+        """
         % (os_info.kernel, os_info.kernel_version)
     )
 
@@ -94,7 +94,7 @@ def issue_survey():
         final_report += textwrap.dedent(
             """\
             Distribution: %s %s
-        """
+            """
             % (os_info.distro, (os_info.distro_version or ""))
         )
 
@@ -109,7 +109,7 @@ def issue_survey():
     final_report += textwrap.dedent(
         """\
         Python: v%s (%s)
-    """
+        """
         % (python_version, python_message)
     )
 
@@ -126,7 +126,7 @@ def issue_survey():
         final_report += textwrap.dedent(
             """\
             Container Engine: %s v%s (%s)
-        """
+            """
             % (os_info.container_info.engine, container_version, container_message)
         )
     elif os.path.exists(
@@ -162,7 +162,7 @@ def issue_survey():
         final_report += textwrap.dedent(
             """\
             OpenLane Git Version: %s
-        """
+            """
             % get_tag()
         )
 
@@ -189,9 +189,9 @@ def issue_survey():
             venv_ok = False
 
         alert = (
-            "pip:venv: " + "INSTALLED"
+            "python-venv: " + "INSTALLED"
             if venv_ok
-            else "NOT FOUND: needed for containerless installs"
+            else "NOT FOUND: Please install python-venv using your operating system's package manager."
         )
         final_report += "%s\n" % alert
         print(alert, file=alerts)
@@ -228,6 +228,12 @@ def issue_survey():
             ).decode("utf8")
 
             final_report += "---\nGit Log (Last 3 Commits)\n\n" + git_log
+
+            remotes = subprocess.check_output(["git", "remote", "-v", "show"]).decode(
+                "utf8"
+            )
+
+            final_report += "---\nGit Remotes\n\n" + remotes
         except subprocess.CalledProcessError:
             pass
 

--- a/scripts/tcl_commands/all.tcl
+++ b/scripts/tcl_commands/all.tcl
@@ -428,13 +428,9 @@ proc prep {args} {
     puts_info "Using configuration in '$config_file_rel'..."
     source_config -run_path $run_path $::env(DESIGN_CONFIG)
 
-    puts_info $::env(STD_CELL_LIBRARY)
-
     if { [info exists arg_values(-override_env)] } {
         load_overrides $arg_values(-override_env)
     }
-
-    puts_info $::env(STD_CELL_LIBRARY)
 
     # Diagnostics
     if { ! [info exists ::env(PDK_ROOT)] || $::env(PDK_ROOT) == "" } {


### PR DESCRIPTION
+ Tagging scheme is now YYYY.MM.DD, postfixed with rX for multiple releases on the same day to match internal Efabless utilities
+ Add git remotes to environment survey
+ Add feature to force reproducibles to be created for a specific script regardless of failure: see `docs/source/using_or_issue.md` for more info
~ Fix `generate_tag.py`
- Remove debugging vestiges from `all.tcl`
---