### PR TITLE
Document Error in JSON Config Files

### DIFF
--- a/designs/spm/config.json
+++ b/designs/spm/config.json
@@ -2,6 +2,7 @@
     "DESIGN_NAME": "spm",
     "VERILOG_FILES": "dir::src/*.v",
     "CLOCK_PERIOD": 10,
+    "TEST_FLOAT_REF": "expr::$CLOCK_PERIOD",
     "CLOCK_PORT": "clk",
     "CLOCK_NET": "ref::$CLOCK_PORT",
     "FP_PDN_VOFFSET": 7,

--- a/docs/source/reference/configuration_files.md
+++ b/docs/source/reference/configuration_files.md
@@ -103,7 +103,7 @@ Note that ***the order of declarations matter here***: as seen in the following 
 
 #### Variable Reference
 
-If a string's value starts with `ref::`, you can interpolate exactly one variable at the beginning of your string.
+If a string's value starts with `ref::`, you can interpolate exactly one **string** variable at the beginning of your string.
 
 Like conditional execution, the order of declarations matter: i.e., you cannot reference a variable that is declared after the current expression.
 
@@ -171,6 +171,16 @@ It is important to note that, like variable referencing and conditional executio
 }
 ```
 > In this example, the first configuration is invalid, as B is used in a mathematical expression before declaration, but the latter is OK, evaluating to 8.
+
+You can also simply reference another number using this prefix:
+
+```json
+{
+    "A": 10,
+    "B": "expr::$A"
+}
+```
+> In this example, B will simply hold the value of A.
 
 ## Tcl
 These configuration files are simple Tcl scripts with environment variables that are sourced by the OpenLane flow. Again, Tcl config files are not recommended for newer designs, but is still maintained and supported at the moment.

--- a/scripts/config/tcl.py
+++ b/scripts/config/tcl.py
@@ -241,6 +241,15 @@ def process_string(value: str, state: State) -> str:
         reference_variable = match[1]
         try:
             found = state.vars[reference_variable]
+            if type(found) != str:
+                if type(found) in [int, float]:
+                    raise InvalidConfig(
+                        f"Referenced variable {reference_variable} is a number and not a string: use expr::{match[0]} if you want to reference this number."
+                    )
+                else:
+                    raise InvalidConfig(
+                        f"Referenced variable {reference_variable} is not a string."
+                    )
             value = reference.replace(match[0], found)
             full_abspath = os.path.abspath(value)
 


### PR DESCRIPTION
+ Add error message and document corner case where `ref::` is used with a non-string