### PR TITLE
Remove duplicate definition of RUN_LVS

### DIFF
--- a/configuration/general.tcl
+++ b/configuration/general.tcl
@@ -52,7 +52,6 @@ set ::env(KLAYOUT_DRC_KLAYOUT_GDS) 0
 set ::env(RUN_KLAYOUT_XOR) 1
 
 set ::env(RUN_CVC) 1
-set ::env(RUN_LVS) 1
 
 set ::env(YOSYS_REWRITE_VERILOG) 0
 set ::env(LEC_ENABLE) 0


### PR DESCRIPTION
`RUN_LVS` is defined in `configuration/lvs.tcl`

Signed-off-by: Kareem Farid <kareefardi@users.noreply.github.com>