### PR TITLE
Update OpenROAD

### DIFF
--- a/dependencies/tool_metadata.yml
+++ b/dependencies/tool_metadata.yml
@@ -58,7 +58,7 @@
   in_install: false
 - name: openroad_app
   repo: https://github.com/The-OpenROAD-Project/OpenROAD
-  commit: 1f720d3b442e2cd8dc6c5372535320b18a105e8d
+  commit: 037e4e3a46ec91e8020445672d86afc9ff675cd6
   build: ''
   in_install: false
 - name: git

--- a/dependencies/tool_metadata.yml
+++ b/dependencies/tool_metadata.yml
@@ -58,7 +58,7 @@
   in_install: false
 - name: openroad_app
   repo: https://github.com/The-OpenROAD-Project/OpenROAD
-  commit: 037e4e3a46ec91e8020445672d86afc9ff675cd6
+  commit: 0264023b6c2a8ae803b8d440478d657387277d93
   build: ''
   in_install: false
 - name: git

--- a/docker/openroad_app/Dockerfile
+++ b/docker/openroad_app/Dockerfile
@@ -18,7 +18,7 @@ FROM ${BUILD_BASE_IMAGE} AS builder
 
 # Build Boost
 WORKDIR /boost
-RUN curl -L https://sourceforge.net/projects/boost/files/boost/1.76.0/boost_1_76_0.tar.bz2/download | tar --strip-components=1 -xjC . && \
+RUN curl -L https://sourceforge.net/projects/boost/files/boost/1.80.0/boost_1_80_0.tar.bz2/download | tar --strip-components=1 -xjC . && \
     ./bootstrap.sh && \
     ./b2 install --with-iostreams --with-test --with-serialization --with-system --with-thread -j $(nproc)
 

--- a/docker/openroad_app/Dockerfile
+++ b/docker/openroad_app/Dockerfile
@@ -76,6 +76,7 @@ RUN python3 ./utils.py fetch-submodules-from-tarballs ${OPENROAD_APP_REPO} ${OPE
 
 # Build OpenROAD
 RUN sed -i "s/GITDIR-NOTFOUND/${OPENROAD_APP_COMMIT}/" cmake/GetGitRevisionDescription.cmake
+RUN sed -i "s/-m64//" src/par/CMakeLists.txt
 RUN sed -i "s/static char Cases/static signed char Cases/" third-party/abc/src/misc/extra/extraUtilMisc.c
 RUN mkdir build && mkdir -p /build/version && mkdir install
 RUN cd build && cmake -DCMAKE_INSTALL_PREFIX=$(pwd)/install ..


### PR DESCRIPTION
OpenROAD requires min 1.78. Changing to 1.80 since is newer and tested upstream.