### PR TITLE
Don't unset env variables after executing a step

### DIFF
--- a/scripts/tcl_commands/magic.tcl
+++ b/scripts/tcl_commands/magic.tcl
@@ -153,9 +153,6 @@ proc run_magic_spice_export {args} {
     run_magic_script $::env(SCRIPTS_DIR)/magic/extract_spice.tcl\
         -indexed_log $log
 
-    unset ::env(_tmp_magic_extract_type)
-    unset ::env(_tmp_magic_feedback_file)
-
     if { $extract_type == "spice" } {
         file copy -force $::env(signoff_results)/$::env(DESIGN_NAME).spice $::env(signoff_results)/$::env(DESIGN_NAME).lef.spice
     }
@@ -218,8 +215,6 @@ proc run_magic_antenna_check {args} {
 
     run_magic_script $::env(SCRIPTS_DIR)/magic/def/antenna_check.tcl\
         -indexed_log $log
-
-    unset ::env(_tmp_feedback_file)
 
     set antenna_violators_rpt [index_file $::env(signoff_reports)/antenna_violators.rpt]
 
@@ -288,8 +283,6 @@ proc erase_box {args} {
         -indexed_log $log
 
     set ::env(CURRENT_GDS) $gds_backup
-    unset ::env(_tmp_mag_box_coordinates)
-    unset ::env(SAVE_GDS)
 }
 
 package provide openlane 0.9

--- a/scripts/tcl_commands/routing.tcl
+++ b/scripts/tcl_commands/routing.tcl
@@ -382,10 +382,6 @@ proc run_spef_extraction {args} {
     run_openroad_script $::env(SCRIPTS_DIR)/openroad/rcx.tcl\
         -indexed_log $log\
         -save "odb=/dev/null,spef=$arg_values(-save)"
-    unset ::env(RCX_LIB)
-    unset ::env(RCX_RULESET)
-    unset ::env(RCX_LEF)
-    unset ::env(RCX_DEF)
 
     TIMER::timer_stop
     exec echo "[TIMER::get_runtime]" | python3 $::env(SCRIPTS_DIR)/write_runtime.py "parasitics extraction - openroad"

--- a/scripts/tcl_commands/sta.tcl
+++ b/scripts/tcl_commands/sta.tcl
@@ -97,7 +97,7 @@ proc run_sta {args} {
             blackbox_modules_check $log
         }
     }
-    unset ::env(STA_MULTICORNER)
+    set ::env(STA_MULTICORNER) 0
     TIMER::timer_stop
     exec echo "[TIMER::get_runtime]" | python3 $::env(SCRIPTS_DIR)/write_runtime.py "sta - openroad"
 }

--- a/scripts/utils/deflef_utils.tcl
+++ b/scripts/utils/deflef_utils.tcl
@@ -214,10 +214,9 @@ proc insert_buffer {args} {
     run_openroad_script $::env(SCRIPTS_DIR)/openroad/insert_buffer.tcl\
         -indexed_log [index_file $::env(routing_logs)/insert_buffer.log]\
         -save "to=$::env(routing_tmpfiles),def,odb"
-    unset ::env(INSERT_BUFFER_COMMAND)
 
     if { ![info exists flags_map(-place)] } {
-        unset ::env(INSERT_BUFFER_NO_PLACE)
+        set ::env(INSERT_BUFFER_NO_PLACE) 0
     }
 
     incr ::env(INSERT_BUFFER_COUNTER)


### PR DESCRIPTION
To avoid causing issues when attempting to run `or_issue.py` outside of the flow (in case it didn't crash)