### PR TITLE
Fix `run_path` not passed to `ConfigHandler`

### DIFF
--- a/scripts/report/report.py
+++ b/scripts/report/report.py
@@ -120,7 +120,7 @@ class Report(object):
         self.run_path = run_path
         self.configuration = params.values()
         self.configuration_full = ConfigHandler.get_config_for_run(
-            None, design_path, tag, full=True
+            run_path, design_path, tag, full=True
         )
         self.raw_report = None
         self.formatted_report = None


### PR DESCRIPTION
Since 2023.03.28 when this line of code was added when -run_path is specified on the command line and -run_path is different from the -design path, reporting would error trying to load config.tcl from the wrong location.