### PR TITLE
Build Script Fixes

### DIFF
--- a/dependencies/installer.py
+++ b/dependencies/installer.py
@@ -155,6 +155,10 @@ class Installer(object):
             )
         )
 
+        print(
+            "[ALERT] The local installer is deprecated and will be removed in a future version of OpenLane.\nIf you're still using it, please file an issue at https://github.com/The-OpenROAD-Project/OpenLane/issues."
+        )
+
         install_dir = realpath("./install")
 
         sh("mkdir", "-p", install_dir, root="retry")
@@ -400,7 +404,7 @@ class Installer(object):
             venv_builder = venv.EnvBuilder(clear=True, with_pip=True)
             venv_builder.create("./venv")
 
-            pip_install_cmd = "python3 -m pip install --upgrade --no-cache-dir"
+            pip_install_cmd = "python3 -m pip install --upgrade"
 
             subprocess.run(
                 [
@@ -435,12 +439,12 @@ class Installer(object):
                         tool = pop()
                         continue
 
-                    if len(tool.dependencies):
-                        dependencies = set(tool.dependencies)
-                        if not dependencies.issubset(installed):
-                            tool_queue.append(tool)
-                            tool = pop()
-                            continue
+                    # if len(tool.dependencies):
+                    #     dependencies = set(tool.dependencies)
+                    #     if not dependencies.issubset(installed):
+                    #         tool_queue.append(tool)
+                    #         tool = pop()
+                    #         continue
 
                     installed_version = ""
                     version_path = f"versions/{tool.name}"

--- a/docker/utils.py
+++ b/docker/utils.py
@@ -30,7 +30,7 @@ SUPPORTED_OPERATING_SYSTEMS = {"centos-7"}
 
 
 def test_manifest_exists(repository, tag) -> str:
-    url = f"https://index.docker.io/v1/repositories/{repository}/tags/{tag}"
+    url = f"https://registry.hub.docker.com/v2/repositories/{repository}/tags/{tag}"
     req = urllib.request.Request(url, headers={"Accept": "application/json"})
     status = None
     try:


### PR DESCRIPTION
~ Update API endpoint for `test_manifest_exists` to use v2 of the Docker API
~ Comment out `tool.dependencies` behavior in `dependencies/installer.py`
~ Add deprecation notice for the local installer

---
Resolves #1276
Resolves #1280 