### PR TITLE
Checkers updates

### DIFF
--- a/configuration/checkers.tcl
+++ b/configuration/checkers.tcl
@@ -15,7 +15,7 @@
 # Synthesis
 set ::env(QUIT_ON_ASSIGN_STATEMENTS) 0
 set ::env(QUIT_ON_UNMAPPED_CELLS) 1
-set ::env(QUIT_ON_SYNTH_CHECKS) 1
+set ::env(QUIT_ON_SYNTH_CHECKS) 0
 
 # STA
 set ::env(QUIT_ON_TIMING_VIOLATIONS) 1

--- a/configuration/checkers.tcl
+++ b/configuration/checkers.tcl
@@ -13,8 +13,9 @@
 # limitations under the License.
 
 # Synthesis
-set ::env(CHECK_ASSIGN_STATEMENTS) 0
-set ::env(CHECK_UNMAPPED_CELLS) 1
+set ::env(QUIT_ON_ASSIGN_STATEMENTS) 0
+set ::env(QUIT_ON_UNMAPPED_CELLS) 1
+set ::env(QUIT_ON_SYNTH_CHECKS) 1
 
 # STA
 set ::env(QUIT_ON_TIMING_VIOLATIONS) 1

--- a/docs/source/reference/configuration.md
+++ b/docs/source/reference/configuration.md
@@ -320,8 +320,9 @@ These variables worked initially, but they were too sky130 specific and will be 
 
 |Variable|Description|
 |-|-|
-| `CHECK_UNMAPPED_CELLS` | Checks if there are unmapped cells after synthesis and aborts if any was found. 1 = Enabled, 0 = Disabled <br> (Default: `1`)|
-| `CHECK_ASSIGN_STATEMENTS` | Checks for assign statement in the generated gate level netlist and aborts of any was found.1 = Enabled, 0 = Disabled <br> (Default: `0`)|
+| `QUIT_ON_UNMAPPED_CELLS` | Use yosys `check -assert` at the end of synthesis. 1 = Enabled, 0 = Disabled <br> (Default: `1`)|
+| `QUIT_ON_SYNTH_CHECKS` | Checks if there are unmapped cells after synthesis and aborts if any was found. 1 = Enabled, 0 = Disabled <br> (Default: `1`)|
+| `QUIT_ON_ASSIGN_STATEMENTS` | Checks for assign statement in the generated gate level netlist and aborts of any was found.1 = Enabled, 0 = Disabled <br> (Default: `0`)|
 | `QUIT_ON_TR_DRC` | Checks for DRC violations after routing and exits the flow if any was found. 1 = Enabled, 0 = Disabled <br> (Default: `1`)|
 | `QUIT_ON_LONG_WIRE` | Exits the flow if any wire length exceeds the threshold set in the PDK. 1 = Enabled, 0 = Disabled <br> (Default: `0`)|
 | `QUIT_ON_MAGIC_DRC` | Checks for DRC violations after magic DRC is executed and exits the flow if any was found. 1 = Enabled, 0 = Disabled <br> (Default: `1`)|

--- a/docs/source/reference/configuration.md
+++ b/docs/source/reference/configuration.md
@@ -320,8 +320,8 @@ These variables worked initially, but they were too sky130 specific and will be 
 
 |Variable|Description|
 |-|-|
-| `QUIT_ON_UNMAPPED_CELLS` | Use yosys `check -assert` at the end of synthesis. 1 = Enabled, 0 = Disabled <br> (Default: `1`)|
-| `QUIT_ON_SYNTH_CHECKS` | Checks if there are unmapped cells after synthesis and aborts if any was found. 1 = Enabled, 0 = Disabled <br> (Default: `1`)|
+| `QUIT_ON_SYNTH_CHECKS` | Use yosys `check -assert` at the end of synthesis. This checks for combinational loops, conflicting drivers and wires with no drivers. 1 = Enabled, 0 = Disabled <br> (Default: `0`)|
+| `QUIT_ON_UNMAPPED_CELLS` | Checks if there are unmapped cells after synthesis and aborts if any was found. 1 = Enabled, 0 = Disabled <br> (Default: `1`)|
 | `QUIT_ON_ASSIGN_STATEMENTS` | Checks for assign statement in the generated gate level netlist and aborts of any was found.1 = Enabled, 0 = Disabled <br> (Default: `0`)|
 | `QUIT_ON_TR_DRC` | Checks for DRC violations after routing and exits the flow if any was found. 1 = Enabled, 0 = Disabled <br> (Default: `1`)|
 | `QUIT_ON_LONG_WIRE` | Exits the flow if any wire length exceeds the threshold set in the PDK. 1 = Enabled, 0 = Disabled <br> (Default: `0`)|

--- a/scripts/tcl_commands/all.tcl
+++ b/scripts/tcl_commands/all.tcl
@@ -636,6 +636,9 @@ proc prep {args} {
     handle_deprecated_config LIB_RESIZER_OPT RSZ_LIB;
     handle_deprecated_config UNBUFFER_NETS RSZ_DONT_TOUCH_RX;
 
+    handle_deprecated_config CHECK_ASSIGN_STATEMENTS QUIT_ON_ASSIGN_STATEMENTS
+    handle_deprecated_config CHECK_UNMAPPED_CELLS QUIT_ON_UNMAPPED_CELLS
+
     #
     ############################
     # Prep directories and files

--- a/scripts/tcl_commands/checkers.tcl
+++ b/scripts/tcl_commands/checkers.tcl
@@ -25,11 +25,13 @@ proc check_assign_statements {args} {
     }
 }
 
-proc check_synthesis_failure {args} {
-    set checker [catch {exec grep "\\\$" [index_file $::env(synthesis_reports)/2.stat.rpt]}]
+proc check_unmapped_cells {stat_file} {
+    set match {\$}
+    set checker [exec bash -c "grep '$match' \
+        $stat_file || true"]
 
-    if { ! $checker } {
-        puts_err "Synthesis failed"
+    if { $checker ne "" } {
+        puts_err "Synthesis failed. There are unmapped cells after synthesis."
         flow_fail
     }
 }

--- a/scripts/tcl_commands/synthesis.tcl
+++ b/scripts/tcl_commands/synthesis.tcl
@@ -122,6 +122,16 @@ proc run_synthesis {args} {
     TIMER::timer_stop
     exec echo "[TIMER::get_runtime]" | python3 $::env(SCRIPTS_DIR)/write_runtime.py "synthesis - yosys"
 
+    if { $::env(QUIT_ON_ASSIGN_STATEMENTS) == 1 } {
+        check_assign_statements
+    }
+
+    if { $::env(QUIT_ON_UNMAPPED_CELLS) == 1 } {
+        set strategy_escaped [string map {" " _} $::env(SYNTH_STRATEGY)]
+        set final_stat_file $::env(synth_report_prefix).$strategy_escaped.stat.rpt
+        check_unmapped_cells $final_stat_file
+    }
+
     run_sta\
         -log $::env(synthesis_logs)/sta.log \
         -netlist_in \
@@ -129,14 +139,6 @@ proc run_synthesis {args} {
         -save_to $::env(synthesis_results)
 
     set ::env(LAST_TIMING_REPORT_TAG) [index_file $::env(synthesis_reports)/syn_sta]
-
-    if { $::env(CHECK_ASSIGN_STATEMENTS) == 1 } {
-        check_assign_statements
-    }
-
-    if { $::env(CHECK_UNMAPPED_CELLS) == 1 } {
-        check_synthesis_failure
-    }
 
     if { [info exists ::env(SYNTH_USE_PG_PINS_DEFINES)] } {
         puts_info "Creating a netlist with power/ground pins."

--- a/scripts/tcl_commands/synthesis.tcl
+++ b/scripts/tcl_commands/synthesis.tcl
@@ -130,7 +130,7 @@ proc run_synthesis {args} {
         set strategy_escaped [string map {" " _} $::env(SYNTH_STRATEGY)]
         set final_stat_file $::env(synth_report_prefix).$strategy_escaped.stat.rpt
         if { [info exists ::env(SYNTH_ELABORATE_ONLY)] \
-            && $::env(SYNTH_ELABORATE_ONLY) == 1} {
+            && $::env(SYNTH_ELABORATE_ONLY) == 1 } {
                 set final_stat_file $::env(synth_report_prefix).stat
             }
         check_unmapped_cells $final_stat_file

--- a/scripts/tcl_commands/synthesis.tcl
+++ b/scripts/tcl_commands/synthesis.tcl
@@ -129,6 +129,10 @@ proc run_synthesis {args} {
     if { $::env(QUIT_ON_UNMAPPED_CELLS) == 1 } {
         set strategy_escaped [string map {" " _} $::env(SYNTH_STRATEGY)]
         set final_stat_file $::env(synth_report_prefix).$strategy_escaped.stat.rpt
+        if { [info exists ::env(SYNTH_ELABORATE_ONLY)] \
+            && $::env(SYNTH_ELABORATE_ONLY) == 1} {
+                set final_stat_file $::env(synth_report_prefix).stat
+            }
         check_unmapped_cells $final_stat_file
     }
 

--- a/scripts/utils/utils.tcl
+++ b/scripts/utils/utils.tcl
@@ -612,7 +612,7 @@ proc run_tcl_script {args} {
     }
 
     if { [file exists $arg_values(-indexed_log)] \
-        && $arg_values(-indexed_log) ne "/dev/null"} {
+        && $arg_values(-indexed_log) ne "/dev/null" } {
         exec bash -c "grep -i warning $arg_values(-indexed_log) > \
             [file rootname $arg_values(-indexed_log)].warnings || true"
 

--- a/scripts/utils/utils.tcl
+++ b/scripts/utils/utils.tcl
@@ -611,6 +611,15 @@ proc run_tcl_script {args} {
         }
     }
 
+    if { [file exists $arg_values(-indexed_log)] \
+        && $arg_values(-indexed_log) ne "/dev/null"} {
+        exec bash -c "grep -i warning $arg_values(-indexed_log) > \
+            [file rootname $arg_values(-indexed_log)].warnings || true"
+
+        exec bash -c "grep -i error $arg_values(-indexed_log) > \
+            [file rootname $arg_values(-indexed_log)].errors || true"
+    }
+
     if { $create_reproducible } {
         save_state
 

--- a/scripts/yosys/synth.tcl
+++ b/scripts/yosys/synth.tcl
@@ -362,7 +362,7 @@ proc run_strategy {output script strategy_name {postfix_with_strategy 0}} {
 
     write_verilog -noattr -noexpr -nohex -nodec -defparam $output
     if { $::env(QUIT_ON_SYNTH_CHECKS) == 1 } {
-        read_liberty $::env(LIB_SYNTH)
+        read_liberty --ignore_miss_func $::env(LIB_SYNTH)
         check -assert $::env(DESIGN_NAME)
     }
     design -reset

--- a/scripts/yosys/synth.tcl
+++ b/scripts/yosys/synth.tcl
@@ -362,7 +362,7 @@ proc run_strategy {output script strategy_name {postfix_with_strategy 0}} {
 
     write_verilog -noattr -noexpr -nohex -nodec -defparam $output
     if { $::env(QUIT_ON_SYNTH_CHECKS) == 1 } {
-        read_liberty --ignore_miss_func $::env(LIB_SYNTH)
+        read_liberty -ignore_miss_func $::env(LIB_SYNTH)
         check -assert $::env(DESIGN_NAME)
     }
     design -reset

--- a/scripts/yosys/synth.tcl
+++ b/scripts/yosys/synth.tcl
@@ -361,6 +361,10 @@ proc run_strategy {output script strategy_name {postfix_with_strategy 0}} {
     }
 
     write_verilog -noattr -noexpr -nohex -nodec -defparam $output
+    if { $::env(QUIT_ON_SYNTH_CHECKS) == 1 } {
+        read_liberty $::env(LIB_SYNTH)
+        check -assert $::env(DESIGN_NAME)
+    }
     design -reset
 }
 design -save checkpoint


### PR DESCRIPTION
\+ Add `QUIT_ON_SYNTH_CHECKS` (perhaps needs a better name?)
\~ `run_tcl_script` now logs warnings to `.warnings` file
\~ `run_tcl_script` now logs errors to `.errors` file
\~ Rename `CHECK_ASSIGN_STATEMENTS` to `QUIT_ON_ASSIGN_STATEMENTS`
\~ Rename `CHECK_UNMAPPED_CELLS` to `QUIT_ON_UNMAPPED_CELLS`
\~ Fix implementation of `QUIT_ON_UNMAPPED_CELLS` by inspecting the correct yosys stat file
\~ Run `QUIT_ON_UNMAPPED_CELLS` and `QUIT_ON_ASSIGN_STATEMENTS` directly after synthesis before sta
