### PR TITLE
Bugfixes

### DIFF
--- a/scripts/openroad/insert_buffer.tcl
+++ b/scripts/openroad/insert_buffer.tcl
@@ -76,8 +76,8 @@ proc insert_buffer {pin_name pin_type master_name net_name inst_name} {
 
             # $inst is the buffer we want to insert, now insert it in the position of the instance it is connected to,
             # using setLocation, and detail_place will help us separate them
-            [$inst setLocation $x_min $y_min]
-            [$inst setPlacementStatus PLACED]
+            $inst setLocation $x_min $y_min
+            $inst setPlacementStatus PLACED
         }
 
         odb::dbITerm_connect $in_iterm $new_net

--- a/scripts/openroad/insert_buffer.tcl
+++ b/scripts/openroad/insert_buffer.tcl
@@ -102,8 +102,8 @@ proc insert_buffer {pin_name pin_type master_name net_name inst_name} {
 
             # $inst is the buffer we want to insert, now insert it in the position of the instance it is connected to,
             # using setLocation, and detail_place will help us separate them
-            [$inst setLocation $x_min $y_min]
-            [$inst setPlacementStatus PLACED]
+            $inst setLocation $x_min $y_min
+            $inst setPlacementStatus PLACED
         }
 
         # Find output/input of buffer iterm

--- a/scripts/report/report.py
+++ b/scripts/report/report.py
@@ -511,7 +511,7 @@ class Report(object):
         klayout_violations = -1
         if klayout_drc_content is not None:
             klayout_violations = 0
-            for line in klayout_violations.split("\n"):
+            for line in klayout_drc_content.split("\n"):
                 if "<item>" in line:
                     klayout_violations += 1
 

--- a/scripts/tcl_commands/synthesis.tcl
+++ b/scripts/tcl_commands/synthesis.tcl
@@ -71,7 +71,7 @@ proc run_yosys {args} {
     if { [info exists ::env(SYNTH_EXPLORE)] && $::env(SYNTH_EXPLORE) } {
         puts_info "This is a Synthesis Exploration and so no need to remove the defparam lines."
     } else {
-        try_catch sed -i {/defparam/d} $::env(CURRENT_NETLIST)
+        try_catch sed -i {/defparam/d} $arg_values(-output)
     }
     unset ::env(SAVE_NETLIST)
 }


### PR DESCRIPTION
\- remove wrapping square brackets for `$inst setLocation $x_min $y_min` and `$inst setPlacementStatus PLACED`. The error was surfaced when trying to re-harden `caravel_clocking` in caravel which uses `openroad/scripts/insert_buffer.tcl`

\~ execute defparam workaround on output netlist. `run_yosys` function with flag `-no_set_netlist` doesn't override `$::env(CURRENT_NETLIST)` generating a netlist without the workaround. Fixes https://github.com/The-OpenROAD-Project/OpenLane/issues/1475
\~ fix `report.py` klayout drc parsing. split `klayout_drc_content` not `klayout_violations`. Fixes https://github.com/The-OpenROAD-Project/OpenLane/issues/1657