### PR TITLE
Generate Timing Models

### DIFF
--- a/scripts/openroad/common/io.tcl
+++ b/scripts/openroad/common/io.tcl
@@ -160,7 +160,36 @@ proc write {args} {
     }
 
     if { [info exists ::env(SAVE_SDF)] } {
-        puts "Writing SDF to $::env(SAVE_SDF)..."
-        write_sdf -include_typ -divider . $::env(SAVE_SDF)
+        set corners [sta::corners]
+        if { [llength $corners] > 1 } {
+            puts "Writing SDF files for all corners..."
+            set prefix [file rootname $::env(SAVE_SDF)]
+            foreach corner $corners {
+                set corner_name [$corner name]
+                set target $prefix.$corner_name.sdf
+                puts "Writing SDF for the $corner_name corner to $target..."
+                write_sdf -include_typ -divider . -corner $corner_name $target
+            }
+        } else {
+            puts "Writing SDF to $::env(SAVE_SDF)..."
+            write_sdf -include_typ -divider . $::env(SAVE_SDF)
+        }
+    }
+
+    if { [info exists ::env(SAVE_LIB)] } {
+        set corners [sta::corners]
+        if { [llength $corners] > 1 } {
+            puts "Writing timing models for all corners..."
+            set prefix [file rootname $::env(SAVE_LIB)]
+            foreach corner $corners {
+                set corner_name [$corner name]
+                set target $prefix.$corner_name.lib
+                puts "Writing timing models for the $corner_name corner to $target..."
+                write_timing_model -corner $corner_name $target
+            }
+        } else {
+            puts "Writing timing model to $::env(SAVE_LIB)..."
+            write_timing_model $::env(SAVE_LIB)
+        }
     }
 }

--- a/scripts/openroad/sta_multi_corner.tcl
+++ b/scripts/openroad/sta_multi_corner.tcl
@@ -162,3 +162,5 @@ puts " report_design_area"
 puts "============================================================================"
 report_design_area
 puts "area_report_end"
+
+write

--- a/scripts/tcl_commands/all.tcl
+++ b/scripts/tcl_commands/all.tcl
@@ -906,6 +906,7 @@ proc save_views {args} {
         {-sdf_path optional}
         {-spef_path optional}
         {-sdc_path optional}
+        {-lib_path optional}
         {-save_path optional}
     }
 
@@ -996,6 +997,14 @@ proc save_views {args} {
         file mkdir $destination
         if { [file exists $arg_values(-sdc_path)] } {
             file copy -force $arg_values(-sdc_path) $destination/$::env(DESIGN_NAME).sdc
+        }
+    }
+
+    if { [info exists arg_values(-lib_path)] } {
+        set destination $path/lib
+        file mkdir $destination
+        if { [file exists $arg_values(-lib_path)] } {
+            file copy -force $arg_values(-lib_path) $destination/$::env(DESIGN_NAME).lib
         }
     }
 }
@@ -1173,6 +1182,9 @@ proc save_final_views {args} {
     }
     if { [info exists ::env(CURRENT_SDC)] } {
         lappend arg_list -sdc_path $::env(CURRENT_SDC)
+    }
+    if { [info exists ::env(CURRENT_LIB)] } {
+        lappend arg_list -lib_path $::env(CURRENT_LIB)
     }
 
     # Add the path if it exists...

--- a/scripts/tcl_commands/synthesis.tcl
+++ b/scripts/tcl_commands/synthesis.tcl
@@ -119,7 +119,7 @@ proc run_synthesis {args} {
     TIMER::timer_stop
     exec echo "[TIMER::get_runtime]" | python3 $::env(SCRIPTS_DIR)/write_runtime.py "synthesis - yosys"
 
-    run_sta -pre_cts -log $::env(synthesis_logs)/sta.log
+    run_sta -pre_cts -log $::env(synthesis_logs)/sta.log -save_to $::env(synthesis_results)
     set ::env(LAST_TIMING_REPORT_TAG) [index_file $::env(synthesis_reports)/syn_sta]
 
     if { $::env(CHECK_ASSIGN_STATEMENTS) == 1 } {

--- a/scripts/utils/utils.tcl
+++ b/scripts/utils/utils.tcl
@@ -486,7 +486,7 @@ proc run_tcl_script {args} {
 
     # C-style for loop because Tcl foreach cannot handle the list being
     # dynamically modified
-    set anything_saved 0
+    set layout_saved 0
     set odb_saved 0
     for {set i 0} {$i < [llength $saved_values]} {incr i} {
         set value [lindex $saved_values $i]
@@ -510,7 +510,6 @@ proc run_tcl_script {args} {
         } elseif { $element == "noindex" } {
             set index 0
         } else {
-            set anything_saved 1
             set extension $element
 
             if { $element == "netlist" } {
@@ -521,6 +520,8 @@ proc run_tcl_script {args} {
                 set extension ".json"
             } elseif { $element == "odb" } {
                 set odb_saved 1
+            } elseif { $element == "def" } {
+                set layout_saved 1
             }
 
             if { $value != "/dev/null" } {
@@ -540,7 +541,7 @@ proc run_tcl_script {args} {
         }
     }
 
-    if { $anything_saved && !$odb_saved } {
+    if { $layout_saved && !$odb_saved } {
         puts_err "The layout was saved, but not the ODB format was not. This is a bug with OpenLane. Please file an issue."
         flow_fail
     }


### PR DESCRIPTION
+ Add function to generate lib files based on OpenSTA's new `write_timing_model` command
+ Implement lib saving for both single and multi-corner STA
+ Add multi-corner SDF saving
~ Arrange RCX extraction and STA outputs under folders

---
Resolves #171