### PR TITLE
Streamlined PDK/SCL Configuration

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,39 +1,67 @@
 ---
 name: Bug Report
-about: If OpenLane is not behaving as expected, please report here.
+about: If OpenLane is not behaving as expected, please file a report here.
 title: ''
 labels: ''
 assignees: ''
 
 ---
 
-<!-- NOTE: This template is NOT a suggestion. Issues not using this template will be marked invalid. -->
+<!--
+    This issue template is REQUIRED for all bug reports. It helps us more
+    quickly track, narrow down, and address bugs. 
 
-### Description
-A clear and concise description of what the bug is.
+    Bug reports not adhering to this template will be likely marked invalid and
+    closed as there is very little we can do without the requisite information.
 
-### Environment
+    Thank you for understanding!
+-->
+
+## Description
+<!-- What went wrong? Be clear and concise. -->
+
+## Expected behavior
+<!-- What did you *want* to happen? -->
+
+## Environment
+<!--
+    This part is incredibly important:
+
+    Please run the following shell command in the OpenLane root folder:
+
+        python3 ./env.py issue-survey
+
+    Then copy and paste the ENTIRE output between the triple-backticks below. (```)
+
+    If the command does not succeed, you are using an out-of-date version of
+    OpenLane, and it is recommended that you update.
+-->
+
 ```
-Please run the following set of commands in the OpenLane folder:
-
-make survey || python3 ./env.py issue-survey
-
-And copy and paste the ENTIRE output between the triple-backticks. Please do not gzip and upload the output.
-
-If neither command succeeds, you are using an out of date version of OpenLane and should probably update. 
+YOUR SURVEY HERE
 ```
 
-### Reproduction Material
-* Upload a tarball containing the relevant design.
-* List the commands used to run the design.
+## Reproduction Material
+<!--
+    You have two options here:
 
-If you see a message like `Reproducible packaged: Please tarball and upload <PATH> if you're going to submit an issue` in your logs, please also tarball and include that path. This will greatly speed up the fixing process.
+    A. If you see a message like `Reproducible packaged: Please tarball and
+       upload <PATH> if you're going to submit an issue` in your logs,
+       please also tarball and include that path. The reproducible tarball is
+       absolutely required for OpenROAD bugs.
 
-### Expected behavior
-A clear and concise description of what you expected to happen.
+    B. If you don't...
+        * Upload a tarball containing the relevant design.
+        * List the commands used to run the design.
+-->
 
-### Logs
+## Logs
+<!--
+    Feel free to add any relevant logs to this section.
+    
+    Please do ensure they're inside the triple-backticks. (```)
+-->
 ```
-Add any relevant logs here. Please do ensure they're enclosed by the triple-backticks.
+YOUR LOGS HERE
 ```
 

--- a/scripts/tcl_commands/all.tcl
+++ b/scripts/tcl_commands/all.tcl
@@ -245,7 +245,7 @@ proc source_config {args} {
     set options {
         {-run_path optional}
     }
-    set flags {}
+    set flags {-process_info_only}
     parse_key_args "source_config" args arg_values $options flags_map $flags
 
     if { ![info exists arg_values(-run_path)] } {
@@ -274,8 +274,10 @@ proc source_config {args} {
     } elseif { $ext == ".json" } {
         set scl NULL
         set arg_list [list]
-        lappend arg_list --pdk $::env(PDK)
-        if { [info exists ::env(STD_CELL_LIBRARY)] } {
+        if { [info exist flags_map(-process_info_only)] } {
+            lappend arg_list --extract-process-info
+        } else {
+            lappend arg_list --pdk $::env(PDK)
             lappend arg_list --scl $::env(STD_CELL_LIBRARY)
         }
         lappend arg_list --output $config_in_path
@@ -292,27 +294,33 @@ proc source_config {args} {
     }
 
 
-    if { ![info exists ::env(STD_CELL_LIBRARY)] } {
-        set ::env(STD_CELL_LIBRARY) {}
-        source $config_in_path
-        unset ::env(STD_CELL_LIBRARY)
-    } else {
-        source $config_in_path
-    }
+    source $config_in_path
 }
 
-proc load_overrides {overrides} {
+proc load_overrides {args} {
+    set options {}
+    set flags {-process_info_only}
+    parse_key_args "load_overrides" args arg_values $options flags_map $flags
+
+    set overrides [lindex $args 0]
+
+    set process_info_allowlist [list]
+    lappend process_info_allowlist PDK
+    lappend process_info_allowlist STD_CELL_LIBRARY
+    lappend process_info_allowlist STD_CELL_LIBRARY_OPT
+
     set env_overrides [split $overrides ',']
     foreach override $env_overrides {
         set kva [split $override '=']
         set key [lindex $kva 0]
         set value [lindex $kva 1]
-        set ::env(${key}) $value
+        if { [info exists flags_map(-process_info_only)] || [lsearch -exact $process_info_allowlist $key] != -1} {
+            set ::env(${key}) $value
+        }
     }
 }
 
 proc prep {args} {
-
     set ::env(timer_start) [clock seconds]
     TIMER::timer_start
     set options {
@@ -335,15 +343,31 @@ proc prep {args} {
     set args_copy $args
     parse_key_args "prep" args arg_values $options flags_map $flags
 
+
+    if [catch {exec python3 $::env(OPENLANE_ROOT)/dependencies/verify_versions.py} ::env(VCHECK_OUTPUT)] {
+        if { $::env(QUIT_ON_MISMATCHES) == "1" } {
+            puts_err $::env(VCHECK_OUTPUT)
+            puts_err "Please update your environment. OpenLane will now quit."
+            exit -1
+        }
+
+        puts_warn "OpenLane may not function properly: $::env(VCHECK_OUTPUT)"
+    }
+
+    # Check Design Directory
+    set ::env(DESIGN_DIR) [file normalize $arg_values(-design)]
+    if { ![file exists $::env(DESIGN_DIR)] } {
+        set ::env(DESIGN_DIR) [file normalize $::env(OPENLANE_ROOT)/designs/$arg_values(-design)]
+        if { ![file exists $::env(DESIGN_DIR)] } {
+            puts_err "Design $arg_values(-design) not found."
+            exit -1
+        }
+    }
+
     # Storing the current state of environment variables
     set ::env(INIT_ENV_VAR_ARRAY) [split [array names ::env] " "]
     set_if_unset arg_values(-src) ""
     set_if_unset arg_values(-design) "."
-
-    set ::env(DESIGN_DIR) [file normalize $arg_values(-design)]
-    if { ![file exists $::env(DESIGN_DIR)] } {
-        set ::env(DESIGN_DIR) [file normalize $::env(OPENLANE_ROOT)/designs/$arg_values(-design)]
-    }
 
     if { [info exists flags_map(-init_design_config)] } {
         set filename "$::env(DESIGN_DIR)/config.json"
@@ -372,15 +396,15 @@ proc prep {args} {
         exit 0
     }
 
+    # Output
     set_if_unset arg_values(-verbose) "0"
     set ::env(OPENLANE_VERBOSE) $arg_values(-verbose)
-
-
     set ::env(TERMINAL_OUTPUT) "/dev/null"
     if { $::env(OPENLANE_VERBOSE) >= 2 } {
         set ::env(TERMINAL_OUTPUT) ">&@stdout"
     }
 
+    # Extract or Create Run Tag and Run Directory
     set ::env(START_TIME) [clock format [clock seconds] -format %Y.%m.%d_%H.%M.%S ]
 
     if { [info exists flags_map(-last_run)] } {
@@ -397,6 +421,16 @@ proc prep {args} {
 
     set ::env(CONFIGS) [cat $::env(OPENLANE_ROOT)/configuration/load_order.txt]
 
+    if { [info exists arg_values(-run_path)] } {
+        set run_path "[file normalize $arg_values(-run_path)]/$tag"
+    } else {
+        set run_path $::env(DESIGN_DIR)/runs/$tag
+    }
+
+    file mkdir $run_path
+
+    # Configuration
+    ## 0. Global Configurations
     if { [info exists arg_values(-config_file)] } {
         set ::env(DESIGN_CONFIG) $arg_values(-config_file)
     } else {
@@ -414,53 +448,46 @@ proc prep {args} {
         source $::env(OPENLANE_ROOT)/configuration/$config
     }
 
-    if { [info exists arg_values(-run_path)] } {
-        set run_path "[file normalize $arg_values(-run_path)]/$tag"
-    } else {
-        set run_path $::env(DESIGN_DIR)/runs/$tag
-    }
-
-    file mkdir $run_path
-
-    # Needs to be preliminarily sourced at this point, as the PDK
-    # and STD_CELL_LIBRARY values can be in this file.
+    ## 1. Configuration File (Process Info Only)
     set config_file_rel [relpath . $::env(DESIGN_CONFIG)]
 
     puts_info "Using configuration in '$config_file_rel'..."
-    source_config -run_path $run_path $::env(DESIGN_CONFIG)
+    source_config -process_info_only -run_path $run_path $::env(DESIGN_CONFIG)
 
+    ## 2. Overrides (Process Info Only)
     if { [info exists arg_values(-override_env)] } {
-        load_overrides $arg_values(-override_env)
+        load_overrides -process_info_only $arg_values(-override_env)
     }
 
-    # Diagnostics
     if { ! [info exists ::env(PDK_ROOT)] || $::env(PDK_ROOT) == "" } {
         puts_err "PDK_ROOT is not specified. Please make sure you have it set."
-        return -code error
+        exit -1
     } else {
         puts_info "PDK Root: $::env(PDK_ROOT)"
     }
 
     if { ! [info exists ::env(PDK)] } {
         puts_err "PDK is not specified."
-        return -code error
+        exit -1
     } else {
         puts_info "Process Design Kit: $::env(PDK)"
         puts_verbose "Setting PDKPATH to $::env(PDK_ROOT)/$::env(PDK)"
         set ::env(PDKPATH) $::env(PDK_ROOT)/$::env(PDK)
     }
 
-    # Source PDK and SCL specific configurations
+    ## 3. PDK-Specific Config
+    if { [info exists ::env(STD_CELL_LIBRARY)] } {
+        set scl_path "$::env(PDK_ROOT)/$::env(PDK)/libs.ref/$::env(STD_CELL_LIBRARY)"
+        if { ![file exists $scl_path] } {
+            puts_err "Standard Cell Library '$::env(STD_CELL_LIBRARY)' not found in PDK."
+            exit -1
+        }
+    }
     set pdk_config $::env(PDK_ROOT)/$::env(PDK)/libs.tech/openlane/config.tcl
     source $pdk_config
 
-    if { ! [info exists ::env(STD_CELL_LIBRARY)] } {
-        puts_err "STD_CELL_LIBRARY is not specified."
-        return -code error
-    } else {
-        puts_info "Standard Cell Library: $::env(STD_CELL_LIBRARY)"
-    }
-
+    ## 4. SCL-Specific Config
+    puts_info "Standard Cell Library: $::env(STD_CELL_LIBRARY)"
     if { ! [info exists ::env(STD_CELL_LIBRARY_OPT)] } {
         set ::env(STD_CELL_LIBRARY_OPT) $::env(STD_CELL_LIBRARY)
         puts_verbose "Optimization SCL also set to $::env(STD_CELL_LIBRARY_OPT)."
@@ -475,8 +502,10 @@ proc prep {args} {
     set scl_config $::env(PDK_ROOT)/$::env(PDK)/libs.tech/openlane/$::env(STD_CELL_LIBRARY)/config.tcl
     source $scl_config
 
-    # Re-source/re-override to make sure it overrides any configurations from the previous two sources
+    ## 5. Design-Specific Config
     source_config -run_path $run_path $::env(DESIGN_CONFIG)
+
+    ## 6. Overrides
     if { [info exists arg_values(-override_env)] } {
         load_overrides $arg_values(-override_env)
     }
@@ -504,18 +533,6 @@ proc prep {args} {
     handle_deprecated_config GLB_RT_LAYER_ADJUSTMENTS GRT_LAYER_ADJUSTMENTS;
 
     handle_deprecated_config RUN_ROUTING_DETAILED RUN_DRT; # Why the hell is this even an option?
-
-
-    if [catch {exec python3 $::env(OPENLANE_ROOT)/dependencies/verify_versions.py} ::env(VCHECK_OUTPUT)] {
-        if { $::env(QUIT_ON_MISMATCHES) == "1" } {
-            puts_err $::env(VCHECK_OUTPUT)
-            puts_err "Please update your environment. OpenLane will now quit."
-            exit -1
-        }
-
-        puts_warn "OpenLane may not function properly: $::env(VCHECK_OUTPUT)"
-    }
-
 
     #
     ############################

--- a/scripts/tcl_commands/cts.tcl
+++ b/scripts/tcl_commands/cts.tcl
@@ -55,7 +55,6 @@ proc run_cts {args} {
 	}
 
 	if {$::env(CLOCK_TREE_SYNTH) && !$::env(RUN_SIMPLE_CTS)} {
-		set ::env(CURRENT_STAGE) cts
 		increment_index
 		TIMER::timer_start
 		set log [index_file $::env(cts_logs)/cts.log]

--- a/scripts/tcl_commands/klayout.tcl
+++ b/scripts/tcl_commands/klayout.tcl
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 proc run_klayout {args} {
-	set ::env(CURRENT_STAGE) signoff
 	if {[ info exists ::env(KLAYOUT_TECH)] } {
 		increment_index
 		set log [index_file $::env(signoff_logs)/gdsii-klayout.log]

--- a/scripts/tcl_commands/magic.tcl
+++ b/scripts/tcl_commands/magic.tcl
@@ -16,7 +16,6 @@ proc run_magic {args} {
     TIMER::timer_start
     increment_index
     puts_info "Running Magic to generate various views..."
-    set ::env(CURRENT_STAGE) signoff
     # |----------------------------------------------------|
     # |----------------   6. TAPE-OUT ---------------------|
     # |----------------------------------------------------|

--- a/scripts/tcl_commands/placement.tcl
+++ b/scripts/tcl_commands/placement.tcl
@@ -161,7 +161,6 @@ proc run_placement {args} {
     # |----------------------------------------------------|
     # |----------------   3. PLACEMENT   ------------------|
     # |----------------------------------------------------|
-    set ::env(CURRENT_STAGE) placement
 
     if { [info exists ::env(PL_TARGET_DENSITY_CELLS)] } {
         set old_pl_target_density $::env(PL_TARGET_DENSITY)

--- a/scripts/tcl_commands/routing.tcl
+++ b/scripts/tcl_commands/routing.tcl
@@ -387,7 +387,6 @@ proc run_routing {args} {
     # |----------------------------------------------------|
     # |----------------   5. ROUTING ----------------------|
     # |----------------------------------------------------|
-    set ::env(CURRENT_STAGE) routing
 
     run_resizer_timing_routing
     remove_buffers_from_nets

--- a/scripts/tcl_commands/synthesis.tcl
+++ b/scripts/tcl_commands/synthesis.tcl
@@ -21,8 +21,6 @@ proc convert_pg_pins {lib_in lib_out} {
 }
 
 proc run_yosys {args} {
-    set ::env(CURRENT_STAGE) synthesis
-
     set options {
         {-output optional}
         {-log optional}


### PR DESCRIPTION
\+ New feature surfaced to extract just the PDK and SCL info from JSON files and `-override_env`
~ `scripts/tcl_commands/all.tcl:prep` reshuffled:
    verify_versions is now one of the first things to run
    config load order documented and more guardrails added
~ Updated bug report template
\- Removed `CURRENT_STAGE` environment variable: nothing used it

---
Resolved #1295 