### PR TITLE
Change the default value of `QUIT_ON_SYNTH_CHECKS` to `1`

### DIFF
--- a/configuration/checkers.tcl
+++ b/configuration/checkers.tcl
@@ -15,7 +15,7 @@
 # Synthesis
 set ::env(QUIT_ON_ASSIGN_STATEMENTS) 0
 set ::env(QUIT_ON_UNMAPPED_CELLS) 1
-set ::env(QUIT_ON_SYNTH_CHECKS) 0
+set ::env(QUIT_ON_SYNTH_CHECKS) 1
 
 # STA
 set ::env(QUIT_ON_TIMING_VIOLATIONS) 1

--- a/docs/source/reference/configuration.md
+++ b/docs/source/reference/configuration.md
@@ -322,7 +322,7 @@ These variables worked initially, but they were too sky130 specific and will be 
 
 |Variable|Description|
 |-|-|
-| `QUIT_ON_SYNTH_CHECKS` | Use yosys `check -assert` at the end of synthesis. This checks for combinational loops, conflicting drivers and wires with no drivers. 1 = Enabled, 0 = Disabled <br> (Default: `0`)|
+| `QUIT_ON_SYNTH_CHECKS` | Use yosys `check -assert` at the end of synthesis. This checks for combinational loops, conflicting drivers and wires with no drivers. 1 = Enabled, 0 = Disabled <br> (Default: `1`)|
 | `QUIT_ON_UNMAPPED_CELLS` | Checks if there are unmapped cells after synthesis and aborts if any was found. 1 = Enabled, 0 = Disabled <br> (Default: `1`)|
 | `QUIT_ON_ASSIGN_STATEMENTS` | Checks for assign statement in the generated gate level netlist and aborts of any was found.1 = Enabled, 0 = Disabled <br> (Default: `0`)|
 | `QUIT_ON_TR_DRC` | Checks for DRC violations after routing and exits the flow if any was found. 1 = Enabled, 0 = Disabled <br> (Default: `1`)|


### PR DESCRIPTION
I think the default value of `QUIT_ON_SYNTH_CHECKS` should always be `1`. A design that has combinational loops or conflicting drivers should not continue through the flow with just synthesis warnings. Yosys usually has a lot of warnings that can be waived, and a conflicting driver warning could be missed in those warnings. 