### PR TITLE
`write_verilog` from a `DEF` file

### DIFF
--- a/scripts/openroad/common/io.tcl
+++ b/scripts/openroad/common/io.tcl
@@ -86,7 +86,7 @@ proc read {args} {
         keys {-override_libs}\
         flags {-multi_corner_libs}
 
-    if { [info exists ::env(IO_READ_DEF)] } {
+    if { [info exists ::env(IO_READ_DEF)] && $::env(IO_READ_DEF) } {
         if { [ catch {read_lef $::env(MERGED_LEF)} errmsg ]} {
             puts stderr $errmsg
             exit 1

--- a/scripts/openroad/common/io.tcl
+++ b/scripts/openroad/common/io.tcl
@@ -86,7 +86,17 @@ proc read {args} {
         keys {-override_libs}\
         flags {-multi_corner_libs}
 
-    if {[catch {read_db $::env(CURRENT_ODB)} errmsg]} {
+    if {
+        [catch {
+            if { [info exists ::env(DEF_IN)] } {
+                puts "Reading def $::env(DEF_IN)"
+                read_lef $::env(MERGED_LEF)
+                read_def $::env(DEF_IN)
+            } else {
+                puts "Reading odb $::env(CURRENT_ODB)"
+                read_db $::env(CURRENT_ODB)
+            }
+        } errmsg]} {
         puts stderr $errmsg
         exit 1
     }

--- a/scripts/openroad/common/io.tcl
+++ b/scripts/openroad/common/io.tcl
@@ -86,18 +86,21 @@ proc read {args} {
         keys {-override_libs}\
         flags {-multi_corner_libs}
 
-    if {
-        [catch {
-            if { [info exists ::env(IO_READ_DEF)] } {
-                read_lef $::env(MERGED_LEF)
-                read_def $::env(CURRENT_DEF)
-            } else {
-                puts "Reading odb $::env(CURRENT_ODB)"
-                read_db $::env(CURRENT_ODB)
-            }
-        } errmsg]} {
-        puts stderr $errmsg
-        exit 1
+    if { [info exists ::env(IO_READ_DEF)] } {
+        if { [ catch {read_lef $::env(MERGED_LEF)} errmsg ]} {
+            puts stderr $errmsg
+            exit 1
+        }
+        if { [ catch {read_def $::env(CURRENT_DEF)} errmsg ]} {
+            puts stderr $errmsg
+            exit 1
+        }
+    } else {
+        puts "\[INFO\]: Reading ODB at '$::env(CURRENT_ODB)'..."
+        if { [ catch {read_db $::env(CURRENT_ODB)} errmsg ]} {
+            puts stderr $errmsg
+            exit 1
+        }
     }
 
     set read_libs_args [list]

--- a/scripts/openroad/common/io.tcl
+++ b/scripts/openroad/common/io.tcl
@@ -88,10 +88,9 @@ proc read {args} {
 
     if {
         [catch {
-            if { [info exists ::env(DEF_IN)] } {
-                puts "Reading def $::env(DEF_IN)"
+            if { [info exists ::env(IO_READ_DEF)] } {
                 read_lef $::env(MERGED_LEF)
-                read_def $::env(DEF_IN)
+                read_def $::env(CURRENT_DEF)
             } else {
                 puts "Reading odb $::env(CURRENT_ODB)"
                 read_db $::env(CURRENT_ODB)

--- a/scripts/tcl_commands/all.tcl
+++ b/scripts/tcl_commands/all.tcl
@@ -1165,9 +1165,14 @@ proc write_verilog {args} {
         set save_arg "$save_arg,powered_netlist=$arg_values(-powered_to)"
     }
 
+    set arg_list [list]
+    lappend arg_list -indexed_log $arg_values(-indexed_log)
+    lappend arg_list -save $save_arg
+    if { [info exists arg_values(-def)] } {
+        lappend arg_list -def_in
+    }
     run_openroad_script $::env(SCRIPTS_DIR)/openroad/write_views.tcl\
-        -indexed_log $arg_values(-indexed_log)\
-        -save $save_arg
+        {*}$arg_list
 
     set $::env(CURRENT_DEF) $current_def_backup
 

--- a/scripts/tcl_commands/all.tcl
+++ b/scripts/tcl_commands/all.tcl
@@ -1147,7 +1147,6 @@ proc write_verilog {args} {
     set flags {}
     parse_key_args "write_verilog" args arg_values $options flags_map $flags
 
-    set_if_unset arg_values(-def) $::env(CURRENT_DEF)
     set_if_unset arg_values(-indexed_log) /dev/null
 
     increment_index
@@ -1158,9 +1157,6 @@ proc write_verilog {args} {
 
     set save_arg "odb=/dev/null,netlist=$filename"
 
-    set current_def_backup $::env(CURRENT_DEF)
-    set ::env(CURRENT_DEF) $arg_values(-def)
-
     if { [info exists arg_values(-powered_to)] } {
         set save_arg "$save_arg,powered_netlist=$arg_values(-powered_to)"
     }
@@ -1168,9 +1164,12 @@ proc write_verilog {args} {
     set arg_list [list]
     lappend arg_list -indexed_log $arg_values(-indexed_log)
     lappend arg_list -save $save_arg
+    set current_def_backup $::env(CURRENT_DEF)
     if { [info exists arg_values(-def)] } {
+        set ::env(CURRENT_DEF) $arg_values(-def)
         lappend arg_list -def_in
     }
+
     run_openroad_script $::env(SCRIPTS_DIR)/openroad/write_views.tcl\
         {*}$arg_list
 

--- a/scripts/utils/utils.tcl
+++ b/scripts/utils/utils.tcl
@@ -487,7 +487,7 @@ proc run_tcl_script {args} {
     set name $::env(DESIGN_NAME)
 
     if { [info exists flag_map(-def_in)] } {
-        set ::env(DEF_IN) $::env(CURRENT_DEF)
+        set ::env(IO_READ_DEF) 1
     }
 
     set saved_values [split $arg_values(-save) ","]
@@ -649,7 +649,7 @@ proc run_tcl_script {args} {
     }
 
     if { [info exists arg_values(-def_in)] } {
-        unset ::env(DEF_IN)
+        unset ::env(IO_READ_DEF)
     }
 
     if { ![info exist flag_map(-no_update_current)]} {

--- a/scripts/utils/utils.tcl
+++ b/scripts/utils/utils.tcl
@@ -471,7 +471,6 @@ proc run_tcl_script {args} {
     # -no_update_current: See '-save'
     set flags {-def_in -netlist_in -gui -no_update_current}
 
-    puts "{*}$args"
     parse_key_args "run_tcl_script" args arg_values $options flag_map $flags
 
     set_if_unset arg_values(-indexed_log) /dev/null

--- a/scripts/utils/utils.tcl
+++ b/scripts/utils/utils.tcl
@@ -469,8 +469,9 @@ proc run_tcl_script {args} {
     # -def_in: Specify that the input is CURRENT_DEF and not the ODB file.
     # -gui: Launch the GUI (OpenROAD Only)
     # -no_update_current: See '-save'
-    set flags {-netlist_in -gui -no_update_current}
+    set flags {-def_in -netlist_in -gui -no_update_current}
 
+    puts "{*}$args"
     parse_key_args "run_tcl_script" args arg_values $options flag_map $flags
 
     set_if_unset arg_values(-indexed_log) /dev/null
@@ -485,6 +486,10 @@ proc run_tcl_script {args} {
     set metrics_path ""
     set index 1
     set name $::env(DESIGN_NAME)
+
+    if { [info exists flag_map(-def_in)] } {
+        set ::env(DEF_IN) $::env(CURRENT_DEF)
+    }
 
     set saved_values [split $arg_values(-save) ","]
 
@@ -642,6 +647,10 @@ proc run_tcl_script {args} {
             puts_info "Reproducible packaged at '$reproducible_dir_relative'."
             exit 0
         }
+    }
+
+    if { [info exists arg_values(-def_in)] } {
+        unset ::env(DEF_IN)
     }
 
     if { ![info exist flag_map(-no_update_current)]} {


### PR DESCRIPTION
~ allow write_verilog to have an input def file 
~ allow reading in def/lef for openroad scripts


More on the PR:

Addresses a bug in `write_powered_verilog` where `write_verilog` didn't read the def produced by `write_powered_def`. `write_powered_def` proved to be useful as it parses a yosys netlist where(supposedly) all power connections are defined. If due to a misconfiguration or other reasons, openroad creates faulty power connections, the openroad gl netlist will also have the same faulty power connections resulting in misleading lvs results. The mentioned behavior was surfaced in https://github.com/The-OpenROAD-Project/OpenLane/issues/1600