### PR TITLE
Fix Synthesis Exploration

### DIFF
--- a/scripts/tcl_commands/synthesis.tcl
+++ b/scripts/tcl_commands/synthesis.tcl
@@ -65,9 +65,13 @@ proc run_yosys {args} {
 
     if { ! [info exists flags_map(-no_set_netlist)] } {
         set_netlist -lec $::env(SAVE_NETLIST)
+    }
 
         # The following is a naive workaround to OpenROAD not accepting defparams.
         # It *should* be handled with a fix to the OpenROAD Verilog parser.
+    if { [info exists ::env(SYNTH_EXPLORE)] && $::env(SYNTH_EXPLORE) } {
+        puts_info "This is a Synthesis Exploration and so no need to remove the defparam lines."
+    } else {
         try_catch sed -i {/defparam/d} $::env(CURRENT_NETLIST)
     }
     unset ::env(SAVE_NETLIST)


### PR DESCRIPTION
Signed-off-by: vijayank88 <paruthi143@gmail.com>
Restore `SYNTH_EXPLORE` configuration to avoid following error:
```
[ERROR]: during executing: "sed -i /defparam/d /openlane/designs/spm/runs/RUN_2022.10.18_10.40.09/results/synthesis/spm.v"
[ERROR]: Exit code: 1
[ERROR]: Last 10 lines:
sed: can't read /openlane/designs/spm/runs/RUN_2022.10.18_10.40.09/results/synthesis/spm.v: No such file or directory
```
Fixes #1392 