### PR TITLE
Rename lvs count report file

### DIFF
--- a/scripts/tcl_commands/lvs.tcl
+++ b/scripts/tcl_commands/lvs.tcl
@@ -185,7 +185,7 @@ proc run_lvs {{layout "$::env(EXT_NETLIST)"}} {
     try_catch netgen -batch source $lvs_file_path \
         |& tee $::env(TERMINAL_OUTPUT) $log
 
-    set count_lvs_log $extraction_prefix.log
+    set count_lvs_log $extraction_prefix-count.log
 
     exec python3 $::env(SCRIPTS_DIR)/count_lvs.py \
         -f $extraction_prefix.json \


### PR DESCRIPTION
~ rename lvs count report file to avoid overwriting the log file created by netgen