### PR TITLE
Fix loading design configs again

### DIFF
--- a/scripts/config/tcl.py
+++ b/scripts/config/tcl.py
@@ -254,12 +254,11 @@ def process_string(value: str, state: State) -> str:
             full_abspath = os.path.abspath(value)
 
             # Resolve globs for paths that are inside the exposed directory
-            if value.startswith("/"):
-                if full_abspath.startswith(found):
-                    files = glob.glob(full_abspath)
-                    if files:
-                        files_escaped = [file.replace("$", r"\$") for file in files]
-                        value = " ".join(files_escaped)
+            if value.startswith("/") and full_abspath.startswith(found):
+                files = glob.glob(full_abspath)
+                if files:
+                    files_escaped = [file.replace("$", r"\$") for file in files]
+                    value = " ".join(files_escaped)
         except KeyError:
             raise InvalidConfig(
                 f"Referenced variable '{reference_variable}' not found."

--- a/scripts/config/tcl.py
+++ b/scripts/config/tcl.py
@@ -294,7 +294,7 @@ def process_config_dict_recursive(config_in: Dict[str, Any], state: State):
         withhold = False
         try:
             if not isinstance(key, str):
-                raise InvalidConfig(f"must be a string.")
+                raise InvalidConfig("must be a string")
             if isinstance(value, dict):
                 withhold = True
                 if key.startswith(PDK_PREFIX):
@@ -318,7 +318,7 @@ def process_config_dict_recursive(config_in: Dict[str, Any], state: State):
 
                 if not valid:
                     raise InvalidConfig(
-                        f"Invalid value: Arrays must consist only of strings."
+                        "Invalid value: Arrays must consist only of strings."
                     )
                 value = " ".join(processed)
             else:

--- a/scripts/config/tcl.py
+++ b/scripts/config/tcl.py
@@ -254,10 +254,15 @@ def process_string(value: str, state: State) -> str:
             full_abspath = os.path.abspath(value)
 
             # Resolve globs for paths that are inside the exposed directory
-            if value.startswith("/") and full_abspath.startswith(found):
-                files = glob.glob(full_abspath)
-                files_escaped = [file.replace("$", r"\$") for file in files]
-                value = " ".join(files_escaped)
+            if value.startswith("/"):
+                if full_abspath.startswith(found):
+                    files = glob.glob(full_abspath)
+                    if not files:
+                        raise InvalidConfig(f"No such file {full_abspath}")
+                    files_escaped = [file.replace("$", r"\$") for file in files]
+                    value = " ".join(files_escaped)
+                else:
+                    raise InvalidConfig(f"Invalid path: {full_abspath}")
         except KeyError:
             raise InvalidConfig(
                 f"Referenced variable '{reference_variable}' not found."
@@ -287,38 +292,39 @@ def process_config_dict_recursive(config_in: Dict[str, Any], state: State):
 
     for key, value in config_in.items():
         withhold = False
-        if not isinstance(key, str):
-            raise InvalidConfig(f"Invalid key {key}: must be a string.")
-        if isinstance(value, dict):
-            withhold = True
-            if key.startswith(PDK_PREFIX):
-                pdk_match = key[len(PDK_PREFIX) :]
-                if fnmatch.fnmatch(state.vars[PDK_VAR], pdk_match):
-                    process_config_dict_recursive(value, state)
-            elif key.startswith(SCL_PREFIX):
-                scl_match = key[len(SCL_PREFIX) :]
-                if state.vars[SCL_VAR] is not None and fnmatch.fnmatch(
-                    state.vars[SCL_VAR], scl_match
-                ):
-                    process_config_dict_recursive(value, state)
-            else:
-                raise InvalidConfig(
-                    f"Invalid value type {type(value)} for key '{key}'."
-                )
-        elif isinstance(value, list):
-            valid = True
-            processed = []
-            for (i, item) in enumerate(value):
-                current_key = f"{key}[{i}]"
-                processed.append(f"{process_scalar(current_key, item, state)}")
+        try:
+            if not isinstance(key, str):
+                raise InvalidConfig(f"must be a string.")
+            if isinstance(value, dict):
+                withhold = True
+                if key.startswith(PDK_PREFIX):
+                    pdk_match = key[len(PDK_PREFIX) :]
+                    if fnmatch.fnmatch(state.vars[PDK_VAR], pdk_match):
+                        process_config_dict_recursive(value, state)
+                elif key.startswith(SCL_PREFIX):
+                    scl_match = key[len(SCL_PREFIX) :]
+                    if state.vars[SCL_VAR] is not None and fnmatch.fnmatch(
+                        state.vars[SCL_VAR], scl_match
+                    ):
+                        process_config_dict_recursive(value, state)
+                else:
+                    raise InvalidConfig(f"Invalid value type {type(value)}'.")
+            elif isinstance(value, list):
+                valid = True
+                processed = []
+                for (i, item) in enumerate(value):
+                    current_key = f"{key}[{i}]"
+                    processed.append(f"{process_scalar(current_key, item, state)}")
 
-            if not valid:
-                raise InvalidConfig(
-                    f"Invalid value for key '{key}': Arrays must consist only of strings."
-                )
-            value = " ".join(processed)
-        else:
-            value = process_scalar(key, value, state)
+                if not valid:
+                    raise InvalidConfig(
+                        f"Invalid value: Arrays must consist only of strings."
+                    )
+                value = " ".join(processed)
+            else:
+                value = process_scalar(key, value, state)
+        except InvalidConfig as e:
+            raise InvalidConfig(f"Key {key}: {e}")
 
         if not withhold:
             state.vars[key] = value

--- a/scripts/config/tcl.py
+++ b/scripts/config/tcl.py
@@ -256,7 +256,7 @@ def process_string(value: str, state: State) -> str:
             # Resolve globs for paths that are inside the exposed directory
             if value.startswith("/") and full_abspath.startswith(found):
                 files = glob.glob(full_abspath)
-                if files:
+                if len(files) != 0:
                     files_escaped = [file.replace("$", r"\$") for file in files]
                     value = " ".join(files_escaped)
         except KeyError:

--- a/scripts/config/tcl.py
+++ b/scripts/config/tcl.py
@@ -257,12 +257,9 @@ def process_string(value: str, state: State) -> str:
             if value.startswith("/"):
                 if full_abspath.startswith(found):
                     files = glob.glob(full_abspath)
-                    if not files:
-                        raise InvalidConfig(f"No such file {full_abspath}")
-                    files_escaped = [file.replace("$", r"\$") for file in files]
-                    value = " ".join(files_escaped)
-                else:
-                    raise InvalidConfig(f"Invalid path: {full_abspath}")
+                    if files:
+                        files_escaped = [file.replace("$", r"\$") for file in files]
+                        value = " ".join(files_escaped)
         except KeyError:
             raise InvalidConfig(
                 f"Referenced variable '{reference_variable}' not found."

--- a/scripts/tcl_commands/all.tcl
+++ b/scripts/tcl_commands/all.tcl
@@ -520,11 +520,6 @@ proc prep {args} {
         source $::env(OPENLANE_ROOT)/configuration/$config
     }
 
-    # Users are allowed to use PDKPATH
-    if { [info exists ::env(PDK)] && [info exists $::env(PDK_ROOT)] } {
-        set ::env(PDKPATH) $::env(PDK_ROOT)/$::env(PDK)
-    }
-
     ## 1. Configuration File (Process Info Only)
     set config_file_rel [relpath . $::env(DESIGN_CONFIG)]
 


### PR DESCRIPTION
\- revert previous "fix"

\~ only substitute glob when there is a match.
\~ wrap section that parses each variable in try and catch so that the exception message contains both key and value. Previously, some exceptions thrown due to value errors were captured at the main function scope and hence losing the ability to find at which key the exception occurred. This is not a mandatory change and can be removed if not desirable.