### PR TITLE
Add FuseSoC support for spm, s44

### DIFF
--- a/designs/s44/data/sky130.tcl
+++ b/designs/s44/data/sky130.tcl
@@ -1,0 +1,5 @@
+set ::env(CLOCK_PERIOD) "30"
+set ::env(CLOCK_PORT) "config_clk"
+set ::env(CLOCK_NET) "config_clk"
+set ::env(FP_CORE_UTIL) 4
+set ::env(PL_TARGET_DENSITY) 0.5

--- a/designs/s44/s44.core
+++ b/designs/s44/s44.core
@@ -1,0 +1,29 @@
+CAPI=2:
+
+name : ::s44:0
+
+filesets:
+  rtl:
+    files:
+      - src/lut.v
+      - src/lut_s44.v
+    file_type : verilogSource
+
+  sky130:
+    files: [data/sky130.tcl : {file_type : tclSource}]
+
+targets:
+  default:
+    filesets : [rtl]
+
+  lint:
+    default_tool: verilator
+    filesets : [rtl]
+    tools:
+      verilator: {mode: lint-only}
+    toplevel : lut_s44
+
+  sky130:
+    default_tool: openlane
+    filesets : [rtl, sky130]
+    toplevel : lut_s44

--- a/designs/spm/sky130.tcl
+++ b/designs/spm/sky130.tcl
@@ -1,0 +1,9 @@
+set ::env(DESIGN_NAME) "spm"
+set ::env(CLOCK_PERIOD) 10
+set ::env(CLOCK_PORT) "clk"
+set ::env(CLOCK_NET) "clk"
+set ::env(FP_PDN_VOFFSET) 7
+set ::env(FP_PDN_HOFFSET) 7
+set ::env(FP_PIN_ORDER_CFG) "pin_order.cfg"
+set ::env(FP_PDN_SKIPTRIM) true
+set ::env(FP_CORE_UTIL) 45

--- a/designs/spm/sky130.tcl
+++ b/designs/spm/sky130.tcl
@@ -1,4 +1,3 @@
-set ::env(DESIGN_NAME) "spm"
 set ::env(CLOCK_PERIOD) 10
 set ::env(CLOCK_PORT) "clk"
 set ::env(CLOCK_NET) "clk"

--- a/designs/spm/spm.core
+++ b/designs/spm/spm.core
@@ -1,0 +1,28 @@
+CAPI=2:
+
+name : efabless::spm:0
+
+filesets:
+  rtl:
+    files: [src/spm.v : {file_type : verilogSource}]
+
+  sky130:
+    files:
+      - pin_order.cfg : {file_type : user, copyto : .}
+      - sky130.tcl : {file_type : tclSource}
+
+targets:
+  default:
+    filesets : [rtl]
+
+  lint:
+    default_tool : verilator
+    filesets : [rtl]
+    tools:
+      verilator: {mode: lint-only}
+    toplevel: spm
+
+  sky130:
+    default_tool : openlane
+    filesets: [rtl, sky130]
+    toplevel : spm


### PR DESCRIPTION
This adds a core description file for the spm core that exposes targets for linting and for building a GDSII using OpenLANE.

This PR is part of a larger effort to upstream OpenLANE support through FuseSoC+Edalize for ALL example designs that OpenLANE uses. The ambition is to avoid stale copies of files and instead making sure that any fixes comes to benefit to all users. The effort can be tracked https://github.com/klasnordmark/openlane-examples/issues/2 This core was one of the only cores where we couldn't find a proper upstream, which is why we file this PR towards OpenLANE itself.

Quick FuseSoC instructions:

 #install FuseSoC
pip3 install fusesoc
 #Create and enter a new workspace
mkdir workspace && cd workspace
 #Register spm as a library in the workspace
fusesoc library add spm /path/to/spm
 #...if repo is available locally or...
fusesoc library add spm https://github.com/The-OpenROAD-Project/OpenLane
 #...to get the upstream repo

 #To run lint
fusesoc run --target=lint efabless::spm
 #To build with OpenLANE running in a docker container
EDALIZE_LAUNCHER=el_docker fusesoc run --target=sky130 efabless::spm
 #List all targets
fusesoc core show efabless::spm