### PR TITLE
LIB_SYNTH_COMPLETE -> LIB_SYNTH_MERGED in some OpenROAD scripts

### DIFF
--- a/scripts/openroad/common/io.tcl
+++ b/scripts/openroad/common/io.tcl
@@ -38,7 +38,7 @@ proc read_libs {args} {
         keys {-override}\
         flags {-multi_corner}
 
-    set libs $::env(LIB_SYNTH_COMPLETE)
+    set libs $::env(LIB_SYNTH_MERGED)
 
     if { [info exists keys(-override)] } {
         set libs $keys(-override)

--- a/scripts/openroad/floorplan.tcl
+++ b/scripts/openroad/floorplan.tcl
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 source $::env(SCRIPTS_DIR)/openroad/common/io.tcl
-read_libs -override "$::env(LIB_SYNTH_COMPLETE)"
+read_libs -override "$::env(LIB_SYNTH_MERGED)"
 read_lef $::env(MERGED_LEF)
 read_netlist
 


### PR DESCRIPTION
When using asap7, LIB_SYNTH_COMPLETE specifies several files, instead of a single one, like many commands in the flow scripts expect. To work around this, we can specify LIB_SYNTH_MERGED instead, which, after `prep` in all.tcl is invoked, refers to the output of Liberty file merging, which should contain everything we need to continue in the flow.

This is what should have been done in 0291a965204e19bbabb2ca0658635b9f0288d05a.

Fixes #1486.