### PR TITLE
Elaboration, Signoff SDC Configuration Variables

### DIFF
--- a/configuration/synthesis.tcl
+++ b/configuration/synthesis.tcl
@@ -27,7 +27,7 @@ set ::env(SYNTH_STRATEGY) "AREA 0"
 set ::env(SYNTH_ADDER_TYPE) "YOSYS"
 set ::env(CLOCK_BUFFER_FANOUT) 16
 set ::env(SYNTH_READ_BLACKBOX_LIB) 0
-set ::env(SYNTH_TOP_LEVEL) 0
+set ::env(SYNTH_ELABORATE_ONLY) 0
 set ::env(SYNTH_FLAT_TOP) 0
 set ::env(IO_PCT) 0.2
 set ::env(SYNTH_EXTRA_MAPPING_FILE) ""

--- a/designs/caravel_upw/config.tcl
+++ b/designs/caravel_upw/config.tcl
@@ -112,7 +112,7 @@ set ::env(RT_MAX_LAYER) {met4}
 set ::env(FP_PDN_CHECK_NODES) 0
 
 # The following is because there are no std cells in the example wrapper project.
-set ::env(SYNTH_TOP_LEVEL) 1
+set ::env(SYNTH_ELABORATE_ONLY) 1
 set ::env(PL_RANDOM_GLB_PLACEMENT) 1
 
 set ::env(PL_RESIZER_DESIGN_OPTIMIZATIONS) 0

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -82,7 +82,7 @@ $(TOOL_EXPORT_TARGETS): pull-% : FORCE
 	rm -rf ./tar/openlane
 	mkdir -p ./tar/openlane
 	for file in $(OPENLANE_SKELETON); do\
-		$(PYTHON_BIN) ./utils.py copy-tree -i */runs/* ../$$file ./tar/openlane/$$file ;\
+		$(PYTHON_BIN) ./utils.py copy-tree -i '*/runs/*' ../$$file ./tar/openlane/$$file ;\
 	done
 
 .PHONY: merge openlane

--- a/docs/source/reference/configuration.md
+++ b/docs/source/reference/configuration.md
@@ -23,8 +23,8 @@ These variables are optional that can be specified in the design configuration f
 |-|-|
 | `PDK` | Specifies the process design kit (PDK). <br> (Default: `sky130A` )|
 | `STD_CELL_LIBRARY` | Specifies the standard cell library to be used under the specified PDK. <br> (Default: `sky130_fd_sc_hd` )|
-| `STD_CELL_LIBRARY_OPT` | Specifies the standard cell library to be used during resizer optimizations. <br> (Default: `$STD_CELL_LIBRARY` )|
-| `PDK_ROOT` | Specifies the folder path of the PDK. It searches for a `config.tcl` in `$PDK_ROOT/$PDK/libs.tech/openlane/` directory and at least have one standard cell library config defined in `$PDK_ROOT/$PDK/libs.tech/openlane/$STD_CELL_LIBRARY`. |
+| `STD_CELL_LIBRARY_OPT` | Specifies the standard cell library to be used during resizer optimizations. <br> (Default: `STD_CELL_LIBRARY` )|
+| `PDK_ROOT` | Specifies the folder path of the PDK. It searches for a `config.tcl` in `$::env(PDK_ROOT)/$::env(PDK)/libs.tech/openlane/` directory and at least have one standard cell library config defined in `$::env(PDK_ROOT)/$::env(PDK)/libs.tech/openlane/$::env(STD_CELL_LIBRARY)`. |
 | `DIODE_PADDING` | Diode cell padding; increases the width of diode cells during placement checks. <br> (Default: `2` microns -- 2 sites)|
 | `MERGED_LEF` | Points to `merged.lef`, which is a merger of various LEF files, including the technology lef, cells lef, any custom lefs, and IO lefs. |
 | `NO_SYNTH_CELL_LIST` | Specifies the file that contains the don't-use-cell-list to be excluded from the liberty file during synthesis. If it's not defined, this path is searched `$::env(PDK_ROOT)/$::env(PDK)/libs.tech/openlane/$::env(STD_CELL_LIBRARY)/no_synth.cells` and if it's not found, then the original liberty will be used as is. |
@@ -58,11 +58,12 @@ These variables are optional that can be specified in the design configuration f
 | `SYNTH_SHARE_RESOURCES` | A flag that enables yosys to reduce the number of cells by determining shareable resources and merging them. <br> Enabled = 1, Disabled = 0 <br> (Default: `1`)|
 | `SYNTH_ADDER_TYPE` | Adder type to which the $add and $sub operators are mapped to. <br> Possible values are `YOSYS/FA/RCA/CSA`; where `YOSYS` refers to using Yosys internal adder definition, `FA` refers to full-adder structure, `RCA` refers to ripple carry adder structure, and `CSA` refers to carry select adder. <br> (Default: `YOSYS`)|
 | `SYNTH_EXTRA_MAPPING_FILE` | Points to extra techmap file for yosys that runs right after yosys `synth` before generic techmap. <br> (Default: `""`)|
-| `SYNTH_PARAMETERS` | Space-separated key value pairs to be `chparam`ed in Yosys. In the format `key1=value1 key2=value2` <br> Default: None.  |
+| `SYNTH_PARAMETERS` | Space-separated key value pairs to be `chparam`ed in Yosys. In the format `key1=value1 key2=value2` <br> (Default: None)  |
+| `SYNTH_ELABORATE_ONLY` | "Elaborate" the design only without attempting any logic mapping. Useful when dealing with structural Verilog netlists. <br> (Default: `0`) |
 | `CLOCK_BUFFER_FANOUT` | Fanout of clock tree buffers. <br> (Default: `16`) |
 | `BASE_SDC_FILE` | Specifies the base sdc file to source before running Static Timing Analysis. <br> (Default: `$::env(OPENLANE_ROOT)/scripts/base.sdc`) |
 | `VERILOG_INCLUDE_DIRS` | Specifies the verilog includes directories. <br> Optional. |
-| `SYNTH_FLAT_TOP` | Specifies whether or not the top level should be flattened during elaboration. 1 = True, 0= False <br> Default: `0`. |
+| `SYNTH_FLAT_TOP` | Specifies whether or not the top level should be flattened during elaboration. 1 = True, 0= False <br> (Default: `0` )|
 | `IO_PCT` | Specifies the percentage of the clock period used in the input/output delays. Ranges from 0 to 1.0. <br> (Default: `0.2`) |
 
 ### Floorplanning
@@ -233,6 +234,7 @@ These variables worked initially, but they were too sky130 specific and will be 
 |-|-|
 | `SPEF_EXTRACTOR` | Specifies which spef extractor to use. Values: `openrcx` or (**removed:** `def2spef`). <br> (Default: `openrcx`) |
 | `RCX_MERGE_VIA_WIRE_RES` | Specifies whether to merge the via resistance with the wire resistance or separate it from the wire resistance. 1 = Merge via resistance, 0 = Separate via resistance <br> (Default: `1`)|
+| `RCX_SDC_FILE` | Specifies SDC file to be used for RCX-based STA, which can be different from the one used for implementation. <br> (Default: `BASE_SDC_FILE`) |
 | `SPEF_WIRE_MODEL` | **Removed:** Specifies the wire model used in SPEF extraction. Options are `L` or `Pi`  <br> (Default: `L`) |
 | `SPEF_EDGE_CAP_FACTOR` | **Removed:** Specifies the edge capacitance factor used in SPEF extraction. Ranges from 0 to 1 <br> (Default: `1`) |
 

--- a/scripts/tcl_commands/all.tcl
+++ b/scripts/tcl_commands/all.tcl
@@ -591,6 +591,7 @@ proc prep {args} {
     set ::env(OPENLANE_VERBOSE) $arg_values(-verbose)
 
     # DEPRECATED CONFIGS
+    handle_deprecated_config SYNTH_TOP_LEVEL SYNTH_ELABORATE_ONLY;
     handle_deprecated_config LIB_MIN LIB_FASTEST;
     handle_deprecated_config LIB_MAX LIB_SLOWEST;
 
@@ -807,8 +808,8 @@ proc prep {args} {
         }
         set_log ::env(SYNTH_MAX_TRAN) $::env(SYNTH_MAX_TRAN) $::env(GLB_CFG_FILE) 1
     }
-    if { $::env(SYNTH_TOP_LEVEL) } {
-        set_log ::env(SYNTH_SCRIPT) "$::env(SCRIPTS_DIR)/yosys/synth_top.tcl" $::env(GLB_CFG_FILE) 0
+    if { $::env(SYNTH_ELABORATE_ONLY) } {
+        set_log ::env(SYNTH_SCRIPT) "$::env(SCRIPTS_DIR)/yosys/elaborate.tcl" $::env(GLB_CFG_FILE) 0
     }
     set_log ::env(SYNTH_OPT) 0 $::env(GLB_CFG_FILE) 0
     set_log ::env(PL_INIT_COEFF) 0.00002 $::env(GLB_CFG_FILE) 0

--- a/scripts/tcl_commands/sta.tcl
+++ b/scripts/tcl_commands/sta.tcl
@@ -82,6 +82,13 @@ proc run_parasitics_sta {args} {
     # * CURRENT_SPEF is the nom SPEF after the loop is done
     # * CURRENT_LIB is the nom/nom LIB after the loop is done
     # * CURRENT_SDF is the nom/nom SDF after the loop is done
+    if { ![info exists ::env(RCX_SDC_FILE)] } {
+        set ::env(RCX_SDC_FILE) $::env(CURRENT_SDC)
+    }
+
+    set backup_sdc_variable $::env(CURRENT_SDC)
+    set ::env(CURRENT_SDC) $::env(RCX_SDC_FILE)
+
     foreach {process_corner lef ruleset} {
         min MERGED_LEF_MIN RCX_RULES_MIN
         max MERGED_LEF_MAX RCX_RULES_MAX
@@ -117,6 +124,8 @@ proc run_parasitics_sta {args} {
             }
         }
     }
+
+    set ::env(CURRENT_SDC) $backup_sdc_variable
 }
 
 package provide openlane 0.9

--- a/scripts/tcl_commands/synthesis.tcl
+++ b/scripts/tcl_commands/synthesis.tcl
@@ -144,7 +144,7 @@ proc run_synthesis {args} {
 proc verilog_elaborate {args} {
     # usually run on structural verilog (top-level netlists)
     set synth_script_old $::env(SYNTH_SCRIPT)
-    set ::env(SYNTH_SCRIPT) $::env(SCRIPTS_DIR)/yosys/synth_top.tcl
+    set ::env(SYNTH_SCRIPT) $::env(SCRIPTS_DIR)/yosys/elaborate.tcl
     run_yosys {*}$args
     set ::env(SYNTH_SCRIPT) $synth_script_old
 }

--- a/scripts/yosys/elaborate.tcl
+++ b/scripts/yosys/elaborate.tcl
@@ -15,7 +15,6 @@ yosys -import
 
 set vtop $::env(DESIGN_NAME)
 set sclib $::env(LIB_SYNTH)
-#set sdc_file $::env(SDC_FILE)
 
 set stat_ext    ".stat.rpt"
 set chk_ext    ".chk.rpt"
@@ -63,8 +62,8 @@ for { set i 0 } { $i < [llength $::env(VERILOG_FILES)] } { incr i } {
 
 if { [info exists ::env(SYNTH_PARAMETERS) ] } {
 	foreach define $::env(SYNTH_PARAMETERS) {
-                set param_and_value [split $define "="]
-                lassign $param_and_value param value
+		set param_and_value [split $define "="]
+		lassign $param_and_value param value
 		chparam -set $param $value $vtop
 	}
 }

--- a/scripts/yosys/synth.tcl
+++ b/scripts/yosys/synth.tcl
@@ -23,8 +23,6 @@ if {[info exists ::env(DFF_LIB_SYNTH)]} {
 } else {
     set dfflib $sclib
 }
-#set opt $::env(SYNTH_OPT)
-#set sdc_file $::env(SDC_FILE)
 
 if { [info exists ::env(SYNTH_DEFINES) ] } {
     foreach define $::env(SYNTH_DEFINES) {
@@ -90,10 +88,9 @@ set timing_ext  ".timing.txt"
 set abc_ext     ".abc"
 
 
-# get old sdc, add library specific stuff for abc scripts
+# Create SDC File
 set sdc_file $::env(synthesis_tmpfiles)/synthesis.sdc
 set outfile [open ${sdc_file} w]
-#puts $outfile $sdc_data
 puts $outfile "set_driving_cell ${driver}"
 puts $outfile "set_load ${cload}"
 close $outfile


### PR DESCRIPTION
+ Create `RCX_SDC_FILE` as an optional SDC file to be used only for parasitics extraction (and consequent STA)
+ Document `SYNTH_ELABORATE_ONLY`, which only elaborates structured netlists without an attempt at logic mapping ~ Add translation behavior from previous, ambiguously named `SYNTH_TOP_LEVEL` to `SYNTH_ELABORATE_ONLY`
~ `scripts/yosys/synth_top.tcl` -> `elaborate.tcl`
~ Documentation consistency fixes
~ Fix wildcard in `docker/Makefile`