### PR TITLE
Add FuseSoC support for s44 design

### DIFF
--- a/designs/s44/data/sky130.tcl
+++ b/designs/s44/data/sky130.tcl
@@ -1,0 +1,5 @@
+set ::env(CLOCK_PERIOD) "30"
+set ::env(CLOCK_PORT) "config_clk"
+set ::env(CLOCK_NET) "config_clk"
+set ::env(FP_CORE_UTIL) 4
+set ::env(PL_TARGET_DENSITY) 0.5

--- a/designs/s44/s44.core
+++ b/designs/s44/s44.core
@@ -1,0 +1,29 @@
+CAPI=2:
+
+name : ::s44:0
+
+filesets:
+  rtl:
+    files:
+      - src/lut.v
+      - src/lut_s44.v
+    file_type : verilogSource
+
+  sky130:
+    files: [data/sky130.tcl : {file_type : tclSource}]
+
+targets:
+  default:
+    filesets : [rtl]
+
+  lint:
+    default_tool: verilator
+    filesets : [rtl]
+    tools:
+      verilator: {mode: lint-only}
+    toplevel : lut_s44
+
+  sky130:
+    default_tool: openlane
+    filesets : [rtl, sky130]
+    toplevel : lut_s44


### PR DESCRIPTION
This adds a core description file for the s44 core that exposes targets for linting and for building a GDSII using OpenLANE.

This PR is part of a larger effort to upstream OpenLANE support through FuseSoC+Edalize for ALL example designs that OpenLANE uses. The ambition is to avoid stale copies of files and instead making sure that any fixes comes to benefit to all users. The effort can be tracked [here](https://github.com/klasnordmark/openlane-examples/issues/2) This core was one of the only cores where we couldn't find a proper upstream, which is why we file this PR towards OpenLANE itself.

Quick FuseSoC instructions:

 #install FuseSoC
pip3 install fusesoc
 #Create and enter a new workspace
mkdir workspace && cd workspace
 #Register s44 as a library in the workspace
fusesoc library add s44 /path/to/s44
 #...if repo is available locally or...
fusesoc library add s44 https://github.com/The-OpenROAD-Project/OpenLane
 #...to get the upstream repo

 #To run lint
fusesoc run --target=lint s44
 #To build with OpenLANE running in a docker container
EDALIZE_LAUNCHER=el_docker fusesoc run --target=sky130 s44
 #List all targets
fusesoc core show s44