### PR TITLE
Deprecate  `-gui` and continuing the flow with an existing tag

### DIFF
--- a/flow.tcl
+++ b/flow.tcl
@@ -157,7 +157,7 @@ proc run_non_interactive_mode {args} {
         {-save_path optional}
         {-override_env optional}
     }
-    set flags {-save -run_hooks -no_lvs -no_drc -no_antennacheck -gui}
+    set flags {-save -run_hooks -no_lvs -no_drc -no_antennacheck -gui -overwrite}
     parse_key_args "run_non_interactive_mode" args arg_values $options flags_map $flags -no_consume
 
     if { [info exists arg_values(-from) ] || [info exists arg_values(-to)] } {
@@ -165,13 +165,21 @@ proc run_non_interactive_mode {args} {
         exit -1
     }
 
+    if { [info exists flags_map(-gui)] } {
+        puts_warn "Flag -gui is now deprecated. Refer to https://openlane.readthedocs.io/en/latest/reference/gui.html to view files graphically.
+Please rerun without it."
+        return
+    }
+
+    if { [info exists flags_map(-overwrite)] } {
+        puts_warn "Flag -overwrite is now deprecated. The default behaviour now is removing the run. Please file an issue if you think there is a value for the flag.
+Please rerun without it."
+        return
+    }
+
     prep {*}$args
     # signal trap SIGINT save_state;
 
-    if { [info exists flags_map(-gui)] } {
-        or_gui
-        return
-    }
     if { [info exists arg_values(-override_env)] } {
         load_overrides $arg_values(-override_env)
     }

--- a/flow.tcl
+++ b/flow.tcl
@@ -166,8 +166,8 @@ proc run_non_interactive_mode {args} {
     }
 
     if { [info exists flags_map(-gui)] } {
-        puts_warn "Flag -gui is now deprecated. Refer to https://openlane.readthedocs.io/en/latest/reference/gui.html to view files graphically."
-        return
+        puts_err "Flag -gui is now deprecated. Refer to https://openlane.readthedocs.io/en/latest/reference/gui.html to view files graphically."
+        throw_error
     }
 
     prep {*}$args

--- a/flow.tcl
+++ b/flow.tcl
@@ -157,7 +157,7 @@ proc run_non_interactive_mode {args} {
         {-save_path optional}
         {-override_env optional}
     }
-    set flags {-save -run_hooks -no_lvs -no_drc -no_antennacheck -gui -overwrite}
+    set flags {-save -run_hooks -no_lvs -no_drc -no_antennacheck -gui}
     parse_key_args "run_non_interactive_mode" args arg_values $options flags_map $flags -no_consume
 
     if { [info exists arg_values(-from) ] || [info exists arg_values(-to)] } {
@@ -167,12 +167,6 @@ proc run_non_interactive_mode {args} {
 
     if { [info exists flags_map(-gui)] } {
         puts_warn "Flag -gui is now deprecated. Refer to https://openlane.readthedocs.io/en/latest/reference/gui.html to view files graphically.
-Please rerun without it."
-        return
-    }
-
-    if { [info exists flags_map(-overwrite)] } {
-        puts_warn "Flag -overwrite is now deprecated. The default behaviour now is removing the run. Please file an issue if you think there is a value for the flag.
 Please rerun without it."
         return
     }

--- a/flow.tcl
+++ b/flow.tcl
@@ -166,8 +166,7 @@ proc run_non_interactive_mode {args} {
     }
 
     if { [info exists flags_map(-gui)] } {
-        puts_warn "Flag -gui is now deprecated. Refer to https://openlane.readthedocs.io/en/latest/reference/gui.html to view files graphically.
-Please rerun without it."
+        puts_warn "Flag -gui is now deprecated. Refer to https://openlane.readthedocs.io/en/latest/reference/gui.html to view files graphically."
         return
     }
 

--- a/scripts/parse_yosys_check.py
+++ b/scripts/parse_yosys_check.py
@@ -66,9 +66,9 @@ def parse_yosys_check(
     >>> rpt = io.StringIO(MULTIPLE_FAILURES); parse_yosys_check(rpt, True, True) #doctest: +REPORT_NDIFF +NORMALIZE_WHITESPACE
     True
     >>> rpt = io.StringIO(NO_TRISTATE); parse_yosys_check(rpt, True, True) #doctest: +REPORT_NDIFF +NORMALIZE_WHITESPACE
-    False
+    True
     >>> rpt = io.StringIO(NO_TRISTATE); parse_yosys_check(rpt, False, True) #doctest: +REPORT_NDIFF +NORMALIZE_WHITESPACE
-    False
+    True
     >>> rpt = io.StringIO(TRISTATE_ONLY); parse_yosys_check(rpt, True, True) #doctest: +REPORT_NDIFF +NORMALIZE_WHITESPACE
     False
     >>> rpt = io.StringIO(TRISTATE_ONLY); parse_yosys_check(rpt, False, True) #doctest: +REPORT_NDIFF +NORMALIZE_WHITESPACE
@@ -78,7 +78,7 @@ def parse_yosys_check(
     error_encountered = False
     current_warning = None
     for line in report:
-        if line.startswith("Warning:"):
+        if line.startswith("Warning:") or line.startswith("Found and reported"):
             if current_warning is not None:
                 if tristate_okay and "tribuf" in current_warning:
                     log("Ignoring tristate-related error:")

--- a/scripts/tcl_commands/all.tcl
+++ b/scripts/tcl_commands/all.tcl
@@ -674,10 +674,15 @@ proc prep {args} {
 
     puts_info "Run Directory: $::env(RUN_DIR)"
 
-    if { [file exists $::env(RUN_DIR)] } {
-        puts_info "Removing existing $::env(RUN_DIR)..."
-        after 1000
-        file delete -force $::env(RUN_DIR)
+    if { [file exists $::env(GLB_CFG_FILE)] } {
+        if { [info exists flags_map(-overwrite)] } {
+            puts_info "Removing existing $::env(RUN_DIR)..."
+            after 1000
+            file delete -force $::env(RUN_DIR)
+        } else {
+            puts_err "A run for $::env(DESIGN_NAME) with tag '$tag' already exists. Pass the -overwrite option to overwrite it."
+            after 1000
+        }
     }
 
     # file mkdir works like shell mkdir -p, i.e., its OK if it already exists

--- a/scripts/tcl_commands/all.tcl
+++ b/scripts/tcl_commands/all.tcl
@@ -680,8 +680,9 @@ proc prep {args} {
             after 1000
             file delete -force $::env(RUN_DIR)
         } else {
-            puts_err "A run for $::env(DESIGN_NAME) with tag '$tag' already exists. Pass the -overwrite option to overwrite it."
+            puts_err "A run for $::env(DESIGN_NAME) with tag '$tag' already exists. Pass the -overwrite option to overwrite it or use a different tag"
             after 1000
+            throw_error
         }
     }
 

--- a/scripts/tcl_commands/all.tcl
+++ b/scripts/tcl_commands/all.tcl
@@ -681,7 +681,6 @@ proc prep {args} {
             file delete -force $::env(RUN_DIR)
         } else {
             puts_err "A run for $::env(DESIGN_NAME) with tag '$tag' already exists. Pass the -overwrite option to overwrite it or use a different tag"
-            after 1000
             throw_error
         }
     }

--- a/scripts/tcl_commands/all.tcl
+++ b/scripts/tcl_commands/all.tcl
@@ -674,27 +674,10 @@ proc prep {args} {
 
     puts_info "Run Directory: $::env(RUN_DIR)"
 
-    if { [file exists $::env(GLB_CFG_FILE)] } {
-        if { [info exists flags_map(-overwrite)] } {
-            puts_info "Removing existing $::env(RUN_DIR)..."
-            after 1000
-            file delete -force $::env(RUN_DIR)
-        } else {
-            if { ![info exists flags_map(-last_run)] } {
-                puts_warn "A run for $::env(DESIGN_NAME) with tag '$tag' already exists. Pass the -overwrite option to overwrite it."
-                after 1000
-            }
-            puts_info "Sourcing $::env(GLB_CFG_FILE). Note that any changes to the DESIGN config file will NOT be applied."
-            source $::env(GLB_CFG_FILE)
-            if { [info exists ::env(CURRENT_ODB)] && $::env(CURRENT_ODB) != 0 } {
-                puts_info "Current ODB: $::env(CURRENT_ODB)"
-                puts_info "Use 'set_odb file_name.odb' if you'd like to change it."
-            }
-            after 1000
-            if { [info exists ::env(BASIC_PREP_COMPLETE)] && "$::env(BASIC_PREP_COMPLETE)" == "1"} {
-                set skip_basic_prep 1
-            }
-        }
+    if { [file exists $::env(RUN_DIR)] } {
+        puts_info "Removing existing $::env(RUN_DIR)..."
+        after 1000
+        file delete -force $::env(RUN_DIR)
     }
 
     # file mkdir works like shell mkdir -p, i.e., its OK if it already exists


### PR DESCRIPTION
`-gui` is superseded by `gui.py`. `or_gui` should still work for interactive scripts. 
Dropping support for continuing existing runs. Users need to use `-overwrite` or provide a different tag.