### PR TITLE
[BugFix] error path joining of get_design_path util

### DIFF
--- a/scripts/utils/utils.py
+++ b/scripts/utils/utils.py
@@ -19,9 +19,9 @@ import json
 
 
 def get_design_path(design):
-    path = os.path.abspath(design) + "/"
+    path = os.path.abspath(design)
     if not os.path.exists(path):
-        path = os.path.join(os.getcwd(), f"designs/{design}/")
+        path = os.path.join(os.getcwd(), "designs", design)
     if os.path.exists(path):
         return path
     else:

--- a/scripts/utils/utils.py
+++ b/scripts/utils/utils.py
@@ -21,7 +21,7 @@ import json
 def get_design_path(design):
     path = os.path.abspath(design) + "/"
     if not os.path.exists(path):
-        path = os.path.join(os.getcwd(), f"./designs/{design}/")
+        path = os.path.join(os.getcwd(), f"designs/{design}/")
     if os.path.exists(path):
         return path
     else:


### PR DESCRIPTION
The `get_design_path` function in `utils.py` has a bug. To run `python3 run_designs.py --regression scripts/config/regression.config spm`, it will show error:
> Traceback (most recent call last):
  File "run_designs.py", line 423, in <module>
    cli()
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 1128, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 1053, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 1395, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "run_designs.py", line 338, in cli
    ConfigHandler.gen_base_config(design, base_config_path)
  File "/openlane/scripts/config/config.py", line 105, in gen_base_config
    copyfile(config_file, base_config_file)
  File "/usr/lib64/python3.6/shutil.py", line 120, in copyfile
    with open(src, 'rb') as fsrc:
FileNotFoundError: [Errno 2] No such file or directory: '/openlane/./designs/spm/config.tcl'

This is because `os.path.join(os.getcwd(), f"./designs/{design}/")` is '/openlane/./designs/spm/'.