### PR TITLE
`io_place.py` Fixes

### DIFF
--- a/designs/spm/config.json
+++ b/designs/spm/config.json
@@ -8,6 +8,7 @@
     "FP_PDN_HOFFSET": 7,
     "FP_PIN_ORDER_CFG": "dir::pin_order.cfg",
     "FP_PDN_SKIPTRIM": true,
+    "FP_IO_MIN_DISTANCE": 1,
     "pdk::sky130*": {
         "FP_CORE_UTIL": 45,
         "scl::sky130_fd_sc_hd": {

--- a/scripts/odbpy/io_place.py
+++ b/scripts/odbpy/io_place.py
@@ -380,14 +380,14 @@ def io_place(
         print(
             f"Error: provided min_distance({min_distance}) is less than min spacing({h_spacing})"
         )
-        exit(1)
+        sys.exit(1)
     v_spacing = V_LAYER.getSpacing()
     v_min_distance = min_distance * reader.dbunits if min_distance else v_spacing
     if v_min_distance < v_spacing:
         print(
             f"Error: provided min_distance({min_distance}) is less than min spacing({v_spacing})"
         )
-        exit(1)
+        sys.exit(1)
 
     origin, count, step = reader.block.findTrackGrid(H_LAYER).getGridPatternY(0)
     print(f"Horizontal Tracks Origin: {origin}, Count: {count}, Step: {step}")

--- a/scripts/tcl_commands/floorplan.tcl
+++ b/scripts/tcl_commands/floorplan.tcl
@@ -124,6 +124,7 @@ proc place_io_ol {args} {
         {-vertical_layer optional}
         {-vertical_mult optional}
         {-vertical_ext optional}
+        {-min_distance optional}
         {-length optional}
         {-output_def optional}
         {-output_odb optional}
@@ -149,6 +150,7 @@ proc place_io_ol {args} {
     set_if_unset arg_values(-horizontal_ext) $::env(FP_IO_HEXTEND)
 
     set_if_unset arg_values(-length) [expr max($::env(FP_IO_VLENGTH), $::env(FP_IO_HLENGTH))]
+    set_if_unset arg_values(-min_distance) $::env(FP_IO_MIN_DISTANCE)
 
     if { $::env(FP_IO_UNMATCHED_ERROR) } {
         set_if_unset flags_map(-unmatched_error) "--unmatched-error"
@@ -170,6 +172,7 @@ proc place_io_ol {args} {
         --hor-extension $arg_values(-horizontal_ext)\
         --ver-extension $arg_values(-vertical_ext)\
         --length $arg_values(-length)\
+        --min-distance $arg_values(-min_distance)\
         {*}$flags_map(-unmatched_error)\
         {*}$arg_values(-extra_args)
 
@@ -258,7 +261,7 @@ proc tap_decap_or {args} {
 
     run_openroad_script $::env(SCRIPTS_DIR)/openroad/tapcell.tcl\
         -indexed_log [index_file $::env(floorplan_logs)/tap.log]\
-        -save "to=$::env(floorplan_results),noindex,def,odb"
+        -save "to=$::env(floorplan_tmpfiles),name=tapcell,def,odb"
     TIMER::timer_stop
     exec echo "[TIMER::get_runtime]" | python3 $::env(SCRIPTS_DIR)/write_runtime.py "tap/decap insertion - openroad"
 
@@ -304,7 +307,7 @@ proc gen_pdn {args} {
 
     run_openroad_script $::env(SCRIPTS_DIR)/openroad/pdn.tcl \
         -indexed_log [index_file $::env(floorplan_logs)/pdn.log] \
-        -save "to=$::env(floorplan_tmpfiles),name=pdn,def,odb"
+        -save "to=$::env(floorplan_results),noindex,def,odb"
 
     TIMER::timer_stop
     exec echo "[TIMER::get_runtime]" | python3 $::env(SCRIPTS_DIR)/write_runtime.py "pdn generation - openroad"


### PR DESCRIPTION
Fixes https://github.com/The-OpenROAD-Project/OpenLane/issues/1711
\+ integrate `FP_IO_MIN_DISTANCE`
\~ respect min spacing while placing pins
\~ print on which side requested pins exceed allowed number of pins

others:
\~ tap_decap step generate output to tmp instead of result
\~ gen_pdn step generate output to result instead of tmp because it is the final step in floorplan stage