### PR TITLE
cli: document `-gui` option

### DIFF
--- a/docs/source/reference/cli.md
+++ b/docs/source/reference/cli.md
@@ -9,6 +9,7 @@ The following are the command-line arguments that can be passed to `flow.tcl`:
 | `-override_env` <br> Optional | Allows you to override certain configuration environment variables for this run. Format: `-override_env KEY1=VALUE1,KEY2=VALUE2` |
 | `-expose_env` | Expose the following environment variables to `config.json` as configuration variables. Has no effect on config.tcl sourcing, which already has access to all environment variables. Format: `-expose_env KEY1,KEY2` |
 | `-tag <name>`  <br>(Optional) | Specifies a "name" for a specific run. If the tag is not specified, a timestamp is generated for identification of that run.  |
+| `-gui`  | Run the OpenROAD GUI to view the results of the run. Must be paired with `-tag <name>` to specify which tag to display.  |
 | `-run_path <path>`  <br>(Optional) | Specifies a `path` to save the run in. By default the run is in `design_path/`, where the design path is the one passed to `-design` |
 | `-src <verilog_source_file>`  <br>(Optional) | Sets the verilog source code file(s) in case of using `-init\_design\_config`.  <br>The default is that the source code files are under `design_path/src/`, where the design path is the one passed to `-design` |
 | `-init_design_config`  <br>(Optional) | Creates a configuration file for a design. The config file is by default `openlane/config.json`, but can be overriden using the value from `-config_file`.  |


### PR DESCRIPTION
The `-gui` option is currently undocumented, and supports opening the OpenROAD GUI to display the results of a run.