### PR TITLE
sed: use cross-platform form for -i flags

### DIFF
--- a/scripts/tcl_commands/all.tcl
+++ b/scripts/tcl_commands/all.tcl
@@ -46,7 +46,8 @@ proc set_netlist {args} {
     set ::env(CURRENT_NETLIST) $netlist
 
     set replace [string map {/ \\/} $::env(CURRENT_NETLIST)]
-    try_catch sed -i -e "s/\\(set ::env(CURRENT_NETLIST)\\).*/\\1 $replace/" "$::env(GLB_CFG_FILE)"
+    try_catch sed -i.bak -e "s/\\(set ::env(CURRENT_NETLIST)\\).*/\\1 $replace/" "$::env(GLB_CFG_FILE)"
+    exec rm -f "$::env(GLB_CFG_FILE).bak"
 
     if { [info exists flags_map(-lec)] && $::env(LEC_ENABLE) && [file exists $previous_netlist] } {
         logic_equiv_check -lhs $previous_netlist -rhs $netlist
@@ -58,7 +59,8 @@ proc set_def {def} {
     puts_verbose "Changing layout to '$def_relative'..."
     set ::env(CURRENT_DEF) $def
     set replace [string map {/ \\/} $def]
-    exec sed -i -e "s/\\(set ::env(CURRENT_DEF)\\).*/\\1 $replace/" "$::env(GLB_CFG_FILE)"
+    exec sed -i.bak -e "s/\\(set ::env(CURRENT_DEF)\\).*/\\1 $replace/" "$::env(GLB_CFG_FILE)"
+    exec rm -f "$::env(GLB_CFG_FILE).bak"
 }
 
 proc set_odb {odb} {
@@ -66,7 +68,8 @@ proc set_odb {odb} {
     puts_verbose "Changing database to '$odb_relative'..."
     set ::env(CURRENT_ODB) $odb
     set replace [string map {/ \\/} $odb]
-    exec sed -i -e "s/\\(set ::env(CURRENT_ODB)\\).*/\\1 $replace/" "$::env(GLB_CFG_FILE)"
+    exec sed -i.bak -e "s/\\(set ::env(CURRENT_ODB)\\).*/\\1 $replace/" "$::env(GLB_CFG_FILE)"
+    exec rm -f "$::env(GLB_CFG_FILE).bak"
 }
 
 proc set_sdc {sdc} {
@@ -74,7 +77,8 @@ proc set_sdc {sdc} {
     puts_verbose "Changing timing constraints to '$sdc_relative'..."
     set ::env(CURRENT_SDC) $sdc
     set replace [string map {/ \\/} $sdc]
-    exec sed -i -e "s/\\(set ::env(CURRENT_SDC)\\).*/\\1 $replace/" "$::env(GLB_CFG_FILE)"
+    exec sed -i.bak -e "s/\\(set ::env(CURRENT_SDC)\\).*/\\1 $replace/" "$::env(GLB_CFG_FILE)"
+    exec rm -f "$::env(GLB_CFG_FILE).bak"
 }
 
 proc set_guide {guide} {
@@ -82,7 +86,8 @@ proc set_guide {guide} {
     puts_verbose "Changing guide to '$guide_relative'..."
     set ::env(CURRENT_GUIDE) $guide
     set replace [string map {/ \\/} $guide]
-    exec sed -i -e "s/\\(set ::env(CURRENT_GUIDE)\\).*/\\1 $replace/" "$::env(GLB_CFG_FILE)"
+    exec sed -i.bak -e "s/\\(set ::env(CURRENT_GUIDE)\\).*/\\1 $replace/" "$::env(GLB_CFG_FILE)"
+    exec rm -f "$::env(GLB_CFG_FILE).bak"
 }
 
 proc prep_lefs {args} {

--- a/scripts/tcl_commands/magic.tcl
+++ b/scripts/tcl_commands/magic.tcl
@@ -51,7 +51,8 @@ proc run_magic {args} {
             -indexed_log $log
 
         # Only keep the properties section in the file
-        try_catch sed -i -n "/^<< properties >>/,/^<< end >>/p" $::env(signoff_tmpfiles)/gds_ptrs.mag
+        try_catch sed -i.bak -n "/^<< properties >>/,/^<< end >>/p" $::env(signoff_tmpfiles)/gds_ptrs.mag
+        exec rm -f $::env(signoff_tmpfiles)/gds_ptrs.mag.bak
     }
 
     # If desired, copy GDS_* properties into the mag/ view

--- a/scripts/tcl_commands/synthesis.tcl
+++ b/scripts/tcl_commands/synthesis.tcl
@@ -71,7 +71,8 @@ proc run_yosys {args} {
     if { [info exists ::env(SYNTH_EXPLORE)] && $::env(SYNTH_EXPLORE) } {
         puts_info "This is a Synthesis Exploration and so no need to remove the defparam lines."
     } else {
-        try_catch sed -i {/defparam/d} $arg_values(-output)
+        try_catch sed -i.bak {/defparam/d} $arg_values(-output)
+        exec rm -f $arg_values(-output).bak
     }
     unset ::env(SAVE_NETLIST)
 }

--- a/scripts/utils/deflef_utils.tcl
+++ b/scripts/utils/deflef_utils.tcl
@@ -26,7 +26,8 @@ proc resize_die {args} {
     set ury [expr {[lindex $arg_values(-area) 3] * $::env(DEF_UNITS_PER_MICRON)}]
 
     puts_info "Resizing Die to $arg_values(-area)"
-    try_catch sed -i -E "0,/^DIEAREA.*$/{s/^DIEAREA.*$/DIEAREA ( $llx $lly ) ( $urx $ury ) ;/}" $arg_values(-def)
+    try_catch sed -i.bak -E "0,/^DIEAREA.*$/{s/^DIEAREA.*$/DIEAREA ( $llx $lly ) ( $urx $ury ) ;/}" $arg_values(-def)
+    try_catch rm -f $arg_values(-def).bak
 }
 
 proc get_instance_position {args} {

--- a/scripts/utils/utils.tcl
+++ b/scripts/utils/utils.tcl
@@ -209,7 +209,8 @@ proc index_file {args} {
     set new_file_full_name "$file_path/$fbasename"
     set replace [string map {/ \\/} $::env(CURRENT_INDEX)]
     if { [info exists ::env(GLB_CFG_FILE)]} {
-        exec sed -i -e "s/\\(set ::env(CURRENT_INDEX)\\).*/\\1 $replace/" "$::env(GLB_CFG_FILE)"
+        exec sed -i.bak -e "s/\\(set ::env(CURRENT_INDEX)\\).*/\\1 $replace/" "$::env(GLB_CFG_FILE)"
+        exec rm -f "$::env(GLB_CFG_FILE).bak"
     }
     return $new_file_full_name
 }


### PR DESCRIPTION
The `-i` argument to sed has differing behaviour under BSD and GNU sed:

  - On BSD it requires an argument, though it can be '' (i.e. `-i ''`).
  - Under GNU sed, it needs to immediately follow the argument (i.e. `-i''`).

Provide a backup file argument and immediately delete it, since this appears to be the only cross-platform solution.

With this, as well as some other patches that we are working to upstream, I have successfully built and synthesized a design on a Mac laptop with an ARM64 core.