### PR TITLE
get_tag.py: Don't encode illegal docker tag when local building

### DIFF
--- a/dependencies/get_tag.py
+++ b/dependencies/get_tag.py
@@ -23,6 +23,11 @@ class NoGitException(Exception):
     pass
 
 
+# Slashes are not allowed in the container tag
+def canon(ref: str) -> str:
+    return ref.replace("/", "-")
+
+
 def get_tag() -> str:
     try:
         if os.path.exists("/git_version"):
@@ -51,7 +56,7 @@ def get_tag() -> str:
         branch_name = branch_name_data.stdout.decode("utf8").strip()
         if branch_name not in ["", "HEAD"]:
             if branch_name not in ["main", "master"]:
-                return f"{branch_name}-dev"
+                return canon(f"{branch_name}-dev")
 
         process_data: subprocess.CompletedProcess = subprocess.run(
             ["git", "rev-parse", "HEAD"],
@@ -62,7 +67,7 @@ def get_tag() -> str:
             raise NoGitException(
                 f"Failed to get commit.  Please specify OPENLANE_IMAGE_NAME manually.\nFull output: {process_data.stderr.decode('utf8').strip()}"
             )
-        return process_data.stdout.decode("utf8").strip()
+        return canon(process_data.stdout.decode("utf8").strip())
     except NoGitException as e:
         raise e
     except Exception as e:


### PR DESCRIPTION
I was getting an encoding of "heads/2023.04.19-dev-amd64" and it seems the slash is not allowed to be there.