### PR TITLE
Added PL_WIRELENGTH_COEF variable to global placement.

### DIFF
--- a/configuration/placement.tcl
+++ b/configuration/placement.tcl
@@ -39,3 +39,4 @@ set ::env(PL_MAX_DISPLACEMENT_X) 500
 set ::env(PL_MAX_DISPLACEMENT_Y) 100
 set ::env(PL_MACRO_HALO) {0 0}
 set ::env(PL_MACRO_CHANNEL) {0 0}
+set ::env(PL_WIRELENGTH_COEF) 0.25

--- a/docs/source/reference/configuration.md
+++ b/docs/source/reference/configuration.md
@@ -162,7 +162,7 @@ These variables worked initially, but they were too sky130 specific and will be 
 | `PL_RESIZER_HOLD_MAX_BUFFER_PERCENT` | Specifies a max number of buffers to insert to fix hold violations. This number is calculated as a percentage of the number of instances in the design. <br> (Default: `50`)|
 | `PL_RESIZER_SETUP_MAX_BUFFER_PERCENT` | Specifies a max number of buffers to insert to fix setup violations. This number is calculated as a percentage of the number of instances in the design. <br> (Default: `50`)|
 | `PL_RESIZER_ALLOW_SETUP_VIOS` | Allows setup violations when fixing hold. <br> (Default: `0`)|
-
+| `PL_WIRELENGTH_COEF` | Global placement initial wirelength coefficient. Decreasing the variable will modify the initial placement of the standard cells to reduce the wirelengths. <br> (Default: `0.25`).|
 | `DONT_USE_CELLS` | The list of cells to not use during resizer optimizations. <br> Default: the contents of `DRC_EXCLUDE_CELL_LIST`. |
 | `PL_ESTIMATE_PARASITICS` | Specifies whether or not to run STA after global placement using OpenROAD's estimate_parasitics -placement and generates reports under `logs/placement`. 1 = Enabled, 0 = Disabled. <br> (Default: `1`) |
 | `PL_OPTIMIZE_MIRRORING` | Specifies whether or not to run an optimize_mirroring pass whenever detailed placement happens. This pass will mirror the cells whenever possible to optimize the design. 1 = Enabled, 0 = Disabled. <br> (Default: `1`) |

--- a/scripts/openroad/gpl.tcl
+++ b/scripts/openroad/gpl.tcl
@@ -66,6 +66,8 @@ set cell_pad_side [expr $::env(GPL_CELL_PADDING) / 2]
 lappend arg_list -pad_right $cell_pad_side
 lappend arg_list -pad_left $cell_pad_side
 
+lappend arg_list -init_wirelength_coef $::env(PL_WIRELENGTH_COEF)
+
 global_placement {*}$arg_list
 
 write


### PR DESCRIPTION
### **Added PL_WIRELENGTH_COEF**

`PL_WIRELENGTH_COEF` is the initial wirelength coefficient that is used in global placement. The default value is 0.25. Decreasing `PL_WIRELENGTH_COEF` will modify the initial placement of the standard cells to reduce the wirelengths. 