### PR TITLE
Fix wrong file extensions and regular expressions

### DIFF
--- a/scripts/generate_reports.py
+++ b/scripts/generate_reports.py
@@ -70,7 +70,7 @@ def cli(design, design_name, tag, run_path, output_file, man_report):
         os.path.join(run_path, "reports", "signoff"), "drc.rpt"
     )
     _, lvs_report = get_name(
-        os.path.join(run_path, "logs", "signoff"), f"{design_name}.lvs.lef.log"
+        os.path.join(run_path, "logs", "signoff"), f"{design_name}.lef.lvs.log"
     )
 
     printArr = []

--- a/scripts/report/report.py
+++ b/scripts/report/report.py
@@ -689,11 +689,8 @@ class Report(object):
                 tapcells = int(match[1])
 
         if diode_log_content is not None:
-            match = None
-            if "inserted!" in diode_log_content:
-                match = re.search(r"(\d+)\s+of\s+.+?\s+inserted!", diode_log_content)
-            else:
-                match = re.search(r"(\d+)\s+diodes\s+inserted\.", diode_log_content)
+            match = re.search(r"Inserted (\d+) diodes\.", diode_log_content)
+
             if match is not None:
                 diodes = int(match[1])
 

--- a/scripts/report/report.py
+++ b/scripts/report/report.py
@@ -357,7 +357,7 @@ class Report(object):
 
         # Power after parasitics-extraction, multi-corner STA
         power_multi_corner_sta = defaultdict(lambda: defaultdict(lambda: -1))
-        power_report = Artifact(rp, "reports", "signoff", "rcx_mca_sta.power.rpt")
+        power_report = Artifact(rp, "reports", "signoff", "rcx_sta.power.rpt")
         power_report_content = power_report.get_content()
         if power_report_content is not None:
             current_corner = None
@@ -396,7 +396,7 @@ class Report(object):
 
         # Critical path
         critical_path_ns = -1
-        critical_path_report = Artifact(rp, "reports", "signoff", "rcx_mca_sta.max.rpt")
+        critical_path_report = Artifact(rp, "reports", "signoff", "rcx_sta.max.rpt")
         critical_path_report_content = critical_path_report.get_content()
         if critical_path_report_content is not None:
             start = 0


### PR DESCRIPTION
due to the wrong extensions on "generate_reports.py" and "report.py", we were unable to see the power dist. outputs in the "metrics.csv" and lvs summary in the "manufacturability.rpt".