### PR TITLE
Rework Tcl String Escaping

### DIFF
--- a/tests/1506/config.json
+++ b/tests/1506/config.json
@@ -15,7 +15,9 @@
     "FP_PDN_AUTO_ADJUST": false,
     "TEST_FLOAT_REF": "expr::$CLOCK_PERIOD",
     "TEST_FLOAT_CALC": "expr::2 * $CLOCK_PERIOD",
-    "TEST_POTENTIALLY_MALICIOUS_VARIABLE": "\t\\};puts hi;{\"\"\"''''",
+    "TEST_MALICIOUS_VAR_0": "\t\\};puts hi;[puts hi];{\"\"\"''''",
+    "TEST_MALICIOUS_VAR_1": "\n\nputs hi;\n\n\u0010potato\n",
     "TEST_INTERNAL_GLOB": "dir::../1506/src/*",
-    "TEST_EXTERNAL_GLOB": "dir::../*"
+    "TEST_EXTERNAL_GLOB": "dir::../*",
+    "TEST_REGEX": "x\\.y"
 }

--- a/tests/1506/hooks/post_run.py
+++ b/tests/1506/hooks/post_run.py
@@ -1,11 +1,11 @@
 import os
 from decimal import Decimal
 
+
 assert Decimal(os.environ["TEST_FLOAT_REF"]) == 1
 assert Decimal(os.environ["TEST_FLOAT_CALC"]) == 2
-assert (
-    os.environ["TEST_POTENTIALLY_MALICIOUS_VARIABLE"]
-    == "\t\\\\\\};puts hi;\\{\"\"\"''''"
-)
+assert os.environ["TEST_MALICIOUS_VAR_0"] == "\t\\};puts hi;[puts hi];{\"\"\"''''"
+assert os.environ["TEST_MALICIOUS_VAR_1"] == "\n\nputs hi;\n\npotato\n"
 assert not os.environ["TEST_INTERNAL_GLOB"].endswith("*")
 assert os.environ["TEST_EXTERNAL_GLOB"].endswith("*")
+assert os.environ["TEST_REGEX"] == r"x\.y"


### PR DESCRIPTION
+ `scripts/config/tcl.py:escape_quoted_string` escapes strings for placement inside quotes for Tcl
~ Generated Tcl files now use quotes instead of {} for strings, using above
~ `Tcl.py` no longer ruins variables via overzealous escaping
~ `set_log` renamed to `set_and_log`, stupid arguments removed
~ `save_state` rewritten to rely on initial copy of `::env` array instead of spaghetti mess
~ Make 1506 test more comprehensive

---
Resolves #1780 