### PR TITLE
Read multi-corner libs while running resizer and CTS

### DIFF
--- a/configuration/cts.tcl
+++ b/configuration/cts.tcl
@@ -14,6 +14,7 @@
 
 # cts defaults
 set ::env(RUN_CTS) 1
+set ::env(CTS_MULTICORNER_LIB) 1
 set ::env(CTS_TARGET_SKEW) 200
 set ::env(CTS_TOLERANCE) 100
 set ::env(CTS_SINK_CLUSTERING_SIZE) 25

--- a/configuration/general.tcl
+++ b/configuration/general.tcl
@@ -16,6 +16,7 @@
 set ::env(CLOCK_PERIOD) "10.0"
 set ::env(USE_GPIO_PADS) 0
 set ::env(RSZ_DONT_TOUCH_RX) "$^"
+set ::env(RSZ_MULTICORNER_LIB) 1
 
 # Flow Controls
 set ::env(LEC_ENABLE) 0

--- a/docs/source/reference/configuration.md
+++ b/docs/source/reference/configuration.md
@@ -196,7 +196,10 @@ These variables worked initially, but they were too sky130 specific and will be 
 | `CTS_CLK_MAX_WIRE_LENGTH` | Specifies the maximum wire length on the clock net. Value in microns. <br> (Default: `0`) |
 | `CTS_DISABLE_POST_PROCESSING` | Specifies whether or not to disable post cts processing for outlier sinks. <br> (Default: `0`) |
 | `CTS_DISTANCE_BETWEEN_BUFFERS` | Specifies the distance (in microns) between buffers when creating the clock tree (Default: `0`) |
-| `LIB_CTS` | The liberty file used for CTS. By default, this is the `LIB_SYNTH_COMPLETE` minus the cells with drc errors as specified by the drc exclude list. <br> (Default: `$::env(cts_tmpfiles)/cts.lib`) |
+| `LIB_CTS` | The liberty file used for CTS for typical. By default, this is the `LIB_SYNTH_COMPLETE` minus the cells with drc errors as specified by the drc exclude list. <br> (Default: `$::env(cts_tmpfiles)/cts.lib`) |
+| `LIB_CTS_SLOWEST` | The liberty file used for CTS for slowest corner. By default, this is the `LIB_SLOWEST` minus the cells with drc errors as specified by the drc exclude list. <br> (Default: `$::env(cts_tmpfiles)/cts-slowest.lib`) |
+| `LIB_CTS_FASTEST` | The liberty file used for CTS for fastest corner. By default, this is the `LIB_FASTEST` minus the cells with drc errors as specified by the drc exclude list. <br> (Default: `$::env(cts_tmpfiles)/cts-fastest.lib`) |
+| `CTS_MULTICORNER_LIB` | A flag for reading fastest and slowest corner during CTS. <br> (Default: `1`) |
 | `FILL_INSERTION` | **Removed: Use `RUN_FILL_INSERTION`** Enables fill cells insertion after cts (if enabled). 1 = Enabled, 0 = Disabled <br> (Default: `1`)|
 | `RUN_SIMPLE_CTS` | **Removed: TritonCTS is always run**: Runs an alternative simple clock tree synthesis after synthesis instead of TritonCTS. 1 = Enabled, 0 = Disabled <br> (Default: `0`)|
 

--- a/docs/source/reference/configuration.md
+++ b/docs/source/reference/configuration.md
@@ -140,7 +140,7 @@ These variables worked initially, but they were too sky130 specific and will be 
 |Variable|Description|
 |-|-|
 | `RSZ_LIB` | Points to the lib file, corresponding to the typical corner, that is used during resizer optimizations. <br> Default: `LIB_SYNTH_COMPLETE`. |
-| `RSZ_LIB_FASTST` | Points to the lib file, corresponding to the fastest corner, that is used during resizer optimizations. <br> Default: `LIB_FASTEST`. |
+| `RSZ_LIB_FASTEST` | Points to the lib file, corresponding to the fastest corner, that is used during resizer optimizations. <br> Default: `LIB_FASTEST`. |
 | `RSZ_LIB_SLOWEST` | Points to the lib file, corresponding to the slowest corner, that is used during resizer optimizations. <br> Default: `LIB_SLOWEST`. |
 | `RSZ_MULTICORNER_LIB` | A flag for reading fastest and slowest corner during resizer optimizations. <br> Default: `1` |
 | `RSZ_DONT_TOUCH_RX` | A single regular expression designating nets as "don't touch" by resizer optimizations. <br> Default: `$^` (matches nothing.) |

--- a/docs/source/reference/configuration.md
+++ b/docs/source/reference/configuration.md
@@ -196,7 +196,7 @@ These variables worked initially, but they were too sky130 specific and will be 
 | `CTS_CLK_MAX_WIRE_LENGTH` | Specifies the maximum wire length on the clock net. Value in microns. <br> (Default: `0`) |
 | `CTS_DISABLE_POST_PROCESSING` | Specifies whether or not to disable post cts processing for outlier sinks. <br> (Default: `0`) |
 | `CTS_DISTANCE_BETWEEN_BUFFERS` | Specifies the distance (in microns) between buffers when creating the clock tree (Default: `0`) |
-| `LIB_CTS` | The liberty file used for CTS for typical. By default, this is the `LIB_SYNTH_COMPLETE` minus the cells with drc errors as specified by the drc exclude list. <br> (Default: `$::env(cts_tmpfiles)/cts.lib`) |
+| `LIB_CTS` | The liberty file used for CTS for typical corner. By default, this is the `LIB_SYNTH_COMPLETE` minus the cells with drc errors as specified by the drc exclude list. <br> (Default: `$::env(cts_tmpfiles)/cts.lib`) |
 | `LIB_CTS_SLOWEST` | The liberty file used for CTS for slowest corner. By default, this is the `LIB_SLOWEST` minus the cells with drc errors as specified by the drc exclude list. <br> (Default: `$::env(cts_tmpfiles)/cts-slowest.lib`) |
 | `LIB_CTS_FASTEST` | The liberty file used for CTS for fastest corner. By default, this is the `LIB_FASTEST` minus the cells with drc errors as specified by the drc exclude list. <br> (Default: `$::env(cts_tmpfiles)/cts-fastest.lib`) |
 | `CTS_MULTICORNER_LIB` | A flag for reading fastest and slowest corner during CTS. <br> (Default: `1`) |

--- a/docs/source/reference/configuration.md
+++ b/docs/source/reference/configuration.md
@@ -139,7 +139,10 @@ These variables worked initially, but they were too sky130 specific and will be 
 
 |Variable|Description|
 |-|-|
-| `RSZ_LIB` | Points to the lib file, corresponding to the typical corner, that is used during resizer optimizations. This is copy of `LIB_SYNTH_COMPLETE`. <br> Default: automatically generated in `$::env(synthesis_tmpfiles)/resizer_<library-name>.lib` |
+| `RSZ_LIB` | Points to the lib file, corresponding to the typical corner, that is used during resizer optimizations. <br> Default: `LIB_SYNTH_COMPLETE`. |
+| `RSZ_LIB_FASTST` | Points to the lib file, corresponding to the fastest corner, that is used during resizer optimizations. <br> Default: `LIB_FASTEST`. |
+| `RSZ_LIB_SLOWEST` | Points to the lib file, corresponding to the slowest corner, that is used during resizer optimizations. <br> Default: `LIB_SLOWEST`. |
+| `RSZ_MULTICORNER_LIB` | A flag for reading fastest and slowest corner during resizer optimizations. <br> Default: `1` |
 | `RSZ_DONT_TOUCH_RX` | A single regular expression designating nets as "don't touch" by resizer optimizations. <br> Default: `$^` (matches nothing.) |
 | `LIB_RESIZER_OPT` | **Deprecated: use `RSZ_LIB`**: Points to the lib file, corresponding to the typical corner, that is used during resizer optimizations. This is copy of `LIB_SYNTH_COMPLETE`. <br> Default: automatically generated in `$::env(synthesis_tmpfiles)/resizer_<library-name>.lib` |
 

--- a/docs/source/reference/configuration.md
+++ b/docs/source/reference/configuration.md
@@ -139,9 +139,9 @@ These variables worked initially, but they were too sky130 specific and will be 
 
 |Variable|Description|
 |-|-|
-| `RSZ_LIB` | Points to the lib file, corresponding to the typical corner, that is used during resizer optimizations. <br> Default: `LIB_SYNTH_COMPLETE`. |
-| `RSZ_LIB_FASTEST` | Points to the lib file, corresponding to the fastest corner, that is used during resizer optimizations. <br> Default: `LIB_FASTEST`. |
-| `RSZ_LIB_SLOWEST` | Points to the lib file, corresponding to the slowest corner, that is used during resizer optimizations. <br> Default: `LIB_SLOWEST`. |
+| `RSZ_LIB` | Points to one or more lib files, corresponding to the typical corner, that is used during resizer optimizations. <br> Default: `LIB_SYNTH_COMPLETE`. |
+| `RSZ_LIB_FASTEST` | Points to one or more lib files, corresponding to the fastest corner, that is used during resizer optimizations. <br> Default: `LIB_FASTEST`. |
+| `RSZ_LIB_SLOWEST` | Points to one or more lib files, corresponding to the slowest corner, that is used during resizer optimizations. <br> Default: `LIB_SLOWEST`. |
 | `RSZ_MULTICORNER_LIB` | A flag for reading fastest and slowest corner during resizer optimizations. <br> Default: `1` |
 | `RSZ_DONT_TOUCH_RX` | A single regular expression designating nets as "don't touch" by resizer optimizations. <br> Default: `$^` (matches nothing.) |
 | `LIB_RESIZER_OPT` | **Deprecated: use `RSZ_LIB`**: Points to the lib file, corresponding to the typical corner, that is used during resizer optimizations. This is copy of `LIB_SYNTH_COMPLETE`. <br> Default: automatically generated in `$::env(synthesis_tmpfiles)/resizer_<library-name>.lib` |

--- a/scripts/openroad/common/io.tcl
+++ b/scripts/openroad/common/io.tcl
@@ -175,13 +175,11 @@ proc write {args} {
     if { [info exists ::env(SAVE_NETLIST)] } {
         puts "Writing netlist to '$::env(SAVE_NETLIST)'…"
         write_verilog $::env(SAVE_NETLIST)
-        exec sed -i "/clknet_11111111/d" $::env(SAVE_NETLIST)
     }
 
     if { [info exists ::env(SAVE_POWERED_NETLIST)] } {
         puts "Writing powered netlist to '$::env(SAVE_POWERED_NETLIST)'…"
         write_verilog -include_pwr_gnd $::env(SAVE_POWERED_NETLIST)
-        exec sed -i "/clknet_11111111/d" $::env(SAVE_POWERED_NETLIST)
     }
 
     if { [info exists ::env(SAVE_DEF)] } {

--- a/scripts/openroad/common/io.tcl
+++ b/scripts/openroad/common/io.tcl
@@ -84,8 +84,10 @@ proc read_libs {args} {
     define_corners {*}[array name corner]
 
     foreach corner_name [array name corner] {
-        puts "read_liberty -corner $corner_name $corner($corner_name)"
-        read_liberty -corner $corner_name $corner($corner_name)
+        foreach lib $corner($corner_name) {
+            puts "read_liberty -corner $corner_name $lib"
+            read_liberty -corner $corner_name $lib
+        }
         if { [info exists flags(-no_extra)] } {
             if { [info exists ::env(EXTRA_LIBS) ] } {
                 foreach lib $::env(EXTRA_LIBS) {
@@ -98,8 +100,8 @@ proc read_libs {args} {
 
 proc read {args} {
     sta::parse_key_args "read" args \
-        keys {-override_libs}\
-        flags {-multi_corner_libs}
+        keys {-lib_fastest -lib_typical -lib_slowest} \
+        flags {}
 
     if { [info exists ::env(IO_READ_DEF)] && $::env(IO_READ_DEF) } {
         if { [ catch {read_lef $::env(MERGED_LEF)} errmsg ]} {
@@ -120,14 +122,17 @@ proc read {args} {
 
     set read_libs_args [list]
 
-    if { [info exists keys(-override_libs)]} {
-        lappend read_libs_args -typical $keys(-override_libs)
+    if { [info exists keys(-lib_typical)]} {
+        lappend read_libs_args -typical "$keys(-lib_typical)"
     } else {
-        lappend read_libs_args -typical $::env(LIB_TYPICAL)
+        lappend read_libs_args -typical "$::env(LIB_TYPICAL)"
     }
 
-    if { [info exists flags(-multi_corner_libs)] } {
-        lappend read_libs_args -fastest $::env(LIB_FASTEST) -slowest $::env(LIB_SLOWEST)
+    if { [info exists keys(-lib_fastest)] } {
+        lappend read_libs_args -fastest "$keys(-lib_fastest)"
+    }
+    if { [info exists keys(-lib_slowest)] } {
+        lappend read_libs_args -slowest "$keys(-lib_slowest)"
     }
 
     read_libs {*}$read_libs_args
@@ -170,11 +175,13 @@ proc write {args} {
     if { [info exists ::env(SAVE_NETLIST)] } {
         puts "Writing netlist to '$::env(SAVE_NETLIST)'…"
         write_verilog $::env(SAVE_NETLIST)
+        exec sed -i "/clknet_11111111/d" $::env(SAVE_NETLIST)
     }
 
     if { [info exists ::env(SAVE_POWERED_NETLIST)] } {
         puts "Writing powered netlist to '$::env(SAVE_POWERED_NETLIST)'…"
         write_verilog -include_pwr_gnd $::env(SAVE_POWERED_NETLIST)
+        exec sed -i "/clknet_11111111/d" $::env(SAVE_POWERED_NETLIST)
     }
 
     if { [info exists ::env(SAVE_DEF)] } {

--- a/scripts/openroad/cts.tcl
+++ b/scripts/openroad/cts.tcl
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 source $::env(SCRIPTS_DIR)/openroad/common/io.tcl
-read -override_libs "$::env(LIB_CTS)"
+read -lib_typical "$::env(LIB_CTS)"
 
 set max_slew [expr {$::env(SYNTH_MAX_TRAN) * 1e-9}]; # must convert to seconds
 set max_cap [expr {$::env(CTS_MAX_CAP) * 1e-12}]; # must convert to farad

--- a/scripts/openroad/cts.tcl
+++ b/scripts/openroad/cts.tcl
@@ -12,7 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 source $::env(SCRIPTS_DIR)/openroad/common/io.tcl
-read -lib_typical "$::env(LIB_CTS)"
+set read_args [list]
+if { $::env(CTS_MULTICORNER_LIB) } {
+    lappend read_args -lib_fastest $::env(LIB_CTS_FASTEST)
+    lappend read_args -lib_slowest $::env(LIB_CTS_SLOWEST)
+}
+lappend read_args -lib_typical $::env(LIB_CTS)
+read {*}$read_args
 
 set max_slew [expr {$::env(SYNTH_MAX_TRAN) * 1e-9}]; # must convert to seconds
 set max_cap [expr {$::env(CTS_MAX_CAP) * 1e-12}]; # must convert to farad

--- a/scripts/openroad/resizer.tcl
+++ b/scripts/openroad/resizer.tcl
@@ -12,7 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 source $::env(SCRIPTS_DIR)/openroad/common/io.tcl
-read -multi_corner_libs -override_libs "$::env(RSZ_LIB)"
+set read_args [list]
+if { $::env(RSZ_MULTICORNER_LIB) } {
+    lappend read_args -lib_fastest $::env(RSZ_LIB_FASTEST)
+    lappend read_args -lib_slowest $::env(RSZ_LIB_SLOWEST)
+}
+lappend read_args -lib_typical $::env(RSZ_LIB)
+read {*}$read_args
+puts "$read_args"
+exit 1
 
 unset_propagated_clock [all_clocks]
 

--- a/scripts/openroad/resizer.tcl
+++ b/scripts/openroad/resizer.tcl
@@ -19,7 +19,6 @@ if { $::env(RSZ_MULTICORNER_LIB) } {
 }
 lappend read_args -lib_typical $::env(RSZ_LIB)
 read {*}$read_args
-puts "$read_args"
 
 unset_propagated_clock [all_clocks]
 

--- a/scripts/openroad/resizer.tcl
+++ b/scripts/openroad/resizer.tcl
@@ -20,7 +20,6 @@ if { $::env(RSZ_MULTICORNER_LIB) } {
 lappend read_args -lib_typical $::env(RSZ_LIB)
 read {*}$read_args
 puts "$read_args"
-exit 1
 
 unset_propagated_clock [all_clocks]
 

--- a/scripts/openroad/resizer.tcl
+++ b/scripts/openroad/resizer.tcl
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 source $::env(SCRIPTS_DIR)/openroad/common/io.tcl
-read -override_libs "$::env(RSZ_LIB)"
+read -multi_corner_libs -override_libs "$::env(RSZ_LIB)"
 
 unset_propagated_clock [all_clocks]
 

--- a/scripts/openroad/resizer_routing_design.tcl
+++ b/scripts/openroad/resizer_routing_design.tcl
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 source $::env(SCRIPTS_DIR)/openroad/common/io.tcl
-read -override_libs "$::env(RSZ_LIB)"
+read -multi_corner_libs -override_libs "$::env(RSZ_LIB)"
 
 set_propagated_clock [all_clocks]
 

--- a/scripts/openroad/resizer_routing_design.tcl
+++ b/scripts/openroad/resizer_routing_design.tcl
@@ -12,7 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 source $::env(SCRIPTS_DIR)/openroad/common/io.tcl
-read -multi_corner_libs -override_libs "$::env(RSZ_LIB)"
+set read_args [list]
+if { $::env(RSZ_MULTICORNER_LIB) } {
+    lappend read_args -lib_fastest $::env(RSZ_LIB_FASTEST)
+    lappend read_args -lib_slowest $::env(RSZ_LIB_SLOWEST)
+}
+lappend read_args -lib_typical $::env(RSZ_LIB)
+read {*}$read_args
 
 set_propagated_clock [all_clocks]
 

--- a/scripts/openroad/resizer_routing_timing.tcl
+++ b/scripts/openroad/resizer_routing_timing.tcl
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 source $::env(SCRIPTS_DIR)/openroad/common/io.tcl
-read -override_libs "$::env(RSZ_LIB)"
+read -multi_corner_libs -override_libs "$::env(RSZ_LIB)"
 
 set_propagated_clock [all_clocks]
 

--- a/scripts/openroad/resizer_routing_timing.tcl
+++ b/scripts/openroad/resizer_routing_timing.tcl
@@ -12,7 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 source $::env(SCRIPTS_DIR)/openroad/common/io.tcl
-read -multi_corner_libs -override_libs "$::env(RSZ_LIB)"
+set read_args [list]
+if { $::env(RSZ_MULTICORNER_LIB) } {
+    lappend read_args -lib_fastest $::env(RSZ_LIB_FASTEST)
+    lappend read_args -lib_slowest $::env(RSZ_LIB_SLOWEST)
+}
+lappend read_args -lib_typical $::env(RSZ_LIB)
+read {*}$read_args
 
 set_propagated_clock [all_clocks]
 

--- a/scripts/openroad/resizer_timing.tcl
+++ b/scripts/openroad/resizer_timing.tcl
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 source $::env(SCRIPTS_DIR)/openroad/common/io.tcl
-read -override_libs "$::env(RSZ_LIB)"
+read -multi_corner_libs -override_libs "$::env(RSZ_LIB)"
 
 set_propagated_clock [all_clocks]
 

--- a/scripts/openroad/resizer_timing.tcl
+++ b/scripts/openroad/resizer_timing.tcl
@@ -12,7 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 source $::env(SCRIPTS_DIR)/openroad/common/io.tcl
-read -multi_corner_libs -override_libs "$::env(RSZ_LIB)"
+set read_args [list]
+if { $::env(RSZ_MULTICORNER_LIB) } {
+    lappend read_args -lib_fastest $::env(RSZ_LIB_FASTEST)
+    lappend read_args -lib_slowest $::env(RSZ_LIB_SLOWEST)
+}
+lappend read_args -lib_typical $::env(RSZ_LIB)
+read {*}$read_args
 
 set_propagated_clock [all_clocks]
 

--- a/scripts/tcl_commands/all.tcl
+++ b/scripts/tcl_commands/all.tcl
@@ -785,6 +785,22 @@ proc prep {args} {
                 -drc_exclude_only
         }
 
+        if { ! [info exists ::env(LIB_CTS_FASTEST) ] } {
+            set ::env(LIB_CTS_FASTEST) $::env(cts_tmpfiles)/cts-fastest.lib
+            trim_lib\
+                -output $::env(LIB_CTS_FASTEST)\
+                -input $::env(LIB_FASTEST)\
+                -drc_exclude_only
+        }
+
+        if { ! [info exists ::env(LIB_CTS_SLOWEST) ] } {
+            set ::env(LIB_CTS_SLOWEST) $::env(cts_tmpfiles)/cts-slowest.lib
+            trim_lib\
+                -output $::env(LIB_CTS_SLOWEST)\
+                -input $::env(LIB_SLOWEST)\
+                -drc_exclude_only
+        }
+
         if { ! [info exists ::env(DONT_USE_CELLS)] } {
             if { $::env(STD_CELL_LIBRARY_OPT) != $::env(STD_CELL_LIBRARY) } {
                 set drc_exclude_list "$::env(DRC_EXCLUDE_CELL_LIST) $::env(DRC_EXCLUDE_CELL_LIST_OPT)"

--- a/scripts/tcl_commands/all.tcl
+++ b/scripts/tcl_commands/all.tcl
@@ -756,24 +756,24 @@ proc prep {args} {
             -output $::env(LIB_SYNTH)\
             -input $::env(LIB_SYNTH_MERGED)
 
-        # trim resizer library
+        # set resizer library
+        # trimming behavior is done using DONT_USE_CELLS
         if { ! [info exists ::env(RSZ_LIB) ] } {
             set ::env(RSZ_LIB) [list]
-            foreach lib $::env(LIB_SYNTH_COMPLETE) {
-                set fbasename [file rootname [file tail $lib]]
-                set lib_resizer $::env(synthesis_tmpfiles)/resizer_$fbasename.lib
-                file copy -force $lib $lib_resizer
-                lappend ::env(RSZ_LIB) $lib_resizer
-            }
-
+            lappend ::env(RSZ_LIB) $::env(LIB_SYNTH_COMPLETE)
             if { $::env(STD_CELL_LIBRARY_OPT) != $::env(STD_CELL_LIBRARY) } {
-                foreach lib $::env(LIB_SYNTH_OPT) {
-                    set fbasename [file rootname [file tail $lib]]
-                    set lib_resizer $::env(synthesis_tmpfiles)/resizer_opt_$fbasename.lib
-                    file copy -force $lib $lib_resizer
-                    lappend ::env(RSZ_LIB) $lib_resizer
-                }
+                lappend ::env(RSZ_LIB) $::env(LIB_SYNTH_OPT)
             }
+        }
+
+        if { ! [info exists ::env(RSZ_LIB_FASTEST] } {
+            set ::env(RSZ_LIB_FASTEST) [list]
+            lappend ::env(RSZ_LIB_FASTEST) $::env(LIB_FASTEST)
+        }
+
+        if { ! [info exists ::env(RSZ_LIB_SLOWEST)] } {
+            set ::env(RSZ_LIB_SLOWEST) [list]
+            lappend ::env(RSZ_LIB_SLOWEST) $::env(LIB_SLOWEST)
         }
 
         # trim the lib for CTS to only exclude cells with drc errors


### PR DESCRIPTION
add -multi_corner_libs to read in resizer scripts
```
+ add `RSZ_MULTICORNER_LIB`: a flag to read multicorner libs during resizer optimizations
+ add `RSZ_LIB_FASTEST`: defaults to `LIB_FASTEST`
+ add `RSZ_LIB_SLOWEST`: defaults to `LIB_SLOWEST`
+ add `LIB_CTS_SLOWEST`
+ add `LIB_CTS_FASTEST`
+ add `CTS_MULTICONER_LIB`
~ in `read_libs`, in `scripts/openroad/common/io.tcl`, iterate over each each corner definition to allow for reading multiple files for each corner.
~ replace `-override_libs` and `-multi_corner_libs` by `-lib_fastest`, `-lib_slowest` and `-lib_typical` and modify resizer and cts tcl scripts accordingly
~ don't make copies of files in `LIB_SYNTH_COMPLETE` for `RSZ_LIB`, instead point to the original files
```