### PR TITLE
Always raise an exception when a design fails in the CI

### DIFF
--- a/.github/scripts/run_tests.py
+++ b/.github/scripts/run_tests.py
@@ -104,6 +104,7 @@ subprocess.check_call(
 print("Created ./reproducible.tar.gz.")
 
 if run_return_code != 0:
+    print("Run failed")
     raise run_exception
 
 difference_reports = glob.glob(os.path.join(results_folder, f"{test_name}*.rpt"))

--- a/.github/scripts/run_tests.py
+++ b/.github/scripts/run_tests.py
@@ -81,6 +81,7 @@ print(f"Running {shlex.join(docker_command)} in {os.getenv('PWD')}…")
 try:
     subprocess.run(docker_command, check=True)
 except subprocess.CalledProcessError as e:
+    print("subprocess error code", e.returncode)
     if e.returncode != 2:
         raise e
 

--- a/.github/scripts/run_tests.py
+++ b/.github/scripts/run_tests.py
@@ -78,11 +78,15 @@ docker_command = [
 
 print(f"Running {shlex.join(docker_command)} in {os.getenv('PWD')}…")
 
+run_return_code = 0
+run_exception = Exception
 try:
     subprocess.run(docker_command, check=True)
 except subprocess.CalledProcessError as e:
     print("subprocess error code", e.returncode)
-    if e.returncode != 2:
+    run_exception = e
+    run_return_code = e.returncode
+    if run_return_code != 2:
         raise e
 
 
@@ -98,6 +102,9 @@ subprocess.check_call(
     ["tar", "-czf", "./reproducible.tar.gz", os.path.join("designs", design, "runs")]
 )
 print("Created ./reproducible.tar.gz.")
+
+if run_return_code != 0:
+    raise run_exception
 
 difference_reports = glob.glob(os.path.join(results_folder, f"{test_name}*.rpt"))
 if len(difference_reports):

--- a/.github/test_sets/test_sets.yml
+++ b/.github/test_sets/test_sets.yml
@@ -12,7 +12,6 @@
     - manual_macro_placement_test
     - spm
     - gcd
-    - y_huff
     - caravel_upw
 - scl: sky130A/sky130_fd_sc_hd
   name: extended_test_set
@@ -23,6 +22,7 @@
     - blabla
     - picorv32a
     - PPU
+    - y_huff
     - aes
 - scl: gf180mcuC/gf180mcu_fd_sc_mcu7t5v0
   name: fastest_test_set
@@ -30,7 +30,6 @@
     - spm
     - APU
     - usb
-    - y_huff
     # - usb_cdc_core
     # - zipdiv
     # - wbqspiflash
@@ -39,3 +38,4 @@
   designs:
     - picorv32a
     - PPU
+    - y_huff

--- a/.github/test_sets/test_sets.yml
+++ b/.github/test_sets/test_sets.yml
@@ -12,6 +12,7 @@
     - manual_macro_placement_test
     - spm
     - gcd
+    - y_huff
     - caravel_upw
 - scl: sky130A/sky130_fd_sc_hd
   name: extended_test_set
@@ -22,7 +23,6 @@
     - blabla
     - picorv32a
     - PPU
-    - y_huff
     - aes
 - scl: gf180mcuC/gf180mcu_fd_sc_mcu7t5v0
   name: fastest_test_set
@@ -30,6 +30,7 @@
     - spm
     - APU
     - usb
+    - y_huff
     # - usb_cdc_core
     # - zipdiv
     # - wbqspiflash
@@ -38,4 +39,3 @@
   designs:
     - picorv32a
     - PPU
-    - y_huff


### PR DESCRIPTION
An exit code of 2 is bypassed. It seems that an exit code that is not 2 is a failure of the python script itself not OpenLane flow. This exception is raised and propagated to the CI. However an exit code of 2 should be propagated as well after a reproducible is made. The CI flow shouldn't attempt to run benchmark when the flow failed. 