### PR TITLE
set SCRIPTS_DIR after saving a snapshot from env

### DIFF
--- a/flow.tcl
+++ b/flow.tcl
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 set ::env(OPENLANE_ROOT) [file dirname [file normalize [info script]]]
-set ::env(SCRIPTS_DIR) "$::env(OPENLANE_ROOT)/scripts"
 
 if { [file exists $::env(OPENLANE_ROOT)/install/env.tcl ] } {
     source $::env(OPENLANE_ROOT)/install/env.tcl

--- a/scripts/tcl_commands/all.tcl
+++ b/scripts/tcl_commands/all.tcl
@@ -20,6 +20,8 @@ foreach key [array names ::env] {
     set ::initial_env($key) $::env($key)
 }
 
+set ::env(SCRIPTS_DIR) "$::env(OPENLANE_ROOT)/scripts"
+
 proc save_state {{start_comment "Saved State"}} {
     puts_info "Saving runtime environment..."
     set_and_log ::env(PDK_ROOT) $::env(PDK_ROOT)


### PR DESCRIPTION
so that SCRIPTS_DIR appear in GLB_CFG_FILE
so that or_issue.py is able to use it and copy the correct files