### PR TITLE
Handle modules deeper in the hierarchy for EXTRA_SPEFS

### DIFF
--- a/scripts/openroad/common/io.tcl
+++ b/scripts/openroad/common/io.tcl
@@ -253,17 +253,17 @@ proc read_spefs {} {
     if { [info exists ::env(EXTRA_SPEFS)] } {
         foreach {module_name spef_file_min spef_file_nom spef_file_max} "$::env(EXTRA_SPEFS)" {
             set matched 0
-            foreach cell [get_cells *] {
+            foreach cell [get_cells * -hierarchical] {
                 if { "[get_property $cell ref_name]" eq "$module_name"} {
-                    puts "Matched [get_property $cell name] with $module_name"
+                    puts "Matched [get_property $cell full_name] with $module_name"
                     set matched 1
                     foreach corner $corners {
                         if { $::env(PROCESS_CORNER) eq "nom" } {
-                            read_spef -path [get_property $cell name] -corner [$corner name] $spef_file_nom
+                            read_spef -path [get_property $cell full_name] -corner [$corner name] $spef_file_nom
                         } elseif { $::env(PROCESS_CORNER) eq "min" } {
-                            read_spef -path [get_property $cell name] -corner [$corner name] $spef_file_min
+                            read_spef -path [get_property $cell full_name] -corner [$corner name] $spef_file_min
                         } elseif { $::env(PROCESS_CORNER) eq "max" } {
-                            read_spef -path [get_property $cell name] -corner [$corner name] $spef_file_max
+                            read_spef -path [get_property $cell full_name] -corner [$corner name] $spef_file_max
                         }
                     }
                 }
@@ -273,5 +273,7 @@ proc read_spefs {} {
                 exit 1
             }
         }
+    } else {
+        puts "Extra spefs not defined"
     }
 }

--- a/scripts/openroad/common/io.tcl
+++ b/scripts/openroad/common/io.tcl
@@ -273,7 +273,5 @@ proc read_spefs {} {
                 exit 1
             }
         }
-    } else {
-        puts "Extra spefs not defined"
     }
 }


### PR DESCRIPTION
```
+ add -hierarchical to get_cells: "Searches hierarchy levels below the current instance for matches."
~ use get_property full_name instead get_property name to get the full hierarchical name of a module.
+ log when extra spefs is not defined
```