### PR TITLE
Makefile: disable seccomp to enable openroad ui

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ endif
 # Allow using GUIs
 UNAME_S = $(shell uname -s)
 ifeq ($(UNAME_S),Linux)
-DOCKER_OPTIONS += -e DISPLAY=$(DISPLAY) -v /tmp/.X11-unix:/tmp/.X11-unix -v $(HOME)/.Xauthority:/.Xauthority --network host
+DOCKER_OPTIONS += -e DISPLAY=$(DISPLAY) -v /tmp/.X11-unix:/tmp/.X11-unix -v $(HOME)/.Xauthority:/.Xauthority --network host --security-opt seccomp=unconfined
   ifneq ("$(wildcard $(HOME)/.openroad)","")
     DOCKER_OPTIONS += -v $(HOME)/.openroad:/.openroad
   endif


### PR DESCRIPTION
Resolves #1149

As described in https://docs.docker.com/engine/security/seccomp/#run-without-the-default-seccomp-profile