### PR TITLE
Do not skip STA when `CLOCK_PORT` is not specified

### DIFF
--- a/scripts/openroad/gpl.tcl
+++ b/scripts/openroad/gpl.tcl
@@ -71,14 +71,3 @@ lappend arg_list -init_wirelength_coef $::env(PL_WIRELENGTH_COEF)
 global_placement {*}$arg_list
 
 write
-
-if {[info exists ::env(CLOCK_PORT)]} {
-	if { $::env(PL_ESTIMATE_PARASITICS) == 1 } {
-		unset_propagated_clock [all_clocks]
-		# set rc values
-		source $::env(SCRIPTS_DIR)/openroad/common/set_rc.tcl
-		estimate_parasitics -placement
-	}
-} else {
-	puts "\[WARN\]: No CLOCK_PORT found. Skipping STA..."
-}

--- a/scripts/openroad/groute.tcl
+++ b/scripts/openroad/groute.tcl
@@ -41,14 +41,3 @@ if { $::env(GRT_REPAIR_ANTENNAS) } {
 }
 
 write
-
-if {[info exists ::env(CLOCK_PORT)]} {
-    if { $::env(GRT_ESTIMATE_PARASITICS) == 1 } {
-        # set rc values
-        source $::env(SCRIPTS_DIR)/openroad/common/set_rc.tcl
-        # estimate wire rc parasitics
-        estimate_parasitics -global_routing
-    }
-} else {
-    puts "\[WARN\]: No CLOCK_PORT found. Skipping STA..."
-}

--- a/scripts/tcl_commands/sta.tcl
+++ b/scripts/tcl_commands/sta.tcl
@@ -13,11 +13,6 @@
 # limitations under the License.
 
 proc run_sta {args} {
-    if {![info exists ::env(CLOCK_PORT)]} {
-        puts_warn "CLOCK_PORT is not set. STA will be skipped..."
-        return
-    }
-
     set options {
         {-log required}
         {-process_corner optional}


### PR DESCRIPTION
- Remove unneeded traces of `*_ESTIMATE_PARASITICS`

-- 
Fixes https://github.com/The-OpenROAD-Project/OpenLane/issues/1788