### PR TITLE
synthesis.tcl: run_verilator --lint-only option changes

### DIFF
--- a/scripts/tcl_commands/synthesis.tcl
+++ b/scripts/tcl_commands/synthesis.tcl
@@ -271,6 +271,9 @@ proc run_verilator {} {
     lappend arg_list {*}$arg
     try_exec bash -c "verilator \
         --lint-only \
+        --no-timing \
+        +define+SYNTHESIS=1 \
+        +define+SYNTHESIS_VERILATOR_LINT_ONLY=1 \
         -Wall \
         --Wno-DECLFILENAME \
         --top-module $::env(DESIGN_NAME) \


### PR DESCRIPTION
Rationale

--no-timing make it not error on timing statements:
  assign #1 out = !in;

+define+SYNTHESIS=1
  as this pass is on behalf of the synthesis phase so should not include
  verilog which is not for synthesis.  Such as blackboxed primitives.

+define+SYNTHESIS_VERILATOR_LINT_ONLY=1
  like the above but provide more explicit control over this specific
  OpenROAD task to ignore.

  Maybe this option should be added to documentation ?