### PR TITLE
Fix resetting IO_READ_DEF

### DIFF
--- a/scripts/tcl_commands/all.tcl
+++ b/scripts/tcl_commands/all.tcl
@@ -665,9 +665,9 @@ proc prep {args} {
             }
             puts_info "Sourcing $::env(GLB_CFG_FILE). Note that any changes to the DESIGN config file will NOT be applied."
             source $::env(GLB_CFG_FILE)
-            if { [info exists ::env(CURRENT_DEF)] && $::env(CURRENT_DEF) != 0 } {
-                puts_info "Current DEF: $::env(CURRENT_DEF)."
-                puts_info "Use 'set_def file_name.def' if you'd like to change it."
+            if { [info exists ::env(CURRENT_ODB)] && $::env(CURRENT_ODB) != 0 } {
+                puts_info "Current ODB: $::env(CURRENT_ODB)"
+                puts_info "Use 'set_odb file_name.odb' if you'd like to change it."
             }
             after 1000
             if { [info exists ::env(BASIC_PREP_COMPLETE)] && "$::env(BASIC_PREP_COMPLETE)" == "1"} {

--- a/scripts/utils/utils.tcl
+++ b/scripts/utils/utils.tcl
@@ -648,8 +648,8 @@ proc run_tcl_script {args} {
         }
     }
 
-    if { [info exists arg_values(-def_in)] } {
-        unset ::env(IO_READ_DEF)
+    if { [info exists flag_map(-def_in)] } {
+        set ::env(IO_READ_DEF) 0
     }
 
     if { ![info exist flag_map(-no_update_current)]} {


### PR DESCRIPTION
when running with pre-existing run without overwrite print info about CURRENT_ODB instead of CURRENT_DEF

The bug with IO_READ_DEF caused `-gui` flag to open the final `CURRENT_DEF` instead of `CURRENT_ODB`

