### PR TITLE
KLayout GDSII updates

### DIFF
--- a/configuration/checkers.tcl
+++ b/configuration/checkers.tcl
@@ -34,4 +34,4 @@ set ::env(QUIT_ON_ILLEGAL_OVERLAPS) 1
 set ::env(QUIT_ON_LVS_ERROR) 1
 
 # Klayout
-set ::env(QUIT_ON_XOR_ERROR) 0
+set ::env(QUIT_ON_XOR_ERROR) 1

--- a/configuration/general.tcl
+++ b/configuration/general.tcl
@@ -79,6 +79,7 @@ set ::env(RUN_KLAYOUT_DRC) 0
 set ::env(KLAYOUT_XOR_GDS) 1
 set ::env(KLAYOUT_XOR_XML) 1
 set ::env(KLAYOUT_XOR_THREADS) 1
+set ::env(KLAYOUT_XOR_IGNORE_LAYERS) ""
 set ::env(TAKE_LAYOUT_SCROT) 0
 set ::env(KLAYOUT_DRC_KLAYOUT_GDS) 0
 set ::env(RUN_KLAYOUT_XOR) 1

--- a/dependencies/tool_metadata.yml
+++ b/dependencies/tool_metadata.yml
@@ -68,7 +68,7 @@
   in_install: false
 - name: open_pdks
   repo: https://github.com/RTimothyEdwards/open_pdks
-  commit: 3f9bdbd857564726b731760dc2c817e84ca7d8ac
+  commit: 327e268bdb7191fe07a28bd40eeac055bba9dffd
   build: ''
   in_install: false
   pdk: true

--- a/docs/source/for_developers/pdk_structure.md
+++ b/docs/source/for_developers/pdk_structure.md
@@ -44,8 +44,8 @@ This section defines the neccessary variables for PDK configuration file. Note t
 | `MAGIC_TECH_FILE` | Points to the magic tech file which mainly has drc rules. |
 | `KLAYOUT_TECH` | Points to the klayout tech file (.lyt). |
 | `KLAYOUT_PROPERTIES` | Points to the klayout properties file (.lyp). |
-| `KLAYOUT_DEF_LAYER_MAP` | Points to the klayout deflef layer map file (.lmp). |
-| `KLAYOUT_XOR_IGNORE_LIST` | A space separated list of layers to ignore during klayout xor check. |
+| `KLAYOUT_DEF_LAYER_MAP` | Points to klayout deflef layer map file (.map). |
+| `KLAYOUT_XOR_IGNORE_LAYERS` | A space separated layers list to ignore during klayout xor check. |
 | `MAGIC_MAGICRC` | Points to the magicrc file that is sourced while running magic in the flow. |
 | `GPIO_PADS_LEF` | A list of the pads lef views. For example:`[glob "$::env(PDK_ROOT)/sky130A/libs.ref/sky130_fd_io/lef/sky130_fd_io.lef"]` |
 | `GPIO_PADS_PREFIX` | A list of pad cells name prefixes. |

--- a/docs/source/for_developers/pdk_structure.md
+++ b/docs/source/for_developers/pdk_structure.md
@@ -44,6 +44,7 @@ This section defines the neccessary variables for PDK configuration file. Note t
 | `MAGIC_TECH_FILE` | Points to the magic tech file which mainly has drc rules. |
 | `KLAYOUT_TECH` | Points to the klayout tech file (.lyt). |
 | `KLAYOUT_PROPERTIES` | Points to the klayout properties file (.lyp). |
+| `KLAYOUT_DEF_LAYER_MAP` | Points to the klayout deflef layer map file (.lmp). |
 | `MAGIC_MAGICRC` | Points to the magicrc file that is sourced while running magic in the flow. |
 | `GPIO_PADS_LEF` | A list of the pads lef views. For example:`[glob "$::env(PDK_ROOT)/sky130A/libs.ref/sky130_fd_io/lef/sky130_fd_io.lef"]` |
 | `NETGEN_SETUP_FILE` | Points to the setup file for netgen(lvs), that can exclude certain cells etc.. |

--- a/docs/source/for_developers/pdk_structure.md
+++ b/docs/source/for_developers/pdk_structure.md
@@ -45,7 +45,7 @@ This section defines the neccessary variables for PDK configuration file. Note t
 | `KLAYOUT_TECH` | Points to the klayout tech file (.lyt). |
 | `KLAYOUT_PROPERTIES` | Points to the klayout properties file (.lyp). |
 | `KLAYOUT_DEF_LAYER_MAP` | Points to the klayout deflef layer map file (.lmp). |
-| `KLAYOUT_XOR_IGNORE_LAYERS` | A space separated list of layers to ignore during klayout xor check. |
+| `KLAYOUT_XOR_IGNORE_LIST` | A space separated list of layers to ignore during klayout xor check. |
 | `MAGIC_MAGICRC` | Points to the magicrc file that is sourced while running magic in the flow. |
 | `GPIO_PADS_LEF` | A list of the pads lef views. For example:`[glob "$::env(PDK_ROOT)/sky130A/libs.ref/sky130_fd_io/lef/sky130_fd_io.lef"]` |
 | `GPIO_PADS_PREFIX` | A list of pad cells name prefixes. |

--- a/docs/source/for_developers/pdk_structure.md
+++ b/docs/source/for_developers/pdk_structure.md
@@ -45,6 +45,7 @@ This section defines the neccessary variables for PDK configuration file. Note t
 | `KLAYOUT_TECH` | Points to the klayout tech file (.lyt). |
 | `KLAYOUT_PROPERTIES` | Points to the klayout properties file (.lyp). |
 | `KLAYOUT_DEF_LAYER_MAP` | Points to the klayout deflef layer map file (.lmp). |
+| `KLAYOUT_XOR_IGNORE_LAYERS` | A space separated list of layers to ignore during klayout xor check. |
 | `MAGIC_MAGICRC` | Points to the magicrc file that is sourced while running magic in the flow. |
 | `GPIO_PADS_LEF` | A list of the pads lef views. For example:`[glob "$::env(PDK_ROOT)/sky130A/libs.ref/sky130_fd_io/lef/sky130_fd_io.lef"]` |
 | `GPIO_PADS_PREFIX` | A list of pad cells name prefixes. |

--- a/scripts/klayout/stream_out.py
+++ b/scripts/klayout/stream_out.py
@@ -65,7 +65,7 @@ except ImportError:
     @click.option(
         "--def-layer-map-file",
         required=True,
-        help="KLayout .lmp (layer map file) file",
+        help="KLayout .map (deflef layer map) file",
     )
     @click.option(
         "-T",

--- a/scripts/klayout/stream_out.py
+++ b/scripts/klayout/stream_out.py
@@ -63,6 +63,11 @@ except ImportError:
         default=os.getenv("MERGED_LEF"),
     )
     @click.option(
+        "--def-layer-map-file",
+        required=True,
+        help="KLayout .lmp (layer map file) file",
+    )
+    @click.option(
         "-T",
         "--tech-file",
         "lyt",
@@ -89,6 +94,7 @@ except ImportError:
         lyp,
         input_gds_files,
         seal_gds_file,
+        def_layer_map_file,
         top,
         input_def,
     ):
@@ -101,6 +107,8 @@ except ImportError:
             f"out_gds={output}",
             "-rd",
             f"lef_file={input_lef}",
+            "-rd",
+            f"def_layer_map_file={def_layer_map_file}",
             "-rd",
             f"tech_file={lyt}",
             "-rd",
@@ -142,6 +150,7 @@ try:
     layout_options = tech.load_layout_options
     layout_options.lefdef_config.macro_resolution_mode = 1
     layout_options.lefdef_config.lef_files = [lef_file]
+    layout_options.lefdef_config.map_file = def_layer_map_file
 
     # Load def file
     main_layout = pya.Layout()

--- a/scripts/klayout/xor.drc
+++ b/scripts/klayout/xor.drc
@@ -20,6 +20,9 @@ if !defined?(RBA)
     opts.on("-R", "--report REPORT_FILE", "Text file  (default: #{options[:rpt_out]})") do |rpt_out|
       options[:rpt_out] = rpt_out
     end
+    opts.on("-i", "--ignore file1,file2,...", "Ignore layer(s)") do |ignore|
+      options[:ignore] = ignore
+    end
     # opts.on("-O", "--gds-out OUTPUT", "GDS output file (required)") do |gds_out|
     #   options[:gds_out] = gds_out
     # end
@@ -28,7 +31,7 @@ if !defined?(RBA)
     end
   end
   optparse.parse!
-  
+
   if [options[:rdb_out], options[:top_cell]].include?(nil)
     puts optparse.help
     exit 64
@@ -43,6 +46,7 @@ if !defined?(RBA)
     "-rd", "jobs=1",
     "-rd", "rdb_out=#{File.absolute_path(options[:rdb_out])}",
     "-rd", "rpt_out=#{File.absolute_path(options[:rpt_out])}",
+    "-rd", "ignore=#{options[:ignore]}",
     # "-rd", "gds_out=#{options[:gds_out]}",
   ]
   puts "Running: '#{args.join(" ")}'..."
@@ -81,14 +85,18 @@ end
 ## Perform per-layer XOR
 total_xor_differences = 0
 layers.keys.sort.each do |layer_name|
-  info "--- Running XOR for layer #{layer_name} ---"
-  
-  layer_info = layers[layer_name]
-  xor_data = a.input(layer_name) ^ b.input(layer_name)
-  total_xor_differences += xor_data.data.size
-  info "XOR differences: #{xor_data.data.size}"
+  if $ignore.include? layer_name
+    warn "Skipping #{layer_name}"
+  else
+    info "--- Running XOR for layer #{layer_name} ---"
 
-  write_data xor_data, layer_info
+    layer_info = layers[layer_name]
+    xor_data = a.input(layer_name) ^ b.input(layer_name)
+    total_xor_differences += xor_data.data.size
+    info "XOR differences: #{xor_data.data.size}"
+
+    write_data xor_data, layer_info
+   end
 end
 
 info "---"

--- a/scripts/klayout/xor.drc
+++ b/scripts/klayout/xor.drc
@@ -20,7 +20,7 @@ if !defined?(RBA)
     opts.on("-R", "--report REPORT_FILE", "Text file  (default: #{options[:rpt_out]})") do |rpt_out|
       options[:rpt_out] = rpt_out
     end
-    opts.on("-i", "--ignore file1,file2,...", "Ignore layer(s)") do |ignore|
+    opts.on("-i", "--ignore SPACE_DELIMITED_LIST", "Ignore layer(s)") do |ignore|
       options[:ignore] = ignore
     end
     # opts.on("-O", "--gds-out OUTPUT", "GDS output file (required)") do |gds_out|

--- a/scripts/tcl_commands/klayout.tcl
+++ b/scripts/tcl_commands/klayout.tcl
@@ -36,6 +36,7 @@ proc run_klayout {args} {
         try_catch python3 $::env(SCRIPTS_DIR)/klayout/stream_out.py\
 			--output $klayout_out\
 			--tech-file $::env(KLAYOUT_TECH)\
+			--def-layer-map-file $::env(KLAYOUT_DEF_LAYER_MAP)\
 			--props-file $::env(KLAYOUT_PROPERTIES)\
 			--top $::env(DESIGN_NAME)\
             {*}$gds_file_arg \

--- a/scripts/tcl_commands/klayout.tcl
+++ b/scripts/tcl_commands/klayout.tcl
@@ -160,6 +160,7 @@ proc run_klayout_gds_xor {args} {
                 -rd b=$arg_values(-layout2) \
                 -rd jobs=$::env(KLAYOUT_XOR_THREADS) \
                 -rd rdb_out=$db \
+                -rd ignore=$::env(KLAYOUT_XOR_IGNORE_LAYERS) \
                 -rd rpt_out=$report \
                 |& tee $::env(TERMINAL_OUTPUT) $log
 			TIMER::timer_stop

--- a/scripts/tcl_commands/klayout.tcl
+++ b/scripts/tcl_commands/klayout.tcl
@@ -160,7 +160,7 @@ proc run_klayout_gds_xor {args} {
                 -rd b=$arg_values(-layout2) \
                 -rd jobs=$::env(KLAYOUT_XOR_THREADS) \
                 -rd rdb_out=$db \
-                -rd ignore=$::env(KLAYOUT_XOR_IGNORE_LIST) \
+                -rd ignore=$::env(KLAYOUT_XOR_IGNORE_LAYERS) \
                 -rd rpt_out=$report \
                 |& tee $::env(TERMINAL_OUTPUT) $log
 			TIMER::timer_stop

--- a/scripts/tcl_commands/klayout.tcl
+++ b/scripts/tcl_commands/klayout.tcl
@@ -160,7 +160,7 @@ proc run_klayout_gds_xor {args} {
                 -rd b=$arg_values(-layout2) \
                 -rd jobs=$::env(KLAYOUT_XOR_THREADS) \
                 -rd rdb_out=$db \
-                -rd ignore=$::env(KLAYOUT_XOR_IGNORE_LAYERS) \
+                -rd ignore=$::env(KLAYOUT_XOR_IGNORE_LIST) \
                 -rd rpt_out=$report \
                 |& tee $::env(TERMINAL_OUTPUT) $log
 			TIMER::timer_stop


### PR DESCRIPTION
\+ Add `KLAYOUT_DEF_LAYER_MAP` for DEF/LEF mapping in klayout. `.lyt` is not sufficient to map a pin shape to pin and metal for example. 
\+ Add `KLAYOUT_XOR_IGNORE_LAYERS` see https://github.com/RTimothyEdwards/open_pdks/pull/347 (default: empty) 
\~ Enable `QUIT_ON_XOR_ERROR` by default