### PR TITLE
Include all PDK lib files when merging

### DIFF
--- a/scripts/tcl_commands/all.tcl
+++ b/scripts/tcl_commands/all.tcl
@@ -736,7 +736,7 @@ proc prep {args} {
         merge_lib\
             -output $::env(LIB_SYNTH_MERGED)\
             -name $::env(PDK)_merged\
-            -inputs {*}$::env(LIB_SYNTH_COMPLETE)
+            -inputs $::env(LIB_SYNTH_COMPLETE)
 
         # trim synthesis library
         set ::env(LIB_SYNTH) $::env(synthesis_tmpfiles)/trimmed.lib


### PR DESCRIPTION
When using [asap7](https://github.com/The-OpenROAD-Project/asap7) (using [this version of volare](https://github.com/efabless/volare/pull/29) to install/activate), the OpenLane flow fails to complete synthesis. The issue is that many cells which are required to perform technology mapping cannot be found by `abc`, even though they're provided in the PDK. This is because when merging Liberty files, the current script fails to provide all files listed by the `LIB_SYNTH_COMPLETE` environment variable as input. This patch fixes that.

Note that this patch is not enough to enable a fully working flow for asap7; it merely fixes a single issue that arises in the process.