### PR TITLE
Multiple fixes for label_marco_pins

### DIFF
--- a/scripts/odbpy/label_macro_pins.py
+++ b/scripts/odbpy/label_macro_pins.py
@@ -35,24 +35,14 @@ from reader import OdbReader, click_odb
     help="Name of the pin of the pad as it appears in the netlist def.",
 )
 @click.option(
-    "-S", "--pin-size", default=1, type=int, help="Size of the block pin created in um"
-)
-@click.option(
     "-m",
     "--map",
-    "map_raw",
     default="",
     help="Semicolon;delimited extra mappings that are hard to infer from the netlist def. Format: -extra pad_instance_name pad_pin block_pin (INPUT|OUTPUT|INOUT)",
 )
 @click_odb
 def label_macro_pins(
-    netlist_def,
-    verbose,
-    all_shapes,
-    pad_pin_name,
-    map,
-    input_lef,
-    reader,
+    netlist_def, verbose, all_shapes, pad_pin_name, map, input_lef, reader,
 ):
     """
     Takes a DEF file with no PINS section, a LEF file that has the shapes of all
@@ -62,8 +52,11 @@ def label_macro_pins(
     """
     top = reader
 
-    extra_mappings = [tuple(m.split()) for m in map.split(";")]
-    extra_mappings_pin_names = [tup[2] for tup in extra_mappings]
+    extra_mappings = []
+    extra_mappings_pin_names = []
+    if map is not "":
+        extra_mappings = [tuple(m.split()) for m in map.split(";")]
+        extra_mappings_pin_names = [tup[2] for tup in extra_mappings]
 
     def getBiggestBox(iterm):
         inst = iterm.getInst()
@@ -237,11 +230,9 @@ def label_macro_pins(
             ]
         )
     )
-    assert pad_pins_to_label_count == len(
-        bterms
-    ), "Some pins were not going to be labeled %d/%d" % (
-        pad_pins_to_label_count,
-        len(bterms),
+    assert pad_pins_to_label_count == len(bterms), (
+        "Some pins were not going to be labeled %d/%d"
+        % (pad_pins_to_label_count, len(bterms),)
     )
     print("Labeling", len(pad_pin_map), "pads")
     print("Labeling", pad_pins_to_label_count, "pad pins")

--- a/scripts/odbpy/label_macro_pins.py
+++ b/scripts/odbpy/label_macro_pins.py
@@ -42,7 +42,13 @@ from reader import OdbReader, click_odb
 )
 @click_odb
 def label_macro_pins(
-    netlist_def, verbose, all_shapes, pad_pin_name, map, input_lef, reader,
+    netlist_def,
+    verbose,
+    all_shapes,
+    pad_pin_name,
+    map,
+    input_lef,
+    reader,
 ):
     """
     Takes a DEF file with no PINS section, a LEF file that has the shapes of all
@@ -230,9 +236,11 @@ def label_macro_pins(
             ]
         )
     )
-    assert pad_pins_to_label_count == len(bterms), (
-        "Some pins were not going to be labeled %d/%d"
-        % (pad_pins_to_label_count, len(bterms),)
+    assert pad_pins_to_label_count == len(
+        bterms
+    ), "Some pins were not going to be labeled %d/%d" % (
+        pad_pins_to_label_count,
+        len(bterms),
     )
     print("Labeling", len(pad_pin_map), "pads")
     print("Labeling", pad_pins_to_label_count, "pad pins")

--- a/scripts/odbpy/label_macro_pins.py
+++ b/scripts/odbpy/label_macro_pins.py
@@ -60,7 +60,7 @@ def label_macro_pins(
 
     extra_mappings = []
     extra_mappings_pin_names = []
-    if map is not "":
+    if map != "":
         extra_mappings = [tuple(m.split()) for m in map.split(";")]
         extra_mappings_pin_names = [tup[2] for tup in extra_mappings]
 

--- a/scripts/tcl_commands/all.tcl
+++ b/scripts/tcl_commands/all.tcl
@@ -1131,7 +1131,7 @@ proc label_macro_pins {args} {
         -input $::env(CURRENT_ODB) \
         --netlist-def $arg_values(-netlist_def)\
         --pad-pin-name $arg_values(-pad_pin_name)\
-        {*}$extra_args
+        {*}$arg_values(-extra_args)
 
     TIMER::timer_stop
     exec echo "[TIMER::get_runtime]" | python3 $::env(SCRIPTS_DIR)/write_runtime.py "label macro pins - label_macro_pins.py"


### PR DESCRIPTION
\~ use the right variable for extra_args in the tcl function
\- remove unused option `--pin-size`
\- remove option (label?) `map_raw`
\~ don't parse extra_mappings if they are empty
\~ formatting