### PR TITLE
Add `gui.py`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,7 @@ endif
 ENV_START = docker run --rm\
 	-v $(OPENLANE_DIR):/openlane\
 	-v $(OPENLANE_DIR)/designs:/openlane/install\
+	-v $(HOME):$(HOME)\
 	$(PDK_OPTS)\
 	$(STD_CELL_OPTS)\
 	$(DOCKER_OPTIONS)

--- a/docs/source/reference/gui.md
+++ b/docs/source/reference/gui.md
@@ -35,6 +35,6 @@ KLayout only supports def format.
 | Argument | Description |
 | - | - |
 | `--viewer <viewer>`<br>(Optional) | The layout viewer, or tool, to display the layout. Available viewers are OpenROAD and KLayout.<br>Default: OpenROAD. |
-| `--format <layout_format>`<br>(Optional) | The layout format to use. Available are `def` and `odb`. For KLayout, only `def` can be used.<br>Default: `def`. |
+| `--format <layout_format>`<br>(Optional) | The layout format to use. Available formats are `gds`, `def` and `odb`. `odb` is only supported by OpenROAD. `gds` is only supported by KLayout.<br>Default: `odb`. |
 | `--stage <stage>`<br>(Optional) | The flow stage to fetch the layout from. `cts`, `floorplan`, `placement`, `routing` and `signoff`.<br>Default: Latest layout produced by the flow. |
 

--- a/docs/source/reference/gui.md
+++ b/docs/source/reference/gui.md
@@ -1,0 +1,40 @@
+# Viewing layouts graphically
+
+You can use `gui.py` to view final layout from a specified run and from the major stages of the flow. 
+Available viewers are OpenROAD and KLayout.
+
+## Usage
+
+To view the final layout using OpenROAD:
+
+```bash
+make mount
+python3 gui.py --viewer openroad ./designs/spm/runs/RUN_2023.05.28_13.36.45
+```
+
+To view the layout from `floorplan` stage:
+
+```bash
+make mount
+python3 gui.py --viewer openroad --stage floorplan ./designs/spm/runs/RUN_2023.05.28_13.36.45
+```
+
+Finally, you can chose to open `def` view instead of `odb` view:
+
+```bash
+make mount
+python3 gui.py --format def --viewer openroad --stage floorplan ./designs/spm/runs/RUN_2023.05.28_13.36.45
+```
+
+:::{note}
+KLayout only supports def view.
+:::
+
+## Command-line interface (CLI)
+
+| Argument | Description |
+| - | - |
+| `--viewer <viewer>`<br>(Optional) | The layout viewer, or tool, to display the layout. Available viewers are OpenROAD and KLayout.<br>Default: OpenROAD. |
+| `--format <layout_format>`<br>(Optional) | The layout format to use. Available are `def` and `odb`. For KLayout, only `def` can be used.<br>Default: `def`. |
+| `--stage <stage>`<br>(Optional) | The flow stage to fetch the layout from. `cts`, `floorplan`, `placement`, `routing` and `signoff`.<br>Default: Latest layout produced by the flow. |
+

--- a/docs/source/reference/gui.md
+++ b/docs/source/reference/gui.md
@@ -27,7 +27,7 @@ python3 gui.py --format def --viewer openroad --stage floorplan ./designs/spm/ru
 ```
 
 :::{note}
-KLayout only supports def view.
+KLayout only supports def format.
 :::
 
 ## Command-line interface (CLI)

--- a/docs/source/reference/gui.md
+++ b/docs/source/reference/gui.md
@@ -27,7 +27,7 @@ python3 gui.py --format def --viewer openroad --stage floorplan ./designs/spm/ru
 ```
 
 :::{note}
-KLayout only supports def format.
+The script needs to run within the OL container.
 :::
 
 ## Command-line interface (CLI)

--- a/docs/source/reference/gui.md
+++ b/docs/source/reference/gui.md
@@ -27,7 +27,9 @@ python3 gui.py --format def --viewer openroad --stage floorplan ./designs/spm/ru
 ```
 
 :::{note}
-The script needs to run within the OL container.
+The script needs to run from the same environment as the OpenLane run, i.e.,
+if you're using OpenLane using `make mount` and the Docker container, `gui.py`
+must be run from the Docker container.
 :::
 
 ## Command-line interface (CLI)
@@ -35,6 +37,6 @@ The script needs to run within the OL container.
 | Argument | Description |
 | - | - |
 | `--viewer <viewer>`<br>(Optional) | The layout viewer, or tool, to display the layout. Available viewers are OpenROAD and KLayout.<br>Default: OpenROAD. |
-| `--format <layout_format>`<br>(Optional) | The layout format to use. Available formats are `gds`, `def` and `odb`. `odb` is only supported by OpenROAD. `gds` is only supported by KLayout.<br>Default: `odb`. |
+| `--format <layout_format>`<br>(Optional) | The layout format to use. Available formats are `gds`, `def` and `odb`. `odb` is only supported by OpenROAD and `gds` is only supported by KLayout.<br>Default: `odb` for OpenROAD, `gds` for KLayout. |
 | `--stage <stage>`<br>(Optional) | The flow stage to fetch the layout from. `cts`, `floorplan`, `placement`, `routing` and `signoff`.<br>Default: Latest layout produced by the flow. |
 

--- a/docs/source/reference/index.rst
+++ b/docs/source/reference/index.rst
@@ -9,4 +9,5 @@ Reference Manual
    openlane_commands
    interactive_mode
    datapoint_definitions
+   gui
 

--- a/gui.py
+++ b/gui.py
@@ -1,0 +1,89 @@
+import click
+
+import os
+import subprocess
+import glob
+
+from scripts.config.tcl import read_tcl_env
+
+
+def err(msg):
+    print(f"Error: {msg}")
+    exit(1)
+
+
+@click.command()
+@click.option(
+    "--viewer",
+    default="openroad",
+    show_default=True,
+    help="Viewer option",
+    type=click.Choice(["klayout", "openroad"]),
+)
+@click.option(
+    "-f",
+    "--format",
+    default="odb",
+    help="Layout format to view",
+    show_default=True,
+    type=click.Choice(["def", "odb"]),
+)
+@click.option(
+    "-s",
+    "--stage",
+    help="Optionally specify which stage to view",
+    type=click.Choice(["cts", "floorplan", "placement", "routing", "signoff"]),
+)
+@click.argument("run_dir")
+def gui(viewer, format, run_dir, stage):
+    """View specified layout from run_dir using supported viewers"""
+
+    run_config_file = os.path.join(run_dir, "config.tcl")
+    if not os.path.exists(run_config_file):
+        err(f"Run config file does not exist.")
+
+    run_config = read_tcl_env(run_config_file)
+
+    if viewer == "openroad":
+        extra_config = {}
+        if stage is not None:
+            matches = glob.glob(os.path.join(run_dir, "results", stage, f"*.{format}"))
+            if matches is []:
+                err(f"No {format} found for stage {stage}")
+            else:
+                extra_config[f"CURRENT_{format.upper()}"] = matches[0]
+
+        if format == "def":
+            extra_config["IO_READ_DEF"] = "1"
+
+        extra_config["GUI_PARASITICS"] = "1"
+        print(f"Using {run_config_file}")
+        run_env = os.environ.copy()
+        subprocess.check_call(
+            ["openroad", "-gui", "./scripts/openroad/gui.tcl"],
+            env={**run_env, **run_config, **extra_config},
+        )
+
+    elif viewer == "klayout":
+        if format == "odb":
+            err("Klayout does not support odb. Please use --format def instead.")
+
+        def_file = run_config["CURRENT_DEF"]
+        subprocess.check_call(
+            [
+                "python3",
+                "./scripts/klayout/open_design.py",
+                "--input-lef",
+                run_config["MERGED_LEF"],
+                "--lyt",
+                run_config["KLAYOUT_TECH"],
+                "--lyp",
+                run_config["KLAYOUT_PROPERTIES"],
+                "--lym",
+                run_config["KLAYOUT_DEF_LAYER_MAP"],
+                def_file,
+            ]
+        )
+
+
+gui()

--- a/gui.py
+++ b/gui.py
@@ -40,7 +40,7 @@ def gui(viewer, format, run_dir, stage):
 
     run_config_file = os.path.join(run_dir, "config.tcl")
     if not os.path.exists(run_config_file):
-        err(f"Run config file does not exist.")
+        err("Run config file does not exist.")
 
     run_config = read_tcl_env(run_config_file)
 

--- a/gui.py
+++ b/gui.py
@@ -86,4 +86,5 @@ def gui(viewer, format, run_dir, stage):
         )
 
 
-gui()
+if __name__ == "__main__":
+    gui()

--- a/scripts/klayout/open_design.py
+++ b/scripts/klayout/open_design.py
@@ -96,6 +96,8 @@ try:
     layout_options.lefdef_config.map_file = lym
 
     cell_view = main_window.load_layout(input, layout_options, 0)
+    layout_view = cell_view.view()
+    layout_view.load_layer_props(lyp)
 
 except Exception as e:
     print(e, file=sys.stderr)

--- a/scripts/klayout/open_design.py
+++ b/scripts/klayout/open_design.py
@@ -97,7 +97,6 @@ try:
 
     cell_view = main_window.load_layout(input, layout_options, 0)
 
-    pya.Application.instance().exit(0)
 except Exception as e:
     print(e, file=sys.stderr)
 

--- a/scripts/openroad/common/io.tcl
+++ b/scripts/openroad/common/io.tcl
@@ -102,7 +102,7 @@ proc read_libs {args} {
 proc read {args} {
     sta::parse_key_args "read" args \
         keys {-lib_fastest -lib_typical -lib_slowest} \
-        flags {}
+        flags {-no_spefs}
 
     if { [info exists ::env(IO_READ_DEF)] && $::env(IO_READ_DEF) } {
         if { [ catch {read_lef $::env(MERGED_LEF)} errmsg ]} {
@@ -144,10 +144,13 @@ proc read {args} {
             exit 1
         }
     }
-    if { [info exists ::env(CURRENT_SPEF)] } {
-        if {[catch {read_spef $::env(CURRENT_SPEF)} errmsg]} {
-            puts stderr $errmsg
-            exit 1
+
+    if { ![info exist flags(-no_spefs)] } {
+        if { [info exists ::env(CURRENT_SPEF)] } {
+            if {[catch {read_spef $::env(CURRENT_SPEF)} errmsg]} {
+                puts stderr $errmsg
+                exit 1
+            }
         }
     }
 }

--- a/scripts/openroad/groute.tcl
+++ b/scripts/openroad/groute.tcl
@@ -29,6 +29,7 @@ source $::env(SCRIPTS_DIR)/openroad/common/set_layer_adjustments.tcl
 set arg_list [list]
 lappend arg_list -congestion_iterations $::env(GRT_OVERFLOW_ITERS)
 lappend arg_list -verbose
+lappend arg_list -congestion_report_file $::env(routing_tmpfiles)/groute-congestion.rpt
 if { $::env(GRT_ALLOW_CONGESTION) == 1 } {
     lappend arg_list -allow_congestion
 }

--- a/scripts/openroad/groute.tcl
+++ b/scripts/openroad/groute.tcl
@@ -29,7 +29,7 @@ source $::env(SCRIPTS_DIR)/openroad/common/set_layer_adjustments.tcl
 set arg_list [list]
 lappend arg_list -congestion_iterations $::env(GRT_OVERFLOW_ITERS)
 lappend arg_list -verbose
-lappend arg_list -congestion_report_file $::env(routing_tmpfiles)/groute-congestion.rpt
+lappend arg_list -congestion_report_file $::env(GRT_CONGESTION_REPORT_FILE)
 if { $::env(GRT_ALLOW_CONGESTION) == 1 } {
     lappend arg_list -allow_congestion
 }

--- a/scripts/openroad/gui.tcl
+++ b/scripts/openroad/gui.tcl
@@ -12,13 +12,36 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 source $::env(SCRIPTS_DIR)/openroad/common/io.tcl
-read
+read -no_spefs
 
-if { [info exists ::env(CURRENT_SPEF)] } {
-    puts "Reading '$::env(CURRENT_SPEF)'..."
-    read_spefs
-} else {
-    puts "\[WARNING\] No SPEF found."
+proc are_insts_placed {} {
+    set odb_block [[[::ord::get_db] getChip] getBlock]
+    set odb_nets [odb::dbBlock_getNets $odb_block]
+    set odb_instances [odb::dbBlock_getInsts $odb_block]
+    foreach instance $odb_instances {
+        if { ![odb::dbInst_isPlaced $instance] } {
+            return 0
+        }
+    }
+    return 1
+}
 
-    puts "You may run estimate_parasitics -placement or estimate_parasitics -global_routing to get basic timing information."
+if { [info exists ::env(GUI_PARASITICS)] } {
+    if { [are_insts_placed] } {
+        if { [grt::have_routes] } {
+            puts "Have routes"
+            if { [info exists ::env(CURRENT_SPEF)] } {
+                puts "Reading '$::env(CURRENT_SPEF)' ..."
+                read_spefs
+            } else {
+                puts "Estimating global parastics ..."
+                source $::env(SCRIPTS_DIR)/openroad/common/set_rc.tcl
+                estimate_parasitics -global_routing
+            }
+        } else {
+                puts "Estimating placement parastics ..."
+                source $::env(SCRIPTS_DIR)/openroad/common/set_rc.tcl
+                estimate_parasitics -placement
+        }
+    }
 }

--- a/scripts/openroad/gui.tcl
+++ b/scripts/openroad/gui.tcl
@@ -29,9 +29,8 @@ proc are_insts_placed {} {
 if { [info exists ::env(GUI_PARASITICS)] } {
     if { [are_insts_placed] } {
         if { [grt::have_routes] } {
-            puts "Have routes"
             if { [info exists ::env(CURRENT_SPEF)] } {
-                puts "Reading '$::env(CURRENT_SPEF)' ..."
+                puts "Reading spefs ..."
                 read_spefs
             } else {
                 puts "Estimating global parastics ..."

--- a/scripts/openroad/gui.tcl
+++ b/scripts/openroad/gui.tcl
@@ -27,7 +27,7 @@ proc are_insts_placed {} {
 }
 
 if { [info exists ::env(GUI_PARASITICS)] } {
-    if { [are_insts_placed] } {
+    if { [are_insts_placed] } { ;# grt::have_routes causes an error with results from floorplan so check if cells are placed
         if { [grt::have_routes] } {
             if { [info exists ::env(CURRENT_SPEF)] } {
                 puts "Reading spefs ..."

--- a/scripts/openroad/resizer_routing_design.tcl
+++ b/scripts/openroad/resizer_routing_design.tcl
@@ -38,7 +38,7 @@ source $::env(SCRIPTS_DIR)/openroad/common/set_layer_adjustments.tcl
 set arg_list [list]
 lappend arg_list -congestion_iterations $::env(GRT_OVERFLOW_ITERS)
 lappend arg_list -verbose
-lappend arg_list -congestion_report_file $::env(routing_tmpfiles)/resizer-routing-design-congestion.rpt
+lappend arg_list -congestion_report_file $::env(GRT_CONGESTION_REPORT_FILE)
 if { $::env(GRT_ALLOW_CONGESTION) == 1 } {
     lappend arg_list -allow_congestion
 }

--- a/scripts/openroad/resizer_routing_design.tcl
+++ b/scripts/openroad/resizer_routing_design.tcl
@@ -38,6 +38,7 @@ source $::env(SCRIPTS_DIR)/openroad/common/set_layer_adjustments.tcl
 set arg_list [list]
 lappend arg_list -congestion_iterations $::env(GRT_OVERFLOW_ITERS)
 lappend arg_list -verbose
+lappend arg_list -congestion_report_file $::env(routing_tmpfiles)/resizer-routing-design-congestion.rpt
 if { $::env(GRT_ALLOW_CONGESTION) == 1 } {
     lappend arg_list -allow_congestion
 }

--- a/scripts/openroad/resizer_routing_timing.tcl
+++ b/scripts/openroad/resizer_routing_timing.tcl
@@ -38,6 +38,7 @@ source $::env(SCRIPTS_DIR)/openroad/common/set_layer_adjustments.tcl
 set arg_list [list]
 lappend arg_list -congestion_iterations $::env(GRT_OVERFLOW_ITERS)
 lappend arg_list -verbose
+lappend arg_list -congestion_report_file $::env(routing_tmpfiles)/resizer-routing-timing-congestion.rpt
 if { $::env(GRT_ALLOW_CONGESTION) == 1 } {
     lappend arg_list -allow_congestion
 }

--- a/scripts/openroad/resizer_routing_timing.tcl
+++ b/scripts/openroad/resizer_routing_timing.tcl
@@ -38,7 +38,7 @@ source $::env(SCRIPTS_DIR)/openroad/common/set_layer_adjustments.tcl
 set arg_list [list]
 lappend arg_list -congestion_iterations $::env(GRT_OVERFLOW_ITERS)
 lappend arg_list -verbose
-lappend arg_list -congestion_report_file $::env(routing_tmpfiles)/resizer-routing-timing-congestion.rpt
+lappend arg_list -congestion_report_file $::env(GRT_CONGESTION_REPORT_FILE)
 if { $::env(GRT_ALLOW_CONGESTION) == 1 } {
     lappend arg_list -allow_congestion
 }

--- a/scripts/tcl_commands/routing.tcl
+++ b/scripts/tcl_commands/routing.tcl
@@ -38,6 +38,7 @@ proc global_routing_fastroute {args} {
     set initial_guide [index_file $::env(routing_tmpfiles)/global.guide]
     set initial_odb [index_file $::env(routing_tmpfiles)/global.odb]
 
+    set ::env(GRT_CONGESTION_REPORT_FILE) $::env(routing_tmpfiles)/groute-congestion.rpt
     run_openroad_script $::env(SCRIPTS_DIR)/openroad/groute.tcl\
         -indexed_log $log\
         -save "def=$initial_def,guide=$initial_guide,odb=$initial_odb"\
@@ -445,6 +446,7 @@ proc run_resizer_design_routing {args} {
         set log [index_file $::env(routing_logs)/resizer_design.log]
         puts_info "Running Global Routing Resizer Design Optimizations (log: [relpath . $log])..."
 
+        set ::env(GRT_CONGESTION_REPORT_FILE) $::env(routing_tmpfiles)/resizer-routing-design-congestion.rpt
         run_openroad_script $::env(SCRIPTS_DIR)/openroad/resizer_routing_design.tcl\
             -indexed_log $log\
             -save "dir=$::env(routing_tmpfiles),def,sdc,odb,netlist,powered_netlist"
@@ -464,6 +466,7 @@ proc run_resizer_timing_routing {args} {
         set log [index_file $::env(routing_logs)/resizer_timing.log]
         puts_info "Running Global Routing Resizer Timing Optimizations (log: [relpath . $log])..."
 
+        set ::env(GRT_CONGESTION_REPORT_FILE) $::env(routing_tmpfiles)/resizer-routing-timing-congestion.rpt
         run_openroad_script $::env(SCRIPTS_DIR)/openroad/resizer_routing_timing.tcl\
             -indexed_log $log\
             -save "dir=$::env(routing_tmpfiles),def,sdc,odb,netlist,powered_netlist"


### PR DESCRIPTION
\+ Add `gui.py`. Adding the help message here:
```
Usage: gui.py [OPTIONS] RUN_DIR

  View specified layout from run_dir using supported viewers

Options:
  --viewer [klayout|openroad]     Viewer option  [default: openroad]
  -f, --format [def|odb|gds]      Layout format to view  [default: odb]
  -s, --stage [cts|floorplan|placement|routing|signoff]
                                  Optionally specify which stage to view
  --help                          Show this message and exit.
```

\+ Mount HOME directory when running `make mount`.
\+ Add `-congestion_report_file` to steps that call global routing