### PR TITLE
Revamp Net Unbuffering

### DIFF
--- a/configuration/README.md
+++ b/configuration/README.md
@@ -146,7 +146,8 @@ These variables worked initially, but they were too sky130 specific and will be 
 | `PL_MACRO_HALO` | Macro placement halo. Format: `{Horizontal} {Vertical}` <br> (Default: `0 0`um). |
 | `PL_MACRO_CHANNEL` | Channel widths between macros. Format: `{Horizontal} {Vertical}` <br> (Default: `0 0`um). |
 | `MACRO_PLACEMENT_CFG` | Specifies the path a file specifying how openlane should place certain macros |
-| `DONT_BUFFER_PORTS` | Semicolon;delimited list of nets from which to remove buffers after placement (but before resizing). <br> (Default: Empty) |
+| `UNBUFFER_NETS` | Semicolon;delimited list of nets from which to remove buffers after every resizer run. Useful for analog ports in mixed-signal designs where OpenROAD may sometimes add a buffer. <br> (Default: Empty) |
+| `DONT_BUFFER_PORTS` | **Deprecated: Use `UNBUFFER_NETS`.** Semicolon;delimited list of nets from which to remove buffers. <br> (Default: Empty) |
 
 ### CTS
 

--- a/configuration/README.md
+++ b/configuration/README.md
@@ -146,8 +146,8 @@ These variables worked initially, but they were too sky130 specific and will be 
 | `PL_MACRO_HALO` | Macro placement halo. Format: `{Horizontal} {Vertical}` <br> (Default: `0 0`um). |
 | `PL_MACRO_CHANNEL` | Channel widths between macros. Format: `{Horizontal} {Vertical}` <br> (Default: `0 0`um). |
 | `MACRO_PLACEMENT_CFG` | Specifies the path a file specifying how openlane should place certain macros |
-| `UNBUFFER_NETS` | Semicolon;delimited list of nets from which to remove buffers after every resizer run. Useful for analog ports in mixed-signal designs where OpenROAD may sometimes add a buffer. <br> (Default: Empty) |
-| `DONT_BUFFER_PORTS` | **Deprecated: Use `UNBUFFER_NETS`.** Semicolon;delimited list of nets from which to remove buffers. <br> (Default: Empty) |
+| `UNBUFFER_NETS` | A regular expression used to match nets from which to remove buffers after every resizer run. Useful for analog ports in mixed-signal designs where OpenROAD may sometimes add a buffer. <br> (Default: `^$`, matches nothing.) |
+| `DONT_BUFFER_PORTS` | **Removed: Use `UNBUFFER_NETS`.** Semicolon;delimited list of nets from which to remove buffers. <br> (Default: Empty) |
 
 ### CTS
 

--- a/configuration/placement.tcl
+++ b/configuration/placement.tcl
@@ -39,4 +39,4 @@ set ::env(PL_MAX_DISPLACEMENT_X) 500
 set ::env(PL_MAX_DISPLACEMENT_Y) 100
 set ::env(PL_MACRO_HALO) {0 0}
 set ::env(PL_MACRO_CHANNEL) {0 0}
-set ::env(DONT_BUFFER_PORTS) {}
+set ::env(UNBUFFER_NETS) {}

--- a/configuration/placement.tcl
+++ b/configuration/placement.tcl
@@ -39,4 +39,4 @@ set ::env(PL_MAX_DISPLACEMENT_X) 500
 set ::env(PL_MAX_DISPLACEMENT_Y) 100
 set ::env(PL_MACRO_HALO) {0 0}
 set ::env(PL_MACRO_CHANNEL) {0 0}
-set ::env(UNBUFFER_NETS) {}
+set ::env(UNBUFFER_NETS) "^$"

--- a/flow.tcl
+++ b/flow.tcl
@@ -44,6 +44,7 @@ proc run_cts_step {args} {
 
     run_cts
     run_resizer_timing
+    remove_buffers_from_nets
 }
 
 proc run_routing_step {args} {

--- a/scripts/odbpy/defutil.py
+++ b/scripts/odbpy/defutil.py
@@ -492,18 +492,16 @@ def replace_pins(output_def, input_lef, logpath, source_def, template_def):
 
 @click.command("remove_components")
 @click.option(
-    "--rx/--not-rx", default=True, help="Treat instance name as a regular expression"
-)
-@click.option(
-    "-n",
-    "--instance-name",
-    default=".+",
-    help="Instance name to be removed (Default '.+', as a regular expression, removes everything.)",
+    "-m",
+    "--match",
+    "rx_str",
+    default="^.+$",
+    help="Regular expression to match for components to be removed. (Default: '^.+$', matches all strings.)",
 )
 @click_odb
-def remove_components(rx, instance_name, output, input_lef, input_def):
+def remove_components(rx_str, output, input_lef, input_def):
     reader = OdbReader(input_lef, input_def)
-    matcher = re.compile(instance_name if rx else f"^{re.escape(instance_name)}$")
+    matcher = re.compile(rx_str)
     instances = reader.block.getInsts()
     for instance in instances:
         name = instance.getName()
@@ -519,21 +517,22 @@ cli.add_command(remove_components)
 
 @click.command("remove_nets")
 @click.option(
-    "--rx/--not-rx", default=True, help="Treat net name as a regular expression"
+    "-m",
+    "--match",
+    "rx_str",
+    default="^.+$",
+    help="Regular expression to match for nets to be removed. (Default: '^.+$', matches all strings.)",
 )
 @click.option(
-    "-n",
-    "--net-name",
-    default=".+",
-    help="Net name to be removed (Default '.+', as a regular expression, removes everything.)",
-)
-@click.option(
-    "--empty-only", is_flag=True, default=False, help="Only remove empty nets."
+    "--empty-only",
+    is_flag=True,
+    default=False,
+    help="Adds a further condition to only remove empty nets (i.e. unconnected nets).",
 )
 @click_odb
-def remove_nets(rx, net_name, output, empty_only, input_lef, input_def):
+def remove_nets(rx_str, output, empty_only, input_lef, input_def):
     reader = OdbReader(input_lef, input_def)
-    matcher = re.compile(net_name if rx else f"^{re.escape(net_name)}$")
+    matcher = re.compile(rx_str)
     nets = reader.block.getNets()
     for net in nets:
         name = net.getName()
@@ -556,18 +555,16 @@ cli.add_command(remove_nets)
 
 @click.command("remove_pins")
 @click.option(
-    "--rx/--not-rx", default=True, help="Treat pin name as a regular expression"
-)
-@click.option(
-    "-n",
-    "--pin-name",
-    default=".+",
-    help="Pin name to be removed (Default '.+', as a regular expression, removes everything.)",
+    "-m",
+    "--match",
+    "rx_str",
+    default="^.+$",
+    help="Regular expression to match for components to be removed. (Default: '^.+$', matches all strings.)",
 )
 @click_odb
-def remove_pins(rx, pin_name, output, input_lef, input_def):
+def remove_pins(rx_str, output, input_lef, input_def):
     reader = OdbReader(input_lef, input_def)
-    matcher = re.compile(pin_name if rx else f"^{re.escape(pin_name)}$")
+    matcher = re.compile(rx_str)
     pins = reader.block.getBTerms()
     for pin in pins:
         name = pin.getName()

--- a/scripts/odbpy/remove_buffers.py
+++ b/scripts/odbpy/remove_buffers.py
@@ -100,7 +100,7 @@ def remove_buffers(output, rx_str: str, input_lef, input_def):
     if rx_str != "^$":
         # Save some compute time :)
 
-        rx = re.compile(rx)
+        rx = re.compile(rx_str)
 
         design_nets = reader.block.getNets()
         dont_buffer_nets = [net for net in design_nets if rx.match(net) is not None]

--- a/scripts/odbpy/remove_buffers.py
+++ b/scripts/odbpy/remove_buffers.py
@@ -12,92 +12,155 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import odb
+
+import os
+from typing import List
+
 import click
 
 from reader import OdbReader, click_odb
 
 
-def get_master_cells(net):
-    master_cells = []
+def get_pin_name(pin: odb.dbITerm):
+    cell = pin.getInst()
+    cell_name = cell.getName()
+    master_pin = pin.getMTerm()
+    master_pin_name = master_pin.getConstName()
+    return f"{cell_name}/{master_pin_name}"
+
+
+def get_sinks(net: odb.dbNet) -> List[odb.dbInst]:
+    sinks = []
+    print(net.getITerms())
     for it in net.getITerms():
-        master_instance = it.getInst().getMaster()
-        master_cells.append(it.getInst())
-        cell_type = master_instance.getConstName()
-        cell_pin = it.getMTerm().getConstName()
-        print(f"Net {net.getConstName()} is connected to {cell_type}, pin {cell_pin}")
+        cell = it.getInst()
+        cell_pin = it.getMTerm()
 
-    return master_cells
+        master_instance = cell.getMaster()
+        master_name = master_instance.getConstName()
+
+        print(net.getConstName(), cell_pin.getIoType())
+        if cell_pin.getIoType() == "INPUT":
+            print(
+                f"  * Net {net.getConstName()} sinks into {get_pin_name(it)} ({master_name})..."
+            )
+            sinks.append(cell)
+
+    return sinks
 
 
-def get_nets(master_instance):
-    input_nets = []
-    output_nets = []
-    for iterm in master_instance.getITerms():
+def get_drivers(net: odb.dbNet) -> List[odb.dbInst]:
+    drivers = []
+    for it in net.getITerms():
+        cell = it.getInst()
+        cell_pin = it.getMTerm()
+
+        master_instance = cell.getMaster()
+        master_name = master_instance.getConstName()
+
+        if cell_pin.getIoType() == "OUTPUT":
+            print(
+                f"  * Net {net.getConstName()} is driven by {get_pin_name(it)} ({master_name})..."
+            )
+            drivers.append(cell)
+
+    return drivers
+
+
+def get_io(cell: odb.dbInst):
+    inputs = []
+    outputs = []
+    for iterm in cell.getITerms():
         if iterm.isSpecial():  # Skip special nets
             continue
 
         if iterm.isInputSignal():
             input_pin_net = iterm.getNet()
-            input_nets.append(input_pin_net)
+            inputs.append((iterm, input_pin_net))
 
         if iterm.isOutputSignal():
             output_pin_net = iterm.getNet()
-            output_nets.append(output_pin_net)
+            outputs.append((iterm, output_pin_net))
 
-    return input_nets, output_nets
+    return inputs, outputs
 
 
 @click.command()
 @click.option(
-    "-p",
-    "--ports",
+    "-n",
+    "--nets",
     required=True,
     help="Semicolon;delimited net(s) to remove buffers from",
 )
 @click_odb
-def remove_buffers(output, ports, input_lef, input_def):
-    ports = ports.split(";")
+def remove_buffers(output, nets, input_lef, input_def):
+    nets = nets.split(";")
     reader = OdbReader(input_lef, input_def)
 
     design_nets = reader.block.getNets()
-    dont_buffer_nets = [net for net in design_nets if net.getConstName() in ports]
+    dont_buffer_nets = [net for net in design_nets if net.getConstName() in nets]
 
     for net in dont_buffer_nets:
+        net_name = net.getConstName()
+        print(f"* Attempting to unbuffer {net_name}...")
         # get the cells driving the dont buffer net
-        master_cells = get_master_cells(net)
+        drivers = get_drivers(net)
 
-        assert (
-            len(master_cells) == 1
-        ), f"Net {net.getConstName()} is driven by multiple cells."
+        if len(drivers) > 1:
+            print(f"Net {net_name} is driven by multiple cells.")
+            exit(os.EX_DATAERR)
+        elif len(drivers) == 0:
+            print(f"Net {net_name} is not driven by any cell..")
+            exit(os.EX_DATAERR)
 
-        cell_name = master_cells[0].getMaster().getConstName()
-        assert (
-            "buf" in cell_name
-        ), f"{net.getConstName()} isn't driven by a buffer cell. It is driven by {cell_name}. "
+        buffer = drivers[0]
+        buffer_name = drivers[0].getName()
+        master = buffer.getMaster()
+        master_name = master.getConstName()
+
+        if "buf" not in master_name:
+            print(
+                f"*  {net_name} isn't driven by a buffer cell. It is driven by {buffer_name} ({master_name}). Skipping..."
+            )
+            continue
 
         # get the net connected to the input pin of this buffer
-        input_nets, output_nets = get_nets(master_cells[0])
+        inputs, outputs = get_io(buffer)
+
+        if len(inputs) != 1:
+            print(
+                f"*  {master_name} has more than one output port. Doesn't appear to actually be a buffer. Skipping..."
+            )
+            continue
+        if len(outputs) != 1:
+            print(
+                f"{master_name} has more than one output port. Doesn't appear to actually be a buffer. Skipping..."
+            )
+            continue
+
+        _, input_net = inputs[0]
+        _, output_net = outputs[0]
 
         assert (
-            len(output_nets) == 1
-        ), f"{cell_name} has more than one output port. Please make sure that {cell_name} is a buffer cell."
-        assert (
-            len(input_nets) == 1
-        ), f"{cell_name} has more than one input port. Please make sure that {cell_name} is a buffer cell."
-        assert (
-            output_nets[0].getConstName() in ports
-        ), f"{cell_name} isn't driving any of the dont buffer nets."
+            output_net.getConstName() in nets
+        ), f"{buffer_name} doesn't appear to be driving any of the unbuffer nets."  # Is this possible???
 
-        # remove the buffer cell instance
-        master_cells[0].destroy(master_cells[0])
+        print("  * Reconnecting IO...")
+        # We connect the driver's output to the output_net: there may not be a
+        # sink with ITerms in case of things like output ports for example.
+        buffer_input_driver = get_drivers(input_net)[0]
+        _, bid_outputs = get_io(buffer_input_driver)
+        (bid_iterm, _) = bid_outputs[0]
+        bid_iterm.connect(output_net)
+        print(f"  * Connected buffer output to {get_pin_name(bid_iterm)}.")
 
-        # connect buffer cell input net to the dont buffer port
-        for input_net in input_nets:
-            input_net_master_cell = get_master_cells(input_net)[0]
-            _, output_nets_2 = get_nets(input_net_master_cell)
-            output_net_it = output_nets_2[0].getITerms()[0]
-            output_net_it.connect(net)
+        print(f"  * Removing net {input_net.getName()}...")
+        odb.dbNet.destroy(input_net)
 
+        print(f"  * Removing buffer {buffer_name} ({master_name})...")
+        odb.dbInst.destroy(buffer)
+
+    print("  * Done.")
     odb.write_def(reader.block, output)
 
 

--- a/scripts/tcl_commands/all.tcl
+++ b/scripts/tcl_commands/all.tcl
@@ -479,6 +479,7 @@ proc prep {args} {
     handle_deprecated_config FP_VERTICAL_HALO FP_PDN_VERTICAL_HALO;
 
     handle_deprecated_config CELL_PAD_EXECLUDE CELL_PAD_EXCLUDE;
+    handle_deprecated_config DONT_BUFFER_PORTS UNBUFFER_NETS;
 
     handle_deprecated_config GLB_RT_ALLOW_CONGESTION GRT_ALLOW_CONGESTION;
     handle_deprecated_config GLB_RT_OVERFLOW_ITERS GRT_OVERFLOW_ITERS;

--- a/scripts/tcl_commands/all.tcl
+++ b/scripts/tcl_commands/all.tcl
@@ -479,7 +479,6 @@ proc prep {args} {
     handle_deprecated_config FP_VERTICAL_HALO FP_PDN_VERTICAL_HALO;
 
     handle_deprecated_config CELL_PAD_EXECLUDE CELL_PAD_EXCLUDE;
-    handle_deprecated_config DONT_BUFFER_PORTS UNBUFFER_NETS;
 
     handle_deprecated_config GLB_RT_ALLOW_CONGESTION GRT_ALLOW_CONGESTION;
     handle_deprecated_config GLB_RT_OVERFLOW_ITERS GRT_OVERFLOW_ITERS;

--- a/scripts/tcl_commands/placement.tcl
+++ b/scripts/tcl_commands/placement.tcl
@@ -229,7 +229,7 @@ proc remove_buffers_from_nets {args} {
     try_catch $::env(OPENROAD_BIN) -python $::env(SCRIPTS_DIR)/odbpy/remove_buffers.py\
         --output $::env(SAVE_DEF)\
         --input-lef $::env(MERGED_LEF)\
-        --nets $::env(UNBUFFER_NETS)\
+        --match $::env(UNBUFFER_NETS)\
         $::env(CURRENT_DEF)\
         |& tee $::env(TERMINAL_OUTPUT) $log
 

--- a/scripts/tcl_commands/routing.tcl
+++ b/scripts/tcl_commands/routing.tcl
@@ -388,7 +388,9 @@ proc run_routing {args} {
     # |----------------   5. ROUTING ----------------------|
     # |----------------------------------------------------|
     set ::env(CURRENT_STAGE) routing
+
     run_resizer_timing_routing
+    remove_buffers_from_nets
 
     if { [info exists ::env(DIODE_CELL)] && ($::env(DIODE_CELL) ne "") } {
         if { ($::env(DIODE_INSERTION_STRATEGY) == 1) || ($::env(DIODE_INSERTION_STRATEGY) == 2) } {

--- a/scripts/utils/deflef_utils.tcl
+++ b/scripts/utils/deflef_utils.tcl
@@ -163,18 +163,4 @@ proc remove_components {args} {
         $arg_values(-input)
 }
 
-proc remove_component {args} {
-    set options {
-        {-input required}
-        {-instance_name required}
-    }
-    set flags {}
-    parse_key_args "remove_component" args arg_values $options flags_map $flags
-    try_catch $::env(OPENROAD_BIN) -python $::env(SCRIPTS_DIR)/odbpy/defutil.py remove_components\
-        --input-lef $::env(MERGED_LEF)\
-        --instance-name $arg_values(-instance_name) --not-rx\
-        --output $arg_values(-input)\
-        $arg_values(-input)
-}
-
 package provide openlane_utils 0.9


### PR DESCRIPTION
\+ `UNBUFFER_NETS` created, which takes a regular expression, which if matched, remove buffers from said net
~ `scripts/odbpy/remove_buffers.py` rewritten to be comprehensible
~ `remove_buffers_from_ports` -> `remove_buffers_from_nets`, now runs after every resizer step
~ `remove_*` python commands now only use regular expressions
\- Remove `DONT_BUFFER_PORTS` as the name does not reflect the proactive nature of buffer removal
\- Remove `remove_component` (singular)- unused
This is a temporary workaround until a proper "don't touch net" feature is available in OpenROAD.