### PR TITLE
Fix forgotten openroad binary env variable

### DIFF
--- a/scripts/tcl_commands/all.tcl
+++ b/scripts/tcl_commands/all.tcl
@@ -102,7 +102,7 @@ proc prep_lefs {args} {
     if { $arg_values(-corner) == "nom" } {
         puts_verbose "Extracting the number of available metal layers from $arg_values(-tech_lef)..."
 
-        try_catch openroad -python\
+        try_catch $::env(OPENROAD_BIN) -python\
             $::env(SCRIPTS_DIR)/odbpy/lefutil.py get_metal_layers\
             -o $::env(TMP_DIR)/layers.list\
             $arg_values(-tech_lef)

--- a/scripts/tcl_commands/placement.tcl
+++ b/scripts/tcl_commands/placement.tcl
@@ -126,7 +126,7 @@ proc manual_macro_placement {args} {
         lappend arg_list --fixed
     }
 
-    try_catch openroad -python\
+    try_catch $::env(OPENROAD_BIN) -python\
         $::env(SCRIPTS_DIR)/odbpy/manual_macro_place.py {*}$arg_list |&\
         tee $::env(TERMINAL_OUTPUT) [index_file $::env(placement_logs)/macro_placement.log]
 


### PR DESCRIPTION
OpenLane cannot be used without this PR outside the Docker when OpenROAD is not on PATH