### PR TITLE
Fix Max Transition Time Usage

### DIFF
--- a/docs/source/reference/configuration.md
+++ b/docs/source/reference/configuration.md
@@ -48,7 +48,7 @@ These variables are optional that can be specified in the design configuration f
 | `SYNTH_CAP_LOAD` | The capacitive load on the output ports in femtofarads. <br> (Default: `33.5` ff)|
 | `SYNTH_DEFINES` | Specifies verilog defines. Variable should be provided as a json/tcl list. <br> (Default: NONE) |
 | `SYNTH_MAX_FANOUT`  | The max load that the output ports can drive. <br> (Default: `10` cells) |
-| `SYNTH_MAX_TRAN` | The max transition time (slew) from high to low or low to high on cell inputs in ns. Used in synthesis <br> (Default: Calculated at runtime as `10%` of the provided clock period, unless this exceeds a set DEFAULT_MAX_TRAN, in which case it will be used as is). |
+| `SYNTH_MAX_TRAN` | The max transition time (slew) from high to low or low to high on cell inputs in ns. If unset, the library's default maximum transition time will be used. |
 | `SYNTH_CLOCK_UNCERTAINTY`  | Specifies a value for the clock uncertainty/jitter for timing analysis. <br> (Default: `0.25`) |
 | `SYNTH_CLOCK_TRANSITION`  |  Specifies a value for the clock transition /slew for timing analysis. <br> (Default: `0.15`) |
 | `SYNTH_TIMING_DERATE`  | Specifies a derating factor to multiply the path delays with. It specifies the upper and lower ranges of timing. <br> (Default: `+5%/-5%`) |

--- a/scripts/base.sdc
+++ b/scripts/base.sdc
@@ -4,12 +4,16 @@ if {[info exists ::env(CLOCK_PORT)] && $::env(CLOCK_PORT) != ""} {
     create_clock -name __VIRTUAL_CLK__ -period $::env(CLOCK_PERIOD)
     set ::env(CLOCK_PORT) __VIRTUAL_CLK__
 }
+
 set input_delay_value [expr $::env(CLOCK_PERIOD) * $::env(IO_PCT)]
 set output_delay_value [expr $::env(CLOCK_PERIOD) * $::env(IO_PCT)]
 puts "\[INFO\]: Setting output delay to: $output_delay_value"
 puts "\[INFO\]: Setting input delay to: $input_delay_value"
 
 set_max_fanout $::env(SYNTH_MAX_FANOUT) [current_design]
+if { [info exists ::env(SYNTH_MAX_TRAN)] } {
+    set_max_transition $::env(SYNTH_MAX_TRAN) [current_design]
+}
 
 set clk_input [get_port $::env(CLOCK_PORT)]
 set clk_indx [lsearch [all_inputs] $clk_input]
@@ -34,7 +38,6 @@ if { ![info exists ::env(SYNTH_CLK_DRIVING_CELL_PIN)] } {
 }
 
 set_driving_cell -lib_cell $::env(SYNTH_DRIVING_CELL) -pin $::env(SYNTH_DRIVING_CELL_PIN) $all_inputs_wo_clk_rst
-
 set_driving_cell -lib_cell $::env(SYNTH_CLK_DRIVING_CELL) -pin $::env(SYNTH_CLK_DRIVING_CELL_PIN) $clk_input
 
 set cap_load [expr $::env(SYNTH_CAP_LOAD) / 1000.0]

--- a/scripts/openroad/cts.tcl
+++ b/scripts/openroad/cts.tcl
@@ -20,8 +20,6 @@ if { $::env(CTS_MULTICORNER_LIB) } {
 lappend read_args -lib_typical $::env(LIB_CTS)
 read {*}$read_args
 
-set max_slew [expr {$::env(SYNTH_MAX_TRAN) * 1e-9}]; # must convert to seconds
-set max_cap [expr {$::env(CTS_MAX_CAP) * 1e-12}]; # must convert to farad
 # set rc values
 source $::env(SCRIPTS_DIR)/openroad/common/set_rc.tcl
 estimate_parasitics -placement
@@ -31,9 +29,12 @@ estimate_parasitics -placement
 repair_clock_inverters
 
 puts "\[INFO\]: Configuring cts characterization..."
-configure_cts_characterization\
-    -max_slew $max_slew\
-    -max_cap $max_cap
+set cts_characterization_args [list]
+lappend -max_cap [expr {$::env(CTS_MAX_CAP) * 1e-12}]; # pF -> F
+if { [info exists ::env(SYNTH_MAX_TRAN)] } {
+    lappend -max_slew [expr {$::env(SYNTH_MAX_TRAN) * 1e-9}]; # ns -> S
+}
+configure_cts_characterization {*}$cts_characterization_args
 
 puts "\[INFO]: Performing clock tree synthesis..."
 puts "\[INFO]: Looking for the following net(s): $::env(CLOCK_NET)"

--- a/scripts/tcl_commands/all.tcl
+++ b/scripts/tcl_commands/all.tcl
@@ -768,7 +768,7 @@ proc prep {args} {
             }
         }
 
-        if { ! [info exists ::env(RSZ_LIB_FASTEST] } {
+        if { ! [info exists ::env(RSZ_LIB_FASTEST)] } {
             set ::env(RSZ_LIB_FASTEST) [list]
             lappend ::env(RSZ_LIB_FASTEST) $::env(LIB_FASTEST)
         }
@@ -841,19 +841,6 @@ proc prep {args} {
         set ::env(BASIC_PREP_COMPLETE) {1}
     }
 
-    # Fill config file with special cases
-    if { ! [info exists ::env(SYNTH_MAX_TRAN)] } {
-        if { [info exists ::env(CLOCK_PERIOD)] } {
-            if { [info exists ::env(DEFAULT_MAX_TRAN)] } {
-                set ::env(SYNTH_MAX_TRAN) [expr min([expr {0.1*$::env(CLOCK_PERIOD)}], $::env(DEFAULT_MAX_TRAN))]
-            } else {
-                set ::env(SYNTH_MAX_TRAN) [expr {0.1*$::env(CLOCK_PERIOD)}]
-            }
-        } else {
-            set ::env(SYNTH_MAX_TRAN) 0
-        }
-        set_and_log ::env(SYNTH_MAX_TRAN) $::env(SYNTH_MAX_TRAN)
-    }
     if { $::env(SYNTH_ELABORATE_ONLY) } {
         set_and_log ::env(SYNTH_SCRIPT) "$::env(SCRIPTS_DIR)/yosys/elaborate.tcl"
     }

--- a/scripts/tcl_commands/synthesis.tcl
+++ b/scripts/tcl_commands/synthesis.tcl
@@ -125,7 +125,7 @@ proc run_synthesis {args} {
                 && $::env(SYNTH_ELABORATE_ONLY) == 1 } {
                 set pre_synth_report $::env(synth_report_prefix).chk.rpt
             }
-        run_synthesis_checkers $log $pre_synth_report
+            run_synthesis_checkers $log $pre_synth_report
         }
     }
     TIMER::timer_stop
@@ -248,7 +248,7 @@ proc run_verilator {} {
     set verilator_verified_scl "sky130_fd_sc_hd"
     set includes ""
     if { [string match *$::env(PDK)* $verilator_verified_pdks] == 0 || \
-            [string match *$::env(STD_CELL_LIBRARY)* $verilator_verified_scl] == 0} {
+        [string match *$::env(STD_CELL_LIBRARY)* $verilator_verified_scl] == 0} {
         puts_warn "PDK '$::env(PDK)', SCL '$::env(STD_CELL_LIBRARY)' will generate errors with instantiated stdcells in the design."
         puts_warn "Either disable QUIT_ON_VERILATOR_ERRORS or remove the instantiated cells."
     } else {

--- a/scripts/yosys/synth.tcl
+++ b/scripts/yosys/synth.tcl
@@ -61,7 +61,7 @@ if { [info exists ::env(VERILOG_FILES_BLACKBOX)] } {
 
 
 # ns expected (in sdc as well)
-set clock_period [expr {$::env(CLOCK_PERIOD)*1000}]
+set clock_period [expr {$::env(CLOCK_PERIOD) * 1000}]; # ns -> ps
 
 set driver  $::env(SYNTH_DRIVING_CELL)
 set cload   $::env(SYNTH_CAP_LOAD)
@@ -129,7 +129,7 @@ set abc_map_new_area  	"amap,-m,-Q,0.1,-F,20,-A,20,-C,5000"
 if {$buffering==1} {
     set max_tr_arg ""
     if { $max_TR != 0 } {
-        set max_tr_arg = ",-S,${max_TR}"
+        set max_tr_arg ",-S,${max_TR}"
     }
     set abc_fine_tune		"buffer,-N,${max_FO}${max_tr_arg};upsize,{D};dnsize,{D}"
 } elseif {$sizing} {

--- a/scripts/yosys/synth.tcl
+++ b/scripts/yosys/synth.tcl
@@ -67,12 +67,10 @@ set driver  $::env(SYNTH_DRIVING_CELL)
 set cload   $::env(SYNTH_CAP_LOAD)
 # input pin cap of IN_3VX8
 set max_FO $::env(SYNTH_MAX_FANOUT)
-if {![info exist ::env(SYNTH_MAX_TRAN)]} {
-    set ::env(SYNTH_MAX_TRAN) [expr {0.1*$clock_period}]
-} else {
-    set ::env(SYNTH_MAX_TRAN) [expr {$::env(SYNTH_MAX_TRAN) * 1000}]
+set max_TR 0
+if { [info exist ::env(SYNTH_MAX_TRAN)]} {
+    set max_TR [expr {$::env(SYNTH_MAX_TRAN) * 1000}]; # ns -> ps
 }
-set max_Tran $::env(SYNTH_MAX_TRAN)
 
 
 # Mapping parameters
@@ -129,7 +127,11 @@ set abc_retime_dly    	"retime,-D,{D},-M,6"
 set abc_map_new_area  	"amap,-m,-Q,0.1,-F,20,-A,20,-C,5000"
 
 if {$buffering==1} {
-    set abc_fine_tune		"buffer,-N,${max_FO},-S,${max_Tran};upsize,{D};dnsize,{D}"
+    set max_tr_arg ""
+    if { $max_TR != 0 } {
+        set max_tr_arg = ",-S,${max_TR}"
+    }
+    set abc_fine_tune		"buffer,-N,${max_FO}${max_tr_arg};upsize,{D};dnsize,{D}"
 } elseif {$sizing} {
     set abc_fine_tune       "upsize,{D};dnsize,{D}"
 } else {


### PR DESCRIPTION
+ Add `SYNTH_MAX_TRAN` to `base.sdc` (if set)
~ Fix syntax error in `all.tcl`
- Removed attempt(s) to calculate a default value for `SYNTH_MAX_TRAN` in `all.tcl`, `openroad/cts.tcl` and `yosys/synth.tcl`

---

Resolves #1825 