### PR TITLE
Run full synth checks when synth elaborate is on

### DIFF
--- a/designs/caravel_upw/src/user_project_wrapper.v
+++ b/designs/caravel_upw/src/user_project_wrapper.v
@@ -118,40 +118,14 @@ user_proj_example mprj1 (
     .irq(user_irq)
 );
 
+// Only testing power connections
+// There is no interest in having functional connectivity
+(* keep *)
 user_proj_example2 mprj2 (
 `ifdef USE_POWER_PINS
 	.vccd2(vccd2),	// User area 1 1.8V power
 	.vssd2(vssd2),	// User area 1 digital ground
 `endif
-
-    .wb_clk_i(wb_clk_i),
-    .wb_rst_i(wb_rst_i),
-
-    // MGMT SoC Wishbone Slave
-
-    .wbs_cyc_i(wbs_cyc_i),
-    .wbs_stb_i(wbs_stb_i),
-    .wbs_we_i(wbs_we_i),
-    .wbs_sel_i(wbs_sel_i),
-    .wbs_adr_i(wbs_adr_i),
-    .wbs_dat_i(wbs_dat_i),
-    .wbs_ack_o(wbs_ack_o),
-    .wbs_dat_o(wbs_dat_o),
-
-    // Logic Analyzer
-
-    .la_data_in(la_data_in),
-    .la_data_out(la_data_out),
-    .la_oenb (la_oenb),
-
-    // IO Pads
-
-    .io_in (io_in),
-    .io_out(io_out),
-    .io_oeb(io_oeb),
-
-    // IRQ
-    .irq(user_irq)
 );
 
 endmodule	// user_project_wrapper

--- a/scripts/openroad/common/io.tcl
+++ b/scripts/openroad/common/io.tcl
@@ -47,7 +47,7 @@ proc read_netlist {args} {
                 } elseif { [catch {read_verilog $verilog_file} err] } {
                     puts "Error while reading $verilog_file:"
                     puts "Make sure that this a gate-level netlist not an RTL file"
-                    puts "Add $blackbox_wildcard to skip this file and blackbox the modules if needed."
+                    puts "You can add the following comment '$blackbox_wildcard' in the file to skip it and blackbox the modules inside if needed."
                     puts $err
                     exit 1
                 }

--- a/scripts/tcl_commands/synthesis.tcl
+++ b/scripts/tcl_commands/synthesis.tcl
@@ -120,8 +120,12 @@ proc run_synthesis {args} {
     } else {
         run_yosys -indexed_log $log
         if { $::env(QUIT_ON_SYNTH_CHECKS) } {
-            set pre_synth_report $::env(synth_report_prefix)_pre_synth.check
-            run_synthesis_checkers $log $pre_synth_report
+            set pre_synth_report $::env(synth_report_prefix)_pre_synth.chk.rpt
+            if { [info exists ::env(SYNTH_ELABORATE_ONLY)] \
+                && $::env(SYNTH_ELABORATE_ONLY) == 1 } {
+                set pre_synth_report $::env(synth_report_prefix).chk.rpt
+            }
+        run_synthesis_checkers $log $pre_synth_report
         }
     }
     TIMER::timer_stop

--- a/scripts/yosys/synth.tcl
+++ b/scripts/yosys/synth.tcl
@@ -81,12 +81,8 @@ set B_factor  0.88
 set F_factor  0.00
 
 # Don't change these unless you know what you are doing
-set stat_ext    ".stat.rpt"
-set chk_ext    ".chk.rpt"
-set gl_ext      ".gl.v"
-set constr_ext  ".$clock_period.constr"
-set timing_ext  ".timing.txt"
-set abc_ext     ".abc"
+set STAT_EXT    "stat.rpt"
+set CHK_EXT    "chk.rpt"
 
 
 # Create SDC File
@@ -272,7 +268,7 @@ if { $::env(SYNTH_NO_FLAT) != 1 } {
 }
 opt_expr
 opt_clean
-tee -o "$::env(synth_report_prefix)_pre_synth.check" check
+tee -o "$::env(synth_report_prefix)_pre_synth.$CHK_EXT" check
 opt -nodffe -nosdff
 fsm
 opt
@@ -379,8 +375,10 @@ proc run_strategy {output script strategy_name {postfix_with_strategy 0}} {
             set stat_libs "$stat_libs -liberty $stat_lib"
         }
     }
-    tee -o "$::env(synth_report_prefix).$strategy_escaped.chk.rpt" check
-    tee -o "$::env(synth_report_prefix).$strategy_escaped.stat.rpt" stat -top $::env(DESIGN_NAME) {*}$stat_libs
+    global CHK_EXT
+    global STAT_EXT
+    tee -o "$::env(synth_report_prefix).$strategy_escaped.$CHK_EXT" check
+    tee -o "$::env(synth_report_prefix).$strategy_escaped.$STAT_EXT" stat -top $::env(DESIGN_NAME) {*}$stat_libs
 
     if { [info exists ::env(SYNTH_AUTONAME)] && $::env(SYNTH_AUTONAME) } {
         # Generate public names for the various nets, resulting in very long names that include


### PR DESCRIPTION
```
+ set pre_synth_report depending on SYNTH_ELABORATE_ONLY
~ adjust _EXT variables in synth.tcl
~ better log message for /// sta-blackbox
- remove multiple drivers in caravel_upw and
keep the power connections only as we are mainly interested in them
```
---
Fixes https://github.com/The-OpenROAD-Project/OpenLane/issues/1735