### PR TITLE
Fix odb python calls to latest openroad.

### DIFF
--- a/scripts/odbpy/contextualize.py
+++ b/scripts/odbpy/contextualize.py
@@ -93,7 +93,7 @@ def contextualize(reader, top_def, top_lef, keep_inner_connections):
                 if node_inst_name not in created_macros:
                     created_macros[node_inst_name] = 1
                     print("Creating: ", node_master.getName(), node_inst_name)
-                    new_inst = odb.dbInst_create(
+                    new_inst = odb.dbInst.create(
                         macro.block, node_master, node_inst_name
                     )
                     new_inst.setOrient(node_inst.getOrient())

--- a/scripts/odbpy/defutil.py
+++ b/scripts/odbpy/defutil.py
@@ -80,7 +80,7 @@ def merge_components(reader, donor_def, input_lef):
     recipient = reader
 
     for instance in donor.instances:
-        odb.dbInst_create(recipient.block, instance.getMaster(), instance.getName())
+        odb.dbInst.create(recipient.block, instance.getMaster(), instance.getName())
 
 
 cli.add_command(merge_components)
@@ -459,7 +459,7 @@ def add_obstructions(obstructions, reader):
         dbu = reader.tech.getDbUnitsPerMicron()
         bbox = [int(x * dbu) for x in bbox]
         print("Creating an obstruction on", layer, "at", *bbox, "(DBU)")
-        odb.dbObstruction_create(reader.block, reader.tech.findLayer(layer), *bbox)
+        odb.dbObstruction.create(reader.block, reader.tech.findLayer(layer), *bbox)
 
 
 cli.add_command(add_obstructions)

--- a/scripts/odbpy/diodes.py
+++ b/scripts/odbpy/diodes.py
@@ -253,7 +253,7 @@ class DiodeInserter:
         diode_inst_name = "ANTENNA_" + inst_name + "_" + it.getMTerm().getConstName()
         diode_master = self.true_diode_master if force_true else self.diode_master
 
-        diode_inst = odb.dbInst_create(self.block, diode_master, diode_inst_name)
+        diode_inst = odb.dbInst.create(self.block, diode_master, diode_inst_name)
 
         diode_inst.setOrient(do)
         diode_inst.setLocation(dx, dy)

--- a/scripts/odbpy/io_place.py
+++ b/scripts/odbpy/io_place.py
@@ -367,7 +367,7 @@ def io_place(
                 assert len(pins) == 1
                 pin_bpin = pins[0]
             else:
-                pin_bpin = odb.dbBPin_create(bterm)
+                pin_bpin = odb.dbBPin.create(bterm)
 
             pin_bpin.setPlacementStatus("PLACED")
 
@@ -378,7 +378,7 @@ def io_place(
                 else:
                     y = BLOCK_LL_Y - V_EXTENSION
                 rect.moveTo(slot - V_WIDTH // 2, y)
-                odb.dbBox_create(pin_bpin, V_LAYER, *rect.ll(), *rect.ur())
+                odb.dbBox.create(pin_bpin, V_LAYER, *rect.ll(), *rect.ur())
             else:
                 rect = odb.Rect(0, 0, LENGTH + H_EXTENSION, H_WIDTH)
                 if side == "#E":
@@ -386,7 +386,7 @@ def io_place(
                 else:
                     x = BLOCK_LL_X - H_EXTENSION
                 rect.moveTo(x, slot - H_WIDTH // 2)
-                odb.dbBox_create(pin_bpin, H_LAYER, *rect.ll(), *rect.ur())
+                odb.dbBox.create(pin_bpin, H_LAYER, *rect.ll(), *rect.ur())
 
 
 if __name__ == "__main__":

--- a/scripts/odbpy/label_macro_pins.py
+++ b/scripts/odbpy/label_macro_pins.py
@@ -134,17 +134,17 @@ def label_macro_pins(
         net_name = pin_name
         net = top.block.findNet(net_name)
         if net is None:
-            net = odb.dbNet_create(top.block, net_name)
+            net = odb.dbNet.create(top.block, net_name)
 
         pin_bterm = top.block.findBTerm(pin_name)
         if pin_bterm is None:
-            pin_bterm = odb.dbBTerm_create(net, pin_name)
+            pin_bterm = odb.dbBTerm.create(net, pin_name)
 
         assert pin_bterm is not None, "Failed to create or find " + pin_name
 
         pin_bterm.setIoType(iotype)
 
-        pin_bpin = odb.dbBPin_create(pin_bterm)
+        pin_bpin = odb.dbBPin.create(pin_bterm)
         pin_bpin.setPlacementStatus("PLACED")
 
         if not all_shapes_flag:
@@ -154,7 +154,7 @@ def label_macro_pins(
 
         for box in boxes:
             layer, ll, ur = box
-            odb.dbBox_create(
+            odb.dbBox.create(
                 pin_bpin, layer, ll.getX(), ll.getY(), ur.getX(), ur.getY()
             )
 

--- a/scripts/odbpy/padringer.py
+++ b/scripts/odbpy/padringer.py
@@ -396,7 +396,7 @@ def padringer(
             placed_cells_count += 1
         else:
             # must be a filler cell
-            new_inst = odb.dbInst_create(
+            new_inst = odb.dbInst.create(
                 top.block, top.db.findMaster(master_name), inst_name
             )
             assert new_inst is not None, "Failed to create " + inst_name

--- a/scripts/odbpy/power_utils.py
+++ b/scripts/odbpy/power_utils.py
@@ -430,7 +430,7 @@ def power_route(
             upper_enclosure_x = via_params.getXTopEnclosure()
             upper_enclosure_y = via_params.getYTopEnclosure()
 
-            custom_via = odb.dbVia_create(reader.block, via_name)
+            custom_via = odb.dbVia.create(reader.block, via_name)
             custom_via.setViaGenerateRule(via_rule)
 
             array_width = width - 2 * max(lower_enclosure_x, upper_enclosure_x)
@@ -699,11 +699,11 @@ def power_route(
 
     # create special nets
     for special_net_name in SPECIAL_NETS:
-        net = odb.dbNet_create(reader.block, special_net_name)
+        net = odb.dbNet.create(reader.block, special_net_name)
         net.setSpecial()
         net.setWildConnected()
 
-        wire = odb.dbSWire_create(net, "ROUTED")
+        wire = odb.dbSWire.create(net, "ROUTED")
 
         SPECIAL_NETS[special_net_name]["net"] = net
         SPECIAL_NETS[special_net_name]["wire"] = wire
@@ -1110,7 +1110,7 @@ def power_route(
         print(net_name, ": drawing a special wire on layer", box["layer"].getName())
         rect = gridify(box["rect"])
         if isRoutingLayer(box["layer"]):
-            odb.dbSBox_create(
+            odb.dbSBox.create(
                 SPECIAL_NETS[net_name]["wire"],
                 box["layer"],
                 *rect.ll(),
@@ -1119,7 +1119,7 @@ def power_route(
                 odb.dbSBox.UNDEFINED,
             )
         else:
-            odb.dbSBox_create(
+            odb.dbSBox.create(
                 SPECIAL_NETS[net_name]["wire"],
                 box["layer"],
                 (rect.xMin() + rect.xMax()) // 2,
@@ -1139,7 +1139,7 @@ def power_route(
         sys.exit(1)
 
     # OUTPUT
-    odb.write_lef(odb.dbLib_getLib(reader.db, 1), f"{output}.lef")
+    odb.write_lef(odb.dbLib.getLib(reader.db, 1), f"{output}.lef")
 
 
 cli.add_command(power_route)


### PR DESCRIPTION
This PR fix ```odb``` python calls to newest ```openroad``` (5d135d53 / 2022-11-02).

* Latest API requires e.g. ```odb.dbBPin_create``` -> ```odb.dbBPin.create``` now.
* Having this PR all openlane targeting [rhel/fedora builds](https://copr.fedorainfracloud.org/coprs/rezso/VLSI/build/5005653/) (+checks) pass fine.

Thanks,
~Cristian.

---

The error message:
```
{...}
openroad -exit -no_init -python /usr/share/openlane/scripts/odbpy/io_place.py \
--config /usr/share/openlane/designs/spm/pin_order.cfg \
--hor-layer met3 --ver-layer met2  --ver-width-mult 2 --hor-width-mult 2  \
--hor-extension -1 --ver-extension -1 --length 4  --unmatched-error --input-lef  
{...}
File "/usr/share/openlane/scripts/odbpy/io_place.py", line 371, in io_place
    pin_bpin = odb.dbBPin_create(bterm)
               ^^^^^^^^^^^^^^^^^
AttributeError: module 'odb' has no attribute 'dbBPin_create'
```

All the valid objects ```import odb; print(dir(odb))``` are:

```
['ADS_MAX_CORNER', 'Oct', 'Point', 'Points', 'Polygon90Set', 'Polygon90Sets', 
'Rect', 'Rects', 'SwigPyIterator', '_SwigNonDynamicMeta', '__builtin__', 
'__builtins__', '__cached__', '__doc__', '__file__', '__loader__', '__lshift__',
 '__name__', '__package__', '__rshift__', '__spec__', '_dbViaParams', '_odb_py', 
'_swig_add_metaclass', '_swig_python_version_info', '_swig_repr', 
'_swig_setattr_nondynamic_class_variable', '_swig_setattr_nondynamic_instance_variable',
 'andSet', 'bloatSet', 'createSBoxes', 'dbAccessPoint', 'dbBPin', 'dbBTerm', 
'dbBlock', 'dbBlockCallBackObj', 'dbBlockage', 'dbBoolProperty', 'dbBox', 
'dbCCSeg', 'dbCapNode', 'dbChip', 'dbDatabase', 'dbDoubleProperty', 'dbFill', 
'dbGCellGrid', 'dbGlobalConnect', 'dbGroup', 'dbGuide', 'dbITerm', 'dbInst', 
'dbIntProperty', 'dbIsolation', 'dbIterator', 'dbLib', 'dbLogicPort', 'dbMPin',
 'dbMTerm', 'dbMaster', 'dbMetalWidthViaMap', 'dbModInst', 'dbModule', 'dbNet', 
'dbObstruction', 'dbPowerDomain', 'dbPowerSwitch', 'dbProperty', 'dbRSeg', 
'dbRegion', 'dbRow', 'dbRtEdge', 'dbRtEndStyle', 'dbRtNode', 'dbRtNodeEdgeIterator',
 'dbRtSegment', 'dbRtShort', 'dbRtTechVia', 'dbRtTree', 'dbRtVWire', 'dbRtVia', 
'dbSBox', 'dbSWire', 'dbSite', 'dbStringProperty', 'dbTarget', 'dbTech', 
'dbTechAntennaPinModel', 'dbTechLayer', 'dbTechLayerAntennaRule', 'dbTechLayerAreaRule', 
'dbTechLayerArraySpacingRule', 'dbTechLayerCornerSpacingRule', 'dbTechLayerCutClassRule', 
'dbTechLayerCutEnclosureRule', 'dbTechLayerCutSpacingRule', 'dbTechLayerCutSpacingTableDefRule', 
'dbTechLayerCutSpacingTableOrthRule', 'dbTechLayerEolExtensionRule', 'dbTechLayerEolKeepOutRule',
 'dbTechLayerMinCutRule', 'dbTechLayerMinStepRule', 'dbTechLayerRule', 'dbTechLayerSpacingEolRule',
 'dbTechLayerSpacingRule', 'dbTechLayerSpacingTablePrlRule', 'dbTechLayerWidthTableRule', 
'dbTechMinCutRule', 'dbTechMinEncRule', 'dbTechNonDefaultRule', 'dbTechSameNetRule', 
'dbTechV55InfluenceEntry', 'dbTechVia', 'dbTechViaGenerateRule', 'dbTechViaLayerRule',
 'dbTechViaRule', 'dbTrackGrid', 'dbTransform', 'dbVia', 'dbViaParams', 'dbWire', 
'dbWireDecoder', 'dbWireEncoder', 'dbWireGraph', 'db_def_diff', 'db_diff', 'dumpAPs', 
'dumpDecoder', 'dumpDecoder4Net', 'getPoints', 'getPolygons', 'getRectangles', 
'newSetFromRect', 'orSet', 'orSets', 'orderWires', 'read_db', 'read_def', 'read_lef',
 'shrinkSet', 'subtractSet', 'vector_str', 'write_db', 'write_def', 'write_lef', 
'write_macro_lef', 'write_tech_lef']

```
