### PR TITLE
Fix bugs when reading views for STA

### DIFF
--- a/scripts/openroad/common/io.tcl
+++ b/scripts/openroad/common/io.tcl
@@ -246,7 +246,7 @@ proc read_spefs {} {
         foreach {module_name spef_file_min spef_file_nom spef_file_max} "$::env(EXTRA_SPEFS)" {
             set matched 0
             foreach cell [get_cells *] {
-                if { "[get_property $cell ref_name]" eq "$module_name" && !$matched } {
+                if { "[get_property $cell ref_name]" eq "$module_name"} {
                     puts "Matched [get_property $cell name] with $module_name"
                     set matched 1
                     foreach corner $corners {

--- a/scripts/openroad/common/io.tcl
+++ b/scripts/openroad/common/io.tcl
@@ -86,9 +86,10 @@ proc read_libs {args} {
     foreach corner_name [array name corner] {
         puts "read_liberty -corner $corner_name $corner($corner_name)"
         read_liberty -corner $corner_name $corner($corner_name)
-        if { [info exists flags(-no_extra)] } {
+        if { ![info exists flags(-no_extra)] } {
             if { [info exists ::env(EXTRA_LIBS) ] } {
                 foreach lib $::env(EXTRA_LIBS) {
+                    puts "read_liberty -corner $corner_name $lib"
                     read_liberty -corner $corner_name $lib
                 }
             }


### PR DESCRIPTION
```
~ fix condition `-no_extra` in `read_libs`
~ dont stop on the first match when matching instances name for `EXTRA_SPEFS`
```