### PR TITLE
Fix PDN OR script sourcing OpenLane utils

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,17 @@ Try to write all major code in Python. Writing some Tcl is usually a necessity b
 
 Please do not write new shell scripts.
 
+## Yosys, OpenROAD and Magic Scripts
+There are some special guidelines for scripts in `scripts/yosys`, `scripts/openroad`, and `scripts/magic`:
+
+* The scripts for each tool are a self-contained ecosystem: do not `source` scripts from outside their directories.
+    * You may duplicate functionality if you deem it necessary.
+* Do not reference the following environment variables anywhere in this folder to avoid causing recursion when generating issue reproducibles:
+    * $PWD
+    * $RUN_DIR
+    * $DESIGN_DIR
+
+
 # Submissions
 Make your changes and then submit them as a pull requests to the `master` branch.
 

--- a/scripts/openroad/pdn_cfg.tcl
+++ b/scripts/openroad/pdn_cfg.tcl
@@ -1,5 +1,3 @@
-source $::env(SCRIPTS_DIR)/utils/utils.tcl
-
 # Power nets
 if { [info exists ::env(FP_PDN_ENABLE_GLOBAL_CONNECTIONS)] } {
     if { $::env(FP_PDN_ENABLE_GLOBAL_CONNECTIONS) == 1 } {
@@ -31,8 +29,8 @@ if { $::env(FP_PDN_ENABLE_MACROS_GRID) == 1 &&
         set ground_pin [lindex $pdn_hook 4]
 
         if { $power_pin == "" || $ground_pin == "" } {
-            puts_err "FP_PDN_MACRO_HOOKS missing power and ground pin names"
-            return -code error
+            puts "FP_PDN_MACRO_HOOKS missing power and ground pin names"
+            exit -1
         }
 
         add_global_connection \


### PR DESCRIPTION
+ Add contributing guidelines for tool-specific tcl scripts
~ fix --verbose output in or_issue.py and add a guard against `/dev` paths
~ remove `source` statement from pdn_cfg.tcl, replace openlane utility with puts_err

---
Resolves #1233 