### PR TITLE
Fix GDS write fail by klayout

### DIFF
--- a/scripts/klayout/stream_out.py
+++ b/scripts/klayout/stream_out.py
@@ -102,7 +102,7 @@ else:
             args.append("-rd")
             if isinstance(value, tuple) or isinstance(value, list):
                 value = ";".join(value)
-            elif isinstance(value, str) and os.path.exists(value):
+            elif isinstance(value, str) and os.path.exists(value) and key != "design_name":
                 value = os.path.abspath(value)
 
             args.append(f"{key}={value or 'NULL'}")


### PR DESCRIPTION
If the `os.path.abspath` is added to the `design_name`, then this causes a fail of the GDS write by `klayout` (see Slack discussion with @donn).