### PR TITLE
Add `report_parasitic_annotation` to sta

### DIFF
--- a/scripts/openroad/sta.tcl
+++ b/scripts/openroad/sta.tcl
@@ -66,7 +66,7 @@ puts "\n========================================================================
 puts "report_parasitic_annotation -report_unannotated"
 puts "============================================================================"
 report_parasitic_annotation -report_unannotated
-puts "annotated_check_report_end"
+puts "parastic_annotation_check"
 
 puts "check_slew"
 puts "\n==========================================================================="

--- a/scripts/openroad/sta.tcl
+++ b/scripts/openroad/sta.tcl
@@ -61,6 +61,13 @@ puts "==========================================================================
 report_checks -slack_max -0.01 -fields {slew cap input nets fanout} -format full_clock_expanded
 puts "check_report_end"
 
+puts "parastic_annotation_check"
+puts "\n==========================================================================="
+puts "report_parasitic_annotation -report_unannotated"
+puts "============================================================================"
+report_parasitic_annotation -report_unannotated
+puts "annotated_check_report_end"
+
 puts "check_slew"
 puts "\n==========================================================================="
 puts " report_check_types -max_slew -max_cap -max_fanout -violators"

--- a/scripts/openroad/sta_multi_corner.tcl
+++ b/scripts/openroad/sta_multi_corner.tcl
@@ -80,6 +80,12 @@ puts "\n======================= Fastest Corner =================================
 report_checks -slack_max -0.01 -fields {slew cap input nets fanout} -format full_clock_expanded -corner ff
 puts "check_report_end"
 
+puts "parastic_annotation_check"
+puts "\n==========================================================================="
+puts "report_parasitic_annotation -report_unannotated"
+puts "============================================================================"
+report_parasitic_annotation -report_unannotated
+puts "parastic_annotation_check_end"
 
 puts "check_slew"
 puts "\n==========================================================================="

--- a/scripts/report/report.py
+++ b/scripts/report/report.py
@@ -226,6 +226,7 @@ class Report(object):
 
         basic_set = [
             ("_sta.rpt", "check_report"),
+            ("_sta.parasitics_check.rpt", "parastic_annotation_check"),
             ("_sta.min.rpt", "min_report"),
             ("_sta.max.rpt", "max_report"),
             ("_sta.wns.rpt", "wns_report"),


### PR DESCRIPTION
A substitute for https://github.com/The-OpenROAD-Project/OpenLane/pull/1425. `report_annotated_check` works on annotations done by sdf files while we read in a spef file and for that we need `report_parasitic_annotation` instead.