### PR TITLE
 Cleanup Deprecated Variable Documentation

### DIFF
--- a/docs/source/for_developers/pdk_structure.md
+++ b/docs/source/for_developers/pdk_structure.md
@@ -1,6 +1,9 @@
 # Porting a PDK
 This readme describes how to structure a PDK for use with OpenLane.
 
+In general, a PDK is expected to define all variables not marked optional in
+the [PDK configuration variable list](../reference/pdk_configuration.md).
+
 ## Folder structure
 This is the expected folder structure for a PDK:
 
@@ -15,153 +18,13 @@ This is the expected folder structure for a PDK:
 				- drc_exclude.cells
 	- libs.ref
 		- lef
-		- techLEF
+		- techlef
 		- lib
+		- ...
 
-## Configuration files
-- `config.tcl` PDK configuration file contains common information for all standard cell libraries under this PDK
-- `<standard cell library>/config.tcl` standard cell library configuration file which contains information specific to that SCL. It can override PDK configuration file.
-- `<standard cell library>/tracks.info` Contains information about the metal layers offsets and pitches. Refer to tracks configuration file [section](#tracks-info-file)
-- `<standard cell library>/no_synth.cells` that should contain the list of newline-separated cell names to trim during synthesis (to not use them in synthesis). More in this [section](#no-synthesis-cells-file).
-
-
-## PDK Variables
-This section defines the necessary variables for PDK configuration file. Note that all examples given are for sky130A.
-
-| Variable      | Description                                                   |
-|---------------|---------------------------------------------------------------|
-| `DEF_UNITS_PER_MICRON` | Defines the unit distance microns. Used during floorplanning for proper def file generation. |
-| `VDD_PIN` | Defines the power pin of the cells.  |
-| `GND_PIN` | Defines the ground pin of the cells. |
-| `TRACKS_INFO_FILE` | Points to the path of the tracks file. Used by the floorplanner to generate tracks |
-| `TECH_LEF_MIN` | Points to the path of the tech lef used for minimum corner extraction. (Optional) |
-| `TECH_LEF` | Points to the path of the tech lef used for nominal corner extraction. |
-| `TECH_LEF_MAX` | Points to the path of the tech lef used for maximum corner extraction. (Optional) |
-| `CELLS_LEF` | A list of paths to the cells lef views. Recommended to use wild card to catch all the files as follows: `[glob "$::env(PDK_ROOT)/sky130A/libs.ref/$::env(STD_CELL_LIBRARY)/lef/*.lef"]` |
-| `GDS_FILES` | A list of paths to the cells GDSII views. Recommended to use wild card to catch all the files as follows: `[glob "$::env(PDK_ROOT)/sky130A/libs.ref/$::env(STD_CELL_LIBRARY)/gds/*.gds"]` |
-| `MAGIC_TECH_FILE` | Points to the magic tech file which mainly has drc rules. |
-| `KLAYOUT_TECH` | Points to the klayout tech file (.lyt). |
-| `KLAYOUT_PROPERTIES` | Points to the klayout properties file (.lyp). |
-| `KLAYOUT_DEF_LAYER_MAP` | Points to klayout deflef layer map file (.map). |
-| `KLAYOUT_XOR_IGNORE_LAYERS` | A space separated layers list to ignore during klayout xor check. |
-| `MAGIC_MAGICRC` | Points to the magicrc file that is sourced while running magic in the flow. |
-| `GPIO_PADS_LEF` | A list of the pads lef views. For example:`[glob "$::env(PDK_ROOT)/sky130A/libs.ref/sky130_fd_io/lef/sky130_fd_io.lef"]` |
-| `GPIO_PADS_PREFIX` | A list of pad cells name prefixes. |
-| `NETGEN_SETUP_FILE` | Points to the setup file for netgen(lvs), that can exclude certain cells etc.. |
-| `FP_TAPCELL_DIST` | The distance between tapcell columns. Used in floorplanning in tapcell insertion. |
-| `DEFAULT_MAX_TRAN` | Defines the default maximum transition value, used in CTS & synthesis. |
-| `FP_PDN_RAIL_OFFSET` | Defines the rail offset for met1 used in PDN. <br> (Example: `0`) | |
-| `FP_PDN_HSPACING`  | The spacing between horizontal power/ground pair <br> (Default: `1.7`) |
-| `FP_PDN_VSPACING`  | The spacing between vertical power/ground pair <br> (Default: `1.7`) |
-| `FP_PDN_VOFFSET`  | The offset of the vertical power stripes on the metal layer 5 in the power distribution network <br> (Default: `16.32`) |
-| `FP_PDN_VPITCH`  | The pitch of the vertical power stripes on the metal layer 4 in the power distribution network <br> (Default: `153.6`) |
-| `FP_PDN_HOFFSET`  | The offset of the horizontal power stripes on the metal layer 5 in the power distribution network <br> (Default: `16.65`) |
-| `FP_PDN_HPITCH`  | The pitch of the horizontal power stripes on the metal layer 5 in the power distribution network <br> (Default: `153.18`) |
-| `FP_PDN_VWIDTH` | Defines the strap width for the vertical layer used in PDN. <br> (Example: `1.6`) | |
-| `FP_PDN_HWIDTH` | Defines the strap width for the horizontal layer used in PDN. <br> (Example: `1.6`) | |
-| `FP_PDN_CORE_RING_VWIDTH` | Defines the vertical width for the vertical layer used to create the core ring in the PDN. <br> (Example: `20`) | |
-| `FP_PDN_CORE_RING_HWIDTH` | Defines the horizontal width for the horizontal layer used to create the core ring in the PDN. <br> (Example: `20`) | |
-| `FP_PDN_CORE_RING_VSPACING` | Defines the spacing for the vertical layer used to create the core ring in the PDN. <br> (Example: `5`) | |
-| `FP_PDN_CORE_RING_HSPACING` | Defines the spacing for the horizontal layer used to create the core ring in the PDN. <br> (Example: `5`) | |
-| `FP_PDN_CORE_RING_VOFFSET` | Defines the offset for the vertical layer used to create the core ring in the PDN. <br> (Example: `20`) | |
-| `FP_PDN_CORE_RING_HOFFSET` | Defines the offset for the horizontal layer used to create the core ring in the PDN. <br> (Example: `20`) | |
-| `WIRE_RC_LAYER` | The metal layer used in estimate parastics `set_wire_rc`. <br> (Example: `met1`) ||
-| `GRT_LAYER_ADJUSTMENTS` | Layer-specific reductions in the routing capacity of the edges between the cells in the global routing graph, delimited by commas. Values range from 0 to 1. <br> (Example: `0.99,0,0,0,0,0`)
-| `FP_IO_HLAYER`  | The metal layer on which to place the io pins horizontally (top and bottom of the die). <br>(Example: `met3`)|
-| `FP_IO_VLAYER`  | The metal layer on which to place the io pins vertically (sides of the die) <br> (Example: `met2`)|
-| `FP_TAPCELL_DIST`  | The horizontal distance between two tapcell columns <br> (Default: `14`) |
-| `RT_MIN_LAYER`  | The lowest metal layer to route on. <br>(Example: `met1`)|
-| `RT_MAX_LAYER`  | The highest metal layer to route on. <br> (Example: `met5`)|
-| `RCX_RULES_MIN` | OpenRCX rules at the minimum corner. (Optional) |
-| `RCX_RULES` | OpenRCX rules at the nominal corner. |
-| `RCX_RULES_MAX` | OpenRCX rules at the maximum corner. (Optional) |
-| `WIRE_LENGTH_THRESHOLD` | A value in microns above which wire lengths generate warnings, and, if `QUIT_ON_LONG_WIRE` is set, the flow will error out. If a PDK does not set this value, the value is considered to be infinite. (Optional) |
-
-## SCL-specific variables
-
-This section defines the necessary variables to configure a standard cell library for use with OpenLane:
-
-| Variable      | Description                                                   |
-|---------------|---------------------------------------------------------------|
-| `LIB_SYNTH` | Points to the lib file used during synthesis. |
-| `LIB_SLOWEST` | Points to the lib file, corresponding to the slowest corner, for max delay calculation during STA. |
-| `LIB_FASTEST` | Points to the lib file, corresponding to the fastest corner, for min delay calculation during STA. |
-| `LIB_TYPICAL` | Points to the lib file for typical delay calculation during STA. |
-| `DFF_LIB_SYNTH` | Points to the lib file for used for dff mapping. If not specified, `LIB_SYNTH` is used. (Optional) |
-| `PLACE_SITE` | Defines the main site used by the cells. Used during floorplanning to generate the rows. |
-| `PLACE_SITE_WIDTH` | Defines the main site width. Used during floorplanning to generate the rows. |
-| `PLACE_SITE_HEIGHT` | Defines the main site height. Used during floorplanning to generate the rows. |
-| `FP_WELLTAP_CELL` | Defines the tapcell to be used in tapcell insertion. <br> If this is not defined then tapcell insertion will be skipped but the flow will resume normally |
-| `FP_ENDCAP_CELL` | Defines the decapcell. Inserted during floorplanning at the sides of the design. |
-| `SYNTH_DRIVING_CELL`  | The cell to drive the input ports, used in synthesis and static timing analysis. <br>(Example: `sky130_fd_sc_hd__inv_1`)|
-| `SYNTH_DRIVING_CELL_PIN`  | The name of the `SYNTH_DRIVING_CELL`'s output pin. <br>(Default: `Y`)|
-| `SYNTH_CLK_DRIVING_CELL`  | An alternative cell with which to drive clock inputs. Can be left empty, where the SDC script will use `SYNTH_DRIVING_CELL` for clock inputs as well. |
-| `SYNTH_CLK_DRIVING_CELL_PIN`  | The name of the SYNTH_CLK_DRIVING_CELL output pin. Can be left empty, where the SDC script will use `SYNTH_DRIVING_CELL_PIN`. |
-| `SYNTH_CAP_LOAD` | Defines the capacitive load on the output ports in femtofarads. Used in synthesis |
-| `SYNTH_MIN_BUF_PORT` | Defines the buffer, followed by its input port and output port to be used by `ins_buf` statements by yosys. It inserts buffer cells into the design for directly connected wires. <br> (Example: `sky130_fd_sc_hd__buf_2 A X`  )|
-| `SYNTH_TIEHI_PORT` | Defines the tie high cell followed by the port that implements the tie high functionality. Used in synthesis. <br> (Example: `sky130_fd_sc_hd__conb_1 HI`)|
-| `SYNTH_TIELO_PORT` | Defines the tie low cell followed by the port that implements the tie high functionality. Used in synthesis. <br> (Example: `sky130_fd_sc_hd__conb_1 LO`)|
-| `TRISTATE_CELL_PREFIX` | Prefix of tristate cells. Used with SYNTH_CHECKS_ALLOW_TRISTATE. <br> Example `sky130_fd_sc_hd__ebuf` |
-| `FILL_CELL` | Defines the fill cell. Used in fill insertion. Can use a wild card to define a class of cells. Example `sky130_fd_sc_hd__fill_*` |
-| `DECAP_CELL` | Defines the decap cell used for fill insertion. Can use a wild card to define a class of cells. Example `sky130_fd_sc_hd__fill_*` |
-| `DIODE_CELL_PIN` | Defines the `DIODE_CELL` pin. This is required if `DIODE_CELL` is defined |
-| `DIODE_CELL` | Defines the diode cell to be used during antenna violations fix step. <br> If this is not defined then the no antenna violations fixes will be attempted |
-| `GPL_CELL_PADDING` | Cell padding value (in sites) for global placement. <br> (Example: `2`) |
-| `DPL_CELL_PADDING` | Defines the number of sites to pad the cells with during detailed placement. This value should not be higher than `GPL_CELL_PADDING` unless you know what you're doing. <br> (Example: `2`) |
-| `CELL_PAD_EXCLUDE` | Defines the cells to exclude from padding for both detailed placement. |
-| `CTS_ROOT_BUFFER` | Defines the cell inserted at the root of the clock tree. Used in CTS. |
-| `CTS_CLK_BUFFER_LIST` | Defines the list of clock buffers to be used in CTS. |
-| `CTS_MAX_CAP` | Defines the maximum capacitance, used in CTS. |
-| `STD_CELL_GROUND_PINS` | Defines ground pins of stdcells. Used in PDN. |
-| `FP_PDN_HORIZONTAL_LAYER` | Defines the upper layer used in PDN. |
-| `FP_PDN_VERTICAL_LAYER` | Defines the lower layer used in PDN. |
-| `FP_PDN_RAIL_LAYER` | Defines the rail layer used in PDN. |
-| `FP_PDN_RAIL_WIDTH` | Defines the rail width for the rail layer used in PDN. |
-| `SYNTH_LATCH_MAP` | A pointer for the file containing the latch mapping for yosys. (Optional) |
-| `TRISTATE_BUFFER_MAP` | A pointer for the file containing the tri-state buffer mapping for yosys. (Optional) |
-| `CARRY_SELECT_ADDER_MAP` | A pointer for the file containing the carry-select adder mapping for Yosys. (Optional) |
-| `FULL_ADDER_MAP` | A pointer for the file containing the full adder mapping for Yosys. (Optional) |
-| `NO_SYNTH_CELL_LIST` | Specifies the file that contains the don't-use-cell-list to be excluded from the liberty file during synthesis. If it's not defined, this path is searched `$::env(PDK_ROOT)/$::env(PDK)/libs.tech/openlane/$::env(STD_CELL_LIBRARY)/no_synth.cells` and if it's not found, then the original liberty will be used as is. |
-| `DRC_EXCLUDE_CELL_LIST` | Specifies the file that contains the don't-use-cell-list to be excluded from the liberty file during synthesis and timing optimizations. If it's not defined, this path is searched `$::env(PDK_ROOT)/$::env(PDK)/libs.tech/openlane/$::env(STD_CELL_LIBRARY)/drc_exclude.cells` and if it's not found, then the original liberty will be used as is. In other words, `DRC_EXCLUDE_CELL_LIST` contain the only excluded cell list in timing optimizations. |
-| `CVC_SCRIPTS_DIR` | A directory of Circuit Validity Checker (CVC) scripts for the relevant PDK. Must contain the following set of files: `cvcrc`, an initialization file, `cdl.awk`, an awk script to remove black box definitions from SPICE files, `models`, cell models, and finally `power.awk`, an awk script that adds power information to the verilog netlists. |
-| `STD_CELL_LIBRARY_CDL` | A pointer for the cdl view of the SCL. |
-| `LAYERS_RC` | A comma separated list specifying capacitance and resistance per layer. Variable should be provided in the following format. `<layer_name> <capacitance> <resistance>, <layer_name> ...` ([warning](../reference/configuration.md#on-comma-delimited-variables)) (Optional) |
-| `VIAS_RC` | A comma separated list specifying capacitance -only- of vias. Variable should be provided in the following format. `<layer_name> <capacitance> , <layer_name> ...` ([warning](../reference/configuration.md#on-comma-delimited-variables)) (Optional) |
-
-## Tracks Info File
-
-The tracks files defines the metal layers pitches and offsets. This information should be extracted from the PDK's tech lef. The following is the format of the files
-
-```
-<layer name> X|Y <offset> <pitch>
-```
-
-## No Synthesis Cells File
-
-There are some cell types that you don't want to use in synthesis like, for example, delay cells and clock buffers (since CTS is a separate step that would insert the clock buffers).
-
-Also, other cells don't have a default mapping in yosys, so they were excluded to reduce the liberty file size until we add a tech mapping file for each.
-
-The smallest sizes of the cells were also removed to prevent the synthesizer from using them, which allows for a larger floorplan. These cells however are accessible by the optimizer which will in turn replace the bigger cells with these smaller sizes when needed. Eventually, this process will produce clean routing without forcing the users of OpenLane to re-configure their designs with smaller `FP_CORE_UTIL` and `PL_TARGET_DENSITY` values. Nonetheless, this change will come some time in the future.
-
-However, this list is likely over-constraining, and if you have done experiments allowing smaller sizes incrementally and still got clean routed layouts, please let us know your findings, or better yet, submit a pull request at [open_pdks](https://github.com/RTimothyEdwards/open_pdks) with a suggested no_synth list.
-
-
-This list is only used during synthesis.
-
-You can also point your custom no_synth.cells by setting the value for `NO_SYNTH_CELL_LIST` to point to it.
-
-
-## DRC Exclude Cells File
-
-Some of the cells, back when this list was created, had hard-to-access pin shapes, so the detailed router didn't manage to do routing cleanly.
-
-Others had DRC violations within the cell definitions.
-
-We excluded all cells of size _0 for the same reasons explained in the previous section.
-
-The lpflow cells were also excluded because the flow is still unable to deal with them and connect a KAPWR supply.
-
-This list is used for both synthesis and timing optimizations.
-
-You can also point your custom no_synth.cells by setting the value for `DRC_EXCLUDE_CELL_LIST` to point to it.
+## Configuration Files
+- `config.tcl`: the PDK configuration file contains common information for all standard cell libraries under this PDK.
+- `<standard cell library>/config.tcl`: Standard cell library configuration file which contains information specific to that SCL. Variables in this file may override the general PDK variables.
+- `<standard cell library>/tracks.info`: Contains information about the metal layers offsets and pitches. Refer to tracks configuration file [section](../reference/pdk_configuration.md#tracks-info-file).
+- `<standard cell library>/drc_exclude.cells` that should contain the list of newline-separated cell names to exclude during synthesis and PnR. More in this [section](../reference/pdk_configuration.md#drc-exclude-cells-file).
+- `<standard cell library>/no_synth.cells` that should contain the list of newline-separated cell names to exclude during synthesis. More in this [section](../reference/pdk_configuration.md#no-synthesis-cells-file).

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -15,8 +15,8 @@ Check the sidebar to the left to get started.
    flow_overview
    usage/index
    tutorials/index
-   for_developers/index
    reference/index
    additional_material
    authors
+   for_developers/index
 

--- a/docs/source/reference/configuration.md
+++ b/docs/source/reference/configuration.md
@@ -126,8 +126,8 @@ These variables are optional that can be specified in the design configuration f
 | `SYNTH_USE_PG_PINS_DEFINES` | Specifies the power guard used in the verilog source code to specify the power and ground pins. This is used to automatically extract `VDD_NETS` and `GND_NET` variables from the verilog, with the assumption that they will be order `inout vdd1, inout gnd1, inout vdd2, inout gnd2, ...`. |
 | `FP_IO_MIN_DISTANCE`  | The minmimum distance between the IOs in microns. <br> (Default: `3`) |
 | `FP_PADFRAME_CFG`  | A configuration file passed to padringer, a padframe generator. <br> (Default: NONE) |
-| `FP_PDN_IRDROP` | **Removed: worthless** Enable calculation of power grid IR drop during PDN generation. <br> (Default: `1`)|
 | `PDN_CFG` | **Deprecated: Use `FP_PDN_CFG`** Points to a pdn configuration file that describes how to construct the pdn in detail.  <br> (Default: `scripts/openroad/common/pdn_cfg.tcl`) |
+| `FP_PDN_IRDROP` | **Removed: worthless** Enable calculation of power grid IR drop during PDN generation. <br> (Default: `1`)|
 
 #### Deprecated I/O Layer variables
 These variables worked initially, but they were too sky130 specific and will be removed. Currently, if you define them in your design, they'll be used, but it's recommended to update your configuration to use `FP_IO_HLAYER` and `FP_IO_VLAYER`, which are defined in the PDK.

--- a/docs/source/reference/configuration.md
+++ b/docs/source/reference/configuration.md
@@ -127,6 +127,7 @@ These variables are optional that can be specified in the design configuration f
 | `FP_IO_MIN_DISTANCE`  | The minmimum distance between the IOs in microns. <br> (Default: `3`) |
 | `FP_PADFRAME_CFG`  | A configuration file passed to padringer, a padframe generator. <br> (Default: NONE) |
 | `FP_PDN_IRDROP` | **Removed: worthless** Enable calculation of power grid IR drop during PDN generation. <br> (Default: `1`)|
+| `PDN_CFG` | **Deprecated use `FP_PDN_CFG`** Points to a pdn configuration file that describes how to construct the pdn in detail.  <br> (Default: `scripts/openroad/common/pdn_cfg.tcl`) |
 
 #### Deprecated I/O Layer variables
 These variables worked initially, but they were too sky130 specific and will be removed. Currently, if you define them in your design, they'll be used, but it's recommended to update your configuration to use `FP_IO_HLAYER` and `FP_IO_VLAYER`, which are defined in the PDK.

--- a/docs/source/reference/configuration.md
+++ b/docs/source/reference/configuration.md
@@ -203,6 +203,7 @@ These variables worked initially, but they were too sky130 specific and will be 
 | `LIB_CTS_SLOWEST` | The liberty file used for CTS for slowest corner. By default, this is the `LIB_SLOWEST` minus the cells with drc errors as specified by the drc exclude list. <br> (Default: `$::env(cts_tmpfiles)/cts-slowest.lib`) |
 | `LIB_CTS_FASTEST` | The liberty file used for CTS for fastest corner. By default, this is the `LIB_FASTEST` minus the cells with drc errors as specified by the drc exclude list. <br> (Default: `$::env(cts_tmpfiles)/cts-fastest.lib`) |
 | `CTS_MULTICORNER_LIB` | A flag for reading fastest and slowest corner during CTS. <br> (Default: `1`) |
+| `CLOCK_TREE_SYNTH` | **Deprecated: Use `RUN_CTS`**: Enable clock tree synthesis. <br> (Default: `1`)|
 | `FILL_INSERTION` | **Removed: Use `RUN_FILL_INSERTION`** Enables fill cells insertion after cts (if enabled). 1 = Enabled, 0 = Disabled <br> (Default: `1`)|
 | `RUN_SIMPLE_CTS` | **Removed: TritonCTS is always run**: Runs an alternative simple clock tree synthesis after synthesis instead of TritonCTS. 1 = Enabled, 0 = Disabled <br> (Default: `0`)|
 

--- a/docs/source/reference/configuration.md
+++ b/docs/source/reference/configuration.md
@@ -336,6 +336,7 @@ These variables worked initially, but they were too sky130 specific and will be 
 | `HEURISTIC_ANTENNA_THRESHOLD` | Minimum manhattan distance of a net to insert a diode in microns. Only applicable for `RUN_HEURISTIC_DIODE_INSERTION` is enabled. <br> (Default: `90`)
 | `USE_ARC_ANTENNA_CHECK` | Specifies whether to use the openroad ARC antenna checker or magic antenna checker. 0=magic antenna checker, 1=ARC OR antenna checker <br> (Default: `1`)
 | `RUN_LINTER` | Enable linter (currently Verilator) <br> (Default: `1`)
+| `RUN_ROUTING_DETAILED` | **Deprecated: Use `RUN_DRT`** Enables detailed routing. 1 = Enabled, 0 = Disabled <br> (Default: `1`)|
 | `TAP_DECAP_INSERTION` | **Deprecated: Use `RUN_TAP_DECAP_INSERTION`** Enables tap and decap cells insertion after floorplanning (if enabled) .1 = Enabled, 0 = Disabled <br> (Default: `1`) |
 | `MAGIC_CONVERT_DRC_TO_RDB` | **Removed: Will always run** Specifies whether or not generate a Calibre RDB out of the magic.drc report. Result is saved in `<run_path>/results/magic/`. 1=enabled 0=disabled <br> Default: `1`|
 | `TEST_MISMATCHES` | **Removed: See `./flow.tcl -test_mismatches`** Test for mismatches between the OpenLane tool versions and the current environment. `all` tests all mismatches. `tools` tests all except the PDK. `pdk` only tests the PDK. `none` disables the check.<br> (Default: `all`) |

--- a/docs/source/reference/configuration.md
+++ b/docs/source/reference/configuration.md
@@ -204,7 +204,7 @@ These variables worked initially, but they were too sky130 specific and will be 
 | `LIB_CTS_SLOWEST` | The liberty file used for CTS for slowest corner. By default, this is the `LIB_SLOWEST` minus the cells with drc errors as specified by the drc exclude list. <br> (Default: `$::env(cts_tmpfiles)/cts-slowest.lib`) |
 | `LIB_CTS_FASTEST` | The liberty file used for CTS for fastest corner. By default, this is the `LIB_FASTEST` minus the cells with drc errors as specified by the drc exclude list. <br> (Default: `$::env(cts_tmpfiles)/cts-fastest.lib`) |
 | `CTS_MULTICORNER_LIB` | A flag for reading fastest and slowest corner during CTS. <br> (Default: `1`) |
-| `CLOCK_TREE_SYNTH` | **Deprecated: Use `RUN_CTS`**: Enable clock tree synthesis. <br> (Default: `1`)|
+| `CLOCK_TREE_SYNTH` | **Deprecated: Use `RUN_CTS`** Enable clock tree synthesis. <br> (Default: `1`)|
 | `FILL_INSERTION` | **Removed: Use `RUN_FILL_INSERTION`** Enables fill cells insertion after cts (if enabled). 1 = Enabled, 0 = Disabled <br> (Default: `1`)|
 | `RUN_SIMPLE_CTS` | **Removed: TritonCTS is always run**: Runs an alternative simple clock tree synthesis after synthesis instead of TritonCTS. 1 = Enabled, 0 = Disabled <br> (Default: `0`)|
 

--- a/docs/source/reference/configuration.md
+++ b/docs/source/reference/configuration.md
@@ -365,6 +365,8 @@ These variables worked initially, but they were too sky130 specific and will be 
 | `LINTER_RELATIVE_INCLUDES` | When a file references an include file, resolve the filename relative to the path of the referencing file, instead of relative to the current directory. <br> (Default: `1`) |
 | `LINTER_INCLUDE_PDK_MODELS` | Enables including verilog models of the pdk with the linter. This is useful when the design has hand instantiated macros. This variable has no effect if the PDK/STD_CELL_LIBRARY aren't supported. Currently, sky130A/sky130_fd_sc_hd and sky130B/sky130_fd_sc_hd are the only ones supported <br> (Default: `1`) |
 | `LINTER_DEFINES` | A list of defines that are passed to the linter. The syntax for each item in the list is as follows `<define>(=<value>)`. `(=value)` is optional. Both `PnR=1` or `PnR` are accepted <br> (Default: `SYNTH_DEFINES`) |
+| `CHECK_ASSIGN_STATEMENTS` | **Deprecated: use `QUIT_ON_ASSIGN_STATEMENTS`** Checks for assign statement in the generated gate level netlist and aborts of any was found.1 = Enabled, 0 = Disabled <br> (Default: `0`)|
+| `CHECK_UNMAPPED_CELLS` | **Deprecated: used `QUIT_ON_UNMAPPED_CELLS`** Checks if there are unmapped cells after synthesis and aborts if any was found. 1 = Enabled, 0 = Disabled <br> (Default: `1`)|
 
 
 ### On comma-delimited variables

--- a/docs/source/reference/configuration.md
+++ b/docs/source/reference/configuration.md
@@ -127,7 +127,7 @@ These variables are optional that can be specified in the design configuration f
 | `FP_IO_MIN_DISTANCE`  | The minmimum distance between the IOs in microns. <br> (Default: `3`) |
 | `FP_PADFRAME_CFG`  | A configuration file passed to padringer, a padframe generator. <br> (Default: NONE) |
 | `FP_PDN_IRDROP` | **Removed: worthless** Enable calculation of power grid IR drop during PDN generation. <br> (Default: `1`)|
-| `PDN_CFG` | **Deprecated use `FP_PDN_CFG`** Points to a pdn configuration file that describes how to construct the pdn in detail.  <br> (Default: `scripts/openroad/common/pdn_cfg.tcl`) |
+| `PDN_CFG` | **Deprecated: Use `FP_PDN_CFG`** Points to a pdn configuration file that describes how to construct the pdn in detail.  <br> (Default: `scripts/openroad/common/pdn_cfg.tcl`) |
 
 #### Deprecated I/O Layer variables
 These variables worked initially, but they were too sky130 specific and will be removed. Currently, if you define them in your design, they'll be used, but it's recommended to update your configuration to use `FP_IO_HLAYER` and `FP_IO_VLAYER`, which are defined in the PDK.
@@ -365,8 +365,8 @@ These variables worked initially, but they were too sky130 specific and will be 
 | `LINTER_RELATIVE_INCLUDES` | When a file references an include file, resolve the filename relative to the path of the referencing file, instead of relative to the current directory. <br> (Default: `1`) |
 | `LINTER_INCLUDE_PDK_MODELS` | Enables including verilog models of the pdk with the linter. This is useful when the design has hand instantiated macros. This variable has no effect if the PDK/STD_CELL_LIBRARY aren't supported. Currently, sky130A/sky130_fd_sc_hd and sky130B/sky130_fd_sc_hd are the only ones supported <br> (Default: `1`) |
 | `LINTER_DEFINES` | A list of defines that are passed to the linter. The syntax for each item in the list is as follows `<define>(=<value>)`. `(=value)` is optional. Both `PnR=1` or `PnR` are accepted <br> (Default: `SYNTH_DEFINES`) |
-| `CHECK_ASSIGN_STATEMENTS` | **Deprecated: use `QUIT_ON_ASSIGN_STATEMENTS`** Checks for assign statement in the generated gate level netlist and aborts of any was found.1 = Enabled, 0 = Disabled <br> (Default: `0`)|
-| `CHECK_UNMAPPED_CELLS` | **Deprecated: used `QUIT_ON_UNMAPPED_CELLS`** Checks if there are unmapped cells after synthesis and aborts if any was found. 1 = Enabled, 0 = Disabled <br> (Default: `1`)|
+| `CHECK_ASSIGN_STATEMENTS` | **Deprecated: Use `QUIT_ON_ASSIGN_STATEMENTS`** Checks for assign statement in the generated gate level netlist and aborts of any was found.1 = Enabled, 0 = Disabled <br> (Default: `0`)|
+| `CHECK_UNMAPPED_CELLS` | **Deprecated: Use `QUIT_ON_UNMAPPED_CELLS`** Checks if there are unmapped cells after synthesis and aborts if any was found. 1 = Enabled, 0 = Disabled <br> (Default: `1`)|
 
 
 ### On comma-delimited variables

--- a/docs/source/reference/configuration.md
+++ b/docs/source/reference/configuration.md
@@ -1,5 +1,15 @@
-# Configuration Variables
-This page describes user-configurable variables and their default values.
+# Flow Configuration Variables
+This page describes user-configurable flow variables and their default values.
+
+```{note}
+Variables that are defined by the PDK configuration support files and not the
+flow itself are listed [in this chapter](./pdk_configuration.md).
+```
+
+```{note}
+Deprecated variables are automatically translated to their new names for at least
+6 months. Removed variables will be entirely ignored by the flow.
+```
 
 ## Load Order
 The default configuration files in this folder are loaded in the order described in `load_order.txt`.
@@ -39,6 +49,16 @@ These variables are optional that can be specified in the design configuration f
 | `EXTRA_LIBS` | Specifies LIB files of pre-hardened macros used in the current design, used during timing analysis. (Optional) |
 | `EXTRA_GDS_FILES` | Specifies GDS files of pre-hardened macros used in the current design, used during tape-out. |
 
+### Linting
+
+|Variable|Description|
+|-|-|
+| `LINTER_RELATIVE_INCLUDES`‡ | When a file references an include file, resolve the filename relative to the path of the referencing file, instead of relative to the current directory. <br> (Default: `1`) |
+| `LINTER_DEFINES` | A list of defines that are passed to the linter. The syntax for each item in the list is as follows `<define>(=<value>)`. `(=value)` is optional. Both `PnR=1` or `PnR` are accepted <br> (Default: `SYNTH_DEFINES`) |
+| `LINTER_INCLUDE_PDK_MODELS` | Enables including verilog models of the pdk with the linter. This is useful when the design has hand instantiated macros. This variable has no effect if the PDK/STD_CELL_LIBRARY aren't supported. Currently, sky130A/sky130_fd_sc_hd and sky130B/sky130_fd_sc_hd are the only ones supported <br> (Default: `1`) |
+
+> **‡** Variable previously prefixed `VERILATOR_` have had their prefix changed to `LINTER_`. The replaced variable is deprecated and will be translated to its new form automatically by the flow.
+
 ### Synthesis
 
 |Variable|Description|
@@ -69,6 +89,7 @@ These variables are optional that can be specified in the design configuration f
 | `IO_PCT` | Specifies the percentage of the clock period used in the input/output delays. Ranges from 0 to 1.0. <br> (Default: `0.2`) |
 | `SYNTH_BUFFER_DIRECT_WIRES` | Insert buffer cells into the design for directly connected wires. <br> (Default: `1`) |
 | `SYNTH_SPLITNETS` | Splits multi-bit nets into single-bit nets. <br> (Default: `1`) |
+| `SYNTH_TOP_LEVEL` | **Deprecated: Use `SYNTH_ELABORATE_ONLY`**: "Elaborate" the design only without attempting any logic mapping. Useful when dealing with structural Verilog netlists. |
 
 
 ### STA
@@ -91,7 +112,7 @@ These variables are optional that can be specified in the design configuration f
 | `FP_IO_MODE`  | Decides the mode of the random IO placement option. 0=matching mode, 1=random equidistant mode <br> (Default: `1`)|
 | `FP_WELLTAP_CELL`  | The name of the welltap cell during welltap insertion. |
 | `FP_ENDCAP_CELL`  | The name of the endcap cell during endcap insertion. |
-| `FP_PDN_CFG` | Points to a pdn configuration file that describes how to construct the pdn in detail.  <br> (Default: `scripts/openroad/common/pdn_cfg.tcl`) |
+| `FP_PDN_CFG` | Points to a PDN configuration file that describes how to construct the PDN in detail. <br> (Default: `scripts/openroad/common/pdn_cfg.tcl`) |
 | `FP_PDN_AUTO_ADJUST` | Decides whether or not the flow should attempt to re-adjust the power grid, in order for it to fit inside the core area of the design, if needed. <br> 1=enabled, 0 =disabled (Default: `1`) |
 | `FP_PDN_SKIPTRIM` | Enables `-skip_trim` option during pdngen which skips the metal trim step, which attempts to remove metal stubs <br> 1=enabled, 0 =disabled (Default: `1`) |
 | `FP_TAPCELL_DIST`  | The horizontal distance between two tapcell columns <br> (Default: `14`) |
@@ -112,10 +133,10 @@ These variables are optional that can be specified in the design configuration f
 | `FP_PDN_ENABLE_MACROS_GRID` | Enables the connection of macros to the top level power grid. 0=Disable 1=Enable. <br> (Default: `1`) |
 | `FP_PDN_MACRO_HOOKS` | Specifies explicit power connections of internal macros to the top level power grid. As a comma-delimited ([warning](#on-comma-delimited-variables)) list of macro instance names, power domain vdd and ground net names, and macro vdd and ground pin names: `<instance_name> <vdd_net> <gnd_net> <vdd_pin> <gnd_pin>`  |
 | `FP_PDN_CHECK_NODES` | Enables checking for unconnected nodes in the power grid. 0=Disable 1=Enable. <br> (Default: `1`) |
-| `FP_TAP_HORIZONTAL_HALO` | Specify the horizontal halo size around macros during tap insertion. The value provided is in microns. <br> Default: `10` |
-| `FP_TAP_VERTICAL_HALO` | Specify the vertical halo size around macros during tap insertion. The value provided is in microns. <br> Default: set to the value of `FP_TAP_HORIZONTAL_HALO` |
-| `FP_PDN_HORIZONTAL_HALO` | Sets the horizontal halo around the macros during power grid insertion. The value provided is in microns. <br> Default: `10` |
-| `FP_PDN_VERTICAL_HALO` | Sets the vertical halo around the macros during power grid insertion. The value provided is in microns. <br> Default: set to the value of `FP_PDN_HORIZONTAL_HALO` |
+| `FP_TAP_HORIZONTAL_HALO` | Specify the horizontal halo size around macros during tap insertion. The value provided is in microns. <br> (Default: `10`) |
+| `FP_TAP_VERTICAL_HALO` | Specify the vertical halo size around macros during tap insertion. The value provided is in microns. <br> (Default: set to the value of `FP_TAP_HORIZONTAL_HALO`) |
+| `FP_PDN_HORIZONTAL_HALO` | Sets the horizontal halo around the macros during power grid insertion. The value provided is in microns. <br> (Default: `10`) |
+| `FP_PDN_VERTICAL_HALO` | Sets the vertical halo around the macros during power grid insertion. The value provided is in microns. <br> (Default: set to the value of `FP_PDN_HORIZONTAL_HALO`) |
 | `DESIGN_IS_CORE` | Controls the layers used in the power grid. Depending on whether the design is the core of the chip or a macro inside the core. 1=Is a Core, 0=Is a Macro <br> (Default: `1`)|
 | `FP_PIN_ORDER_CFG` | Points to the pin order configuration file to set the pins in specific directions (S, W, E, N). If not set, then the IO pins will be placed based on one of the other methods depending on the rest of the configurations. `$<number>` i.e. `$1` can be used to place a virtual pin where `<number>` is the count of virtual pins. This can create separation between pins. You can also use `@min_distance=<number>` i.e. `@min_distance=0.8` to set preferred min distance between pins in a specific direction. See spm configuration file as an example.<br> (Default: NONE)|
 | `FP_CONTEXT_DEF` | Points to the parent DEF file that includes this macro/design and uses this DEF file to determine the best locations for the pins. It must be used with `FP_CONTEXT_LEF`, otherwise it's considered non-existing. If not set, then the IO pins will be placed based on one of the other methods depending on the rest of the configurations. <br> (Default: NONE)|
@@ -126,8 +147,10 @@ These variables are optional that can be specified in the design configuration f
 | `SYNTH_USE_PG_PINS_DEFINES` | Specifies the power guard used in the verilog source code to specify the power and ground pins. This is used to automatically extract `VDD_NETS` and `GND_NET` variables from the verilog, with the assumption that they will be order `inout vdd1, inout gnd1, inout vdd2, inout gnd2, ...`. |
 | `FP_IO_MIN_DISTANCE`  | The minmimum distance between the IOs in microns. <br> (Default: `3`) |
 | `FP_PADFRAME_CFG`  | A configuration file passed to padringer, a padframe generator. <br> (Default: NONE) |
-| `PDN_CFG` | **Deprecated: Use `FP_PDN_CFG`** Points to a pdn configuration file that describes how to construct the pdn in detail.  <br> (Default: `scripts/openroad/common/pdn_cfg.tcl`) |
-| `FP_PDN_IRDROP` | **Removed: worthless** Enable calculation of power grid IR drop during PDN generation. <br> (Default: `1`)|
+| `PDN_CFG` | **Deprecated: Use `FP_PDN_CFG`**: Points to a PDN configuration file that describes how to construct the PDN in detail. |
+| `FP_HORIZONTAL_HALO` | **Deprecated: Use `FP_PDN_HORIZONTAL_HALO`**: Sets the horizontal halo around the macros during power grid insertion. The value provided is in microns.|
+| `FP_PDN_VERTICAL_HALO` | **Deprecated: Use `FP_PDN_VERTICAL_HALO`**: Sets the vertical halo around the macros during power grid insertion. The value provided is in microns. |
+| `FP_PDN_IRDROP` | **Removed: No point running it this early in the flow**: Enable calculation of power grid IR drop during PDN generation. |
 
 #### Deprecated I/O Layer variables
 These variables worked initially, but they were too sky130 specific and will be removed. Currently, if you define them in your design, they'll be used, but it's recommended to update your configuration to use `FP_IO_HLAYER` and `FP_IO_VLAYER`, which are defined in the PDK.
@@ -142,13 +165,13 @@ These variables worked initially, but they were too sky130 specific and will be 
 
 |Variable|Description|
 |-|-|
-| `RSZ_LIB` | Points to one or more lib files, corresponding to the typical corner, that is used during resizer optimizations. <br> Default: `LIB_SYNTH_COMPLETE`. |
-| `RSZ_LIB_FASTEST` | Points to one or more lib files, corresponding to the fastest corner, that is used during resizer optimizations. <br> Default: `LIB_FASTEST`. |
-| `RSZ_LIB_SLOWEST` | Points to one or more lib files, corresponding to the slowest corner, that is used during resizer optimizations. <br> Default: `LIB_SLOWEST`. |
-| `RSZ_MULTICORNER_LIB` | A flag for reading fastest and slowest corner during resizer optimizations. <br> Default: `1` |
-| `RSZ_DONT_TOUCH_RX` | A single regular expression designating nets as "don't touch" by resizer optimizations. <br> Default: `$^` (matches nothing.) |
-| `RSZ_DONT_TOUCH` | A list of nets or instances to set as "don't touch". <br> Default: Empty. |
-| `LIB_RESIZER_OPT` | **Deprecated: use `RSZ_LIB`**: Points to the lib file, corresponding to the typical corner, that is used during resizer optimizations. This is copy of `LIB_SYNTH_COMPLETE`. <br> Default: automatically generated in `$::env(synthesis_tmpfiles)/resizer_<library-name>.lib` |
+| `RSZ_LIB` | Points to one or more lib files, corresponding to the typical corner, that is used during resizer optimizations. <br> (Default: set to the value of PDK's `LIB_SYNTH`) |
+| `RSZ_LIB_FASTEST` | Points to one or more lib files, corresponding to the fastest corner, that is used during resizer optimizations. <br> (Default: set to the value of PDK's `LIB_FASTEST`) |
+| `RSZ_LIB_SLOWEST` | Points to one or more lib files, corresponding to the slowest corner, that is used during resizer optimizations. <br> (Default: set to the value of PDK's `LIB_SLOWEST`) |
+| `RSZ_MULTICORNER_LIB` | A flag for reading fastest and slowest corner during resizer optimizations. <br> (Default: `1`) |
+| `RSZ_DONT_TOUCH_RX` | A single regular expression designating nets as "don't touch" by resizer optimizations. <br> (Default: `$^` (matches nothing)) |
+| `RSZ_DONT_TOUCH` | A list of nets or instances to set as "don't touch". <br> (Default: Empty) |
+| `LIB_RESIZER_OPT` | **Deprecated: Use `RSZ_LIB`**: Points to the lib file, corresponding to the typical corner, that is used during resizer optimizations. This is copy of `LIB_SYNTH`.|
 
 ### Placement
 
@@ -173,7 +196,7 @@ These variables worked initially, but they were too sky130 specific and will be 
 | `PL_RESIZER_SETUP_MAX_BUFFER_PERCENT` | Specifies a max number of buffers to insert to fix setup violations. This number is calculated as a percentage of the number of instances in the design. <br> (Default: `50`)|
 | `PL_RESIZER_ALLOW_SETUP_VIOS` | Allows setup violations when fixing hold. <br> (Default: `0`)|
 | `PL_WIRELENGTH_COEF` | Global placement initial wirelength coefficient. Decreasing the variable will modify the initial placement of the standard cells to reduce the wirelengths. <br> (Default: `0.25`).|
-| `DONT_USE_CELLS` | The list of cells to not use during resizer optimizations. <br> Default: the contents of `DRC_EXCLUDE_CELL_LIST`. |
+| `DONT_USE_CELLS` | The list of cells to not use during resizer optimizations. <br> (Default: the contents of `DRC_EXCLUDE_CELL_LIST`) |
 | `PL_ESTIMATE_PARASITICS` | Specifies whether or not to run STA after global placement using OpenROAD's estimate_parasitics -placement and generates reports under `logs/placement`. 1 = Enabled, 0 = Disabled. <br> (Default: `1`) |
 | `PL_OPTIMIZE_MIRRORING` | Specifies whether or not to run an optimize_mirroring pass whenever detailed placement happens. This pass will mirror the cells whenever possible to optimize the design. 1 = Enabled, 0 = Disabled. <br> (Default: `1`) |
 | `PL_RESIZER_BUFFER_INPUT_PORTS` | Specifies whether or not to insert buffers on input ports whenever resizer optimizations are run. For this to be used, `PL_RESIZER_DESIGN_OPTIMIZATIONS` must be set to 1. 1 = Enabled, 0 = Disabled. <br> (Default: `1`) |
@@ -184,14 +207,13 @@ These variables worked initially, but they were too sky130 specific and will be 
 | `PL_MACRO_HALO` | Macro placement halo. Format: `{Horizontal} {Vertical}` <br> (Default: `0 0`μm). |
 | `PL_MACRO_CHANNEL` | Channel widths between macros. Format: `{Horizontal} {Vertical}` <br> (Default: `0 0`μm). |
 | `MACRO_PLACEMENT_CFG` | Specifies the path a file specifying how openlane should place certain macros |
-| `UNBUFFER_NETS` | **Deprecated: Use `RSZ_DONT_TOUCH_RX`** A regular expression used to match nets from which to remove buffers after every resizer run. Useful for analog ports in mixed-signal designs where OpenROAD may sometimes add a buffer. <br> (Default: `^$`, matches nothing.) |
-| `DONT_BUFFER_PORTS` | **Removed: Use `RSZ_DONT_TOUCH_RX`.** Semicolon;delimited list of nets from which to remove buffers. <br> (Default: Empty) |
+| `UNBUFFER_NETS` | **Deprecated: Use `RSZ_DONT_TOUCH_RX`**: A regular expression used to match nets from which to remove buffers after every resizer run. Useful for analog ports in mixed-signal designs where OpenROAD may sometimes add a buffer. |
+| `DONT_BUFFER_PORTS` | **Removed: Use `RSZ_DONT_TOUCH_RX`**: Semicolon;delimited list of nets from which to remove buffers. |
 
 ### CTS
 
 |Variable|Description|
 |-|-|
-| `CTS_TARGET_SKEW` | The target clock skew in picoseconds. <br> (Default: `200`ps)|
 | `RUN_CTS` | Enable clock tree synthesis. <br> (Default: `1`)|
 | `CTS_TOLERANCE` | An integer value that represents a tradeoff of QoR and runtime. Higher values will produce smaller runtime but worse QoR <br> (Default: `100`) |
 | `CTS_SINK_CLUSTERING_SIZE` | Specifies the maximum number of sinks per cluster. <br> (Default: `25`) |
@@ -200,17 +222,16 @@ These variables worked initially, but they were too sky130 specific and will be 
 | `CTS_CLK_MAX_WIRE_LENGTH` | Specifies the maximum wire length on the clock net. Value in microns. <br> (Default: `0`) |
 | `CTS_DISABLE_POST_PROCESSING` | Specifies whether or not to disable post cts processing for outlier sinks. <br> (Default: `0`) |
 | `CTS_DISTANCE_BETWEEN_BUFFERS` | Specifies the distance (in microns) between buffers when creating the clock tree (Default: `0`) |
-| `LIB_CTS` | The liberty file used for CTS for typical corner. By default, this is the `LIB_SYNTH_COMPLETE` minus the cells with drc errors as specified by the drc exclude list. <br> (Default: `$::env(cts_tmpfiles)/cts.lib`) |
+| `LIB_CTS` | The liberty file used for CTS for typical corner. By default, this is the `LIB_SYNTH` minus the cells with drc errors as specified by the drc exclude list. <br> (Default: `$::env(cts_tmpfiles)/cts.lib`) |
 | `LIB_CTS_SLOWEST` | The liberty file used for CTS for slowest corner. By default, this is the `LIB_SLOWEST` minus the cells with drc errors as specified by the drc exclude list. <br> (Default: `$::env(cts_tmpfiles)/cts-slowest.lib`) |
 | `LIB_CTS_FASTEST` | The liberty file used for CTS for fastest corner. By default, this is the `LIB_FASTEST` minus the cells with drc errors as specified by the drc exclude list. <br> (Default: `$::env(cts_tmpfiles)/cts-fastest.lib`) |
 | `CTS_MULTICORNER_LIB` | A flag for reading fastest and slowest corner during CTS. <br> (Default: `1`) |
-| `CLOCK_TREE_SYNTH` | **Deprecated: Use `RUN_CTS`** Enable clock tree synthesis. <br> (Default: `1`)|
-| `FILL_INSERTION` | **Removed: Use `RUN_FILL_INSERTION`** Enables fill cells insertion after cts (if enabled). 1 = Enabled, 0 = Disabled <br> (Default: `1`)|
-| `RUN_SIMPLE_CTS` | **Removed: TritonCTS is always run**: Runs an alternative simple clock tree synthesis after synthesis instead of TritonCTS. 1 = Enabled, 0 = Disabled <br> (Default: `0`)|
+| `CLOCK_TREE_SYNTH` | **Deprecated: Use `RUN_CTS`**: Enable clock tree synthesis. 1 = Enabled, 0 = Disabled. |
+| `FILL_INSERTION` | **Removed: Use `RUN_FILL_INSERTION`**: Enables fill cells insertion after CTS. 1 = Enabled, 0 = Disabled. |
+| `RUN_SIMPLE_CTS` | **Removed: TritonCTS is always run**: Run an alternative simple clock tree synthesis after synthesis instead of TritonCTS. 1 = Enabled, 0 = Disabled. |
+| `CTS_TARGET_SKEW` | **Removed: No longer supported by underlying utility.** The target clock skew in picoseconds. <br> (Default: `200`ps)|
 
-### Routing
-
-> **Note:** All variables previously prefixed GLB_RT_ have had their prefix changed to GRT_.
+### Routing 
 
 |Variable|Description|
 |-|-|
@@ -219,8 +240,8 @@ These variables worked initially, but they were too sky130 specific and will be 
 | `ROUTING_CORES` | Specifies the number of threads to be used in TritonRoute. Can be overriden via environment variable. <br> (Default: `2`) |
 | `RT_CLOCK_MIN_LAYER` | The name of lowest layer to be used in routing the clock net. <br> (Default: `RT_MIN_LAYER`)|
 | `RT_CLOCK_MAX_LAYER` | The name of highest layer to be used in routing the clock net. <br> (Default: `RT_MAX_LAYER`)|
-| `GLB_RESIZER_TIMING_OPTIMIZATIONS` | Specifies whether resizer timing optimizations should be performed after global routing or not. 0 = false, 1 = true <br> (Default: `1`)
-| `GLB_RESIZER_DESIGN_OPTIMIZATIONS` | Specifies whether resizer design optimizations should be performed after global routing or not. 0 = false, 1 = true <br> (Default: `1`)
+| `GLB_RESIZER_TIMING_OPTIMIZATIONS` | Specifies whether resizer timing optimizations should be performed after global routing or not. 1 = Enabled, 0 = Disabled. <br> (Default: `1`)
+| `GLB_RESIZER_DESIGN_OPTIMIZATIONS` | Specifies whether resizer design optimizations should be performed after global routing or not. 1 = Enabled, 0 = Disabled. <br> (Default: `1`)
 | `GLB_RESIZER_MAX_WIRE_LENGTH` | Specifies the maximum wire length cap used by resizer to insert buffers. If set to 0, no buffers will be inserted. Value in microns. <br> (Default: `0`)|
 | `GLB_RESIZER_MAX_SLEW_MARGIN` | Specifies a margin for the slews. <br> (Default: `10`)|
 | `GLB_RESIZER_MAX_CAP_MARGIN` | Specifies a margin for the capacitances. <br> (Default: `10`)|
@@ -230,27 +251,29 @@ These variables worked initially, but they were too sky130 specific and will be 
 | `GLB_RESIZER_SETUP_MAX_BUFFER_PERCENT` | Specifies a max number of buffers to insert to fix setup violations. This number is calculated as a percentage of the number of instances in the design. <br> (Default: `50`)|
 | `GLB_RESIZER_ALLOW_SETUP_VIOS` | Allows setup violations when fixing hold. <br> (Default: `0`)|
 | `GLB_OPTIMIZE_MIRRORING` | Specifies whether or not to run an optimize_mirroring pass whenever detailed placement happens after Routing timing optimization. This pass will mirror the cells whenever possible to optimize the design. 1 = Enabled, 0 = Disabled. <br> (Default: `1`) |
-| `GRT_ALLOW_CONGESTION` | Allow congestion in the resulting guides. 0 = false, 1 = true <br> (Default: `0`) 
-| `GRT_OVERFLOW_ITERS` | The maximum number of iterations waiting for the overflow to reach the desired value. <br> (Default: `50`) |
-| `GRT_ANT_ITERS` | The maximum number of iterations for global router repair_antenna. This option is only available when `GRT_REPAIR_ANTENNAS` is enabled. <br> (Default: `15`) |
-| `GRT_ANT_MARGIN` | The margin to over fix antenna violations in global routing as a percentage. This option is only available when `GRT_REPAIR_ANTENNAS` is enabled. <br> (Default: `10`) |
-| `GRT_ESTIMATE_PARASITICS` | Specifies whether or not to run STA after global routing using OpenROAD's estimate_parasitics -global_routing and generates reports under `logs/routing`. 1 = Enabled, 0 = Disabled. <br> (Default: `1`) |
-| `GRT_MAX_DIODE_INS_ITERS` | Controls the maximum number of iterations at which re-running Fastroute for diode insertion stops. Each iteration ARC detects the violations and FastRoute fixes them by inserting diodes, then producing the new DEF. The number of antenna violations is compared with the previous iteration and if they are equal or the number is greater the iterations stop and the DEF from the previous iteration is used in the rest of the flow. If the current antenna violations reach zero, the current def will be used and the iterations will not continue. This option is only available in when `GRT_REPAIR_ANTENNAS` is enabled.  <br> (Default: `1`) |
-| `GRT_REPAIR_ANTENNAS` | Enables OpenROAD's antenna avoidance flow. <br> (Default: `1`) |
-| `GRT_OBS` | Specifies custom obstruction to be added prior to global routing. Comma-delimited ([warning](#on-comma-delimited-variables)) list of layer and coordinates: `layer llx lly urx ury`, where `ll` and `ur` stand for "lower left" and "upper right" respectively.<br> (Example: `li1 0 100 1000 300, met5 0 0 1000 500`)  <br> (Default: unset) |
-| `GRT_ADJUSTMENT` | Reduction in the routing capacity of the edges between the cells in the global routing graph. Values range from 0 to 1. <br> 1 = most reduction, 0 = least reduction  <br> (Default: `0.3`)|
-| `GRT_MACRO_EXTENSION` | Sets the number of GCells added to the blockages boundaries from macros. A GCell is typically defined in terms of Mx routing tracks. The default GCell size is 15 M3 pitches. <br> (Default: `0`) |
+| `GRT_ALLOW_CONGESTION`‡ | Allow congestion in the resulting guides. 0 = false, 1 = true <br> (Default: `0`) 
+| `GRT_OVERFLOW_ITERS`‡ | The maximum number of iterations waiting for the overflow to reach the desired value. <br> (Default: `50`) |
+| `GRT_ANT_ITERS`‡ | The maximum number of iterations for global router repair_antenna. This option is only available when `GRT_REPAIR_ANTENNAS` is enabled. <br> (Default: `15`) |
+| `GRT_ANT_MARGIN`‡ | The margin to over fix antenna violations in global routing as a percentage. This option is only available when `GRT_REPAIR_ANTENNAS` is enabled. <br> (Default: `10`) |
+| `GRT_ESTIMATE_PARASITICS`‡ | Specifies whether or not to run STA after global routing using OpenROAD's estimate_parasitics -global_routing and generates reports under `logs/routing`. 1 = Enabled, 0 = Disabled. <br> (Default: `1`) |
+| `GRT_MAX_DIODE_INS_ITERS`‡ | Controls the maximum number of iterations at which re-running Fastroute for diode insertion stops. Each iteration ARC detects the violations and FastRoute fixes them by inserting diodes, then producing the new DEF. The number of antenna violations is compared with the previous iteration and if they are equal or the number is greater the iterations stop and the DEF from the previous iteration is used in the rest of the flow. If the current antenna violations reach zero, the current def will be used and the iterations will not continue. This option is only available in when `GRT_REPAIR_ANTENNAS` is enabled.  <br> (Default: `1`) |
+| `GRT_REPAIR_ANTENNAS`‡ | Enables OpenROAD's antenna avoidance flow. <br> (Default: `1`) |
+| `GRT_OBS`‡ | Specifies custom obstruction to be added prior to global routing. Comma-delimited ([warning](#on-comma-delimited-variables)) list of layer and coordinates: `layer llx lly urx ury`, where `ll` and `ur` stand for "lower left" and "upper right" respectively.<br> (Example: `li1 0 100 1000 300, met5 0 0 1000 500`)  <br> (Default: unset) |
+| `GRT_ADJUSTMENT`‡ | Reduction in the routing capacity of the edges between the cells in the global routing graph. Values range from 0 to 1. <br> 1 = most reduction, 0 = least reduction  <br> (Default: `0.3`)|
+| `GRT_MACRO_EXTENSION`‡ | Sets the number of GCells added to the blockages boundaries from macros. A GCell is typically defined in terms of Mx routing tracks. The default GCell size is 15 M3 pitches. <br> (Default: `0`) |
 | `DRT_MIN_LAYER` | An optional override to the lowest layer used in detailed routing. For example, in sky130, you may want global routing to avoid li1, but let detailed routing use li1 if it has to. <br> (Default: `RT_MIN_LAYER`)|
 | `DRT_MAX_LAYER` | An optional override to the highest layer used in detailed routing. <br> (Default: `RT_MAX_LAYER`)|
 | `DRT_OPT_ITERS` | Specifies the maximum number of optimization iterations during Detailed Routing in TritonRoute. <br> (Default: `64`) |
-| `ROUTING_OPT_ITERS` |**Removed: Use DRT_OPT_ITERS**: Specifies the maximum number of optimization iterations during Detailed Routing in TritonRoute. <br> (Default: `64`) |
-| `GLB_RT_MINLAYER` | **Removed: Use RT_MIN_LAYER**: The number of lowest layer to be used in routing. <br> (Default: `1`)|
-| `GLB_RT_MAXLAYER` | **Removed: Use RT_MAX_LAYER**: The number of highest layer to be used in routing. <br> (Default: `6`)|
-| `GLB_RT_CLOCK_MINLAYER` | **Removed: Use RT_CLOCK_MIN_LAYER**: The number of lowest layer to be used in routing the clock net. <br> (Default: `GLB_RT_MINLAYER`)|
-| `GLB_RT_CLOCK_MAXLAYER` | **Removed: Use RT_CLOCK_MIN_LAYER**: The number of highest layer to be used in routing the clock net. <br> (Default: `GLB_RT_MAXLAYER`)|
+| `ROUTING_OPT_ITERS` |**Removed: Use `DRT_OPT_ITERS`**: Specifies the maximum number of optimization iterations during Detailed Routing in TritonRoute.|
+| `GLB_RT_MINLAYER` | **Removed: Use `RT_MIN_LAYER`**: The number of lowest layer to be used in routing.|
+| `GLB_RT_MAXLAYER` | **Removed: Use `RT_MAX_LAYER`**: The number of highest layer to be used in routing.|
+| `GLB_RT_CLOCK_MINLAYER` | **Removed: Use `RT_CLOCK_MIN_LAYER`**: The number of lowest layer to be used in routing the clock net.|
+| `GLB_RT_CLOCK_MAXLAYER` | **Removed: Use `RT_CLOCK_MIN_LAYER`**: The number of highest layer to be used in routing the clock net.|
 | `GLB_RT_L{1/2/3/4/5/6}_ADJUSTMENT` | **Removed: See PDK variable `GRT_LAYER_ADJUSTMENTS` instead**: Reduction in the routing capacity of the edges between the cells in the global routing graph but specific to a metal layer in sky130A. Values ranged from 0 to 1 |
-| `GLB_RT_UNIDIRECTIONAL` | **Removed**: Allow unidirectional routing. 0 = false, 1 = true <br> (Default: `1`) |
-| `GLB_RT_TILES` | **Removed**: The size of the GCELL used by Fastroute during global routing. <br> (Default: `15`) |
+| `GLB_RT_UNIDIRECTIONAL` | **Removed**: Allow unidirectional routing. 1 = Enabled, 0 = Disabled. |
+| `GLB_RT_TILES` | **Removed**: The size of the GCELL used by Fastroute during global routing. |
+
+> **‡** Variable previously prefixed `GLB_RT_` have had its prefix changed to `GRT_`. The replaced variable is deprecated and will be translated to its new form automatically by the flow.
 
 ### RC Extraction
 
@@ -259,8 +282,8 @@ These variables worked initially, but they were too sky130 specific and will be 
 | `SPEF_EXTRACTOR` | Specifies which spef extractor to use. Values: `openrcx` or (**removed:** `def2spef`). <br> (Default: `openrcx`) |
 | `RCX_MERGE_VIA_WIRE_RES` | Specifies whether to merge the via resistance with the wire resistance or separate it from the wire resistance. 1 = Merge via resistance, 0 = Separate via resistance <br> (Default: `1`)|
 | `RCX_SDC_FILE` | Specifies SDC file to be used for RCX-based STA, which can be different from the one used for implementation. <br> (Default: `BASE_SDC_FILE`) |
-| `SPEF_WIRE_MODEL` | **Removed:** Specifies the wire model used in SPEF extraction. Options are `L` or `Pi`  <br> (Default: `L`) |
-| `SPEF_EDGE_CAP_FACTOR` | **Removed:** Specifies the edge capacitance factor used in SPEF extraction. Ranges from 0 to 1 <br> (Default: `1`) |
+| `SPEF_WIRE_MODEL` | **Removed:** Specifies the wire model used in SPEF extraction. Options are `L` or `Pi` |
+| `SPEF_EDGE_CAP_FACTOR` | **Removed:** Specifies the edge capacitance factor used in SPEF extraction. Ranges from 0 to 1 |
 
 ### IR Drop Analysis
 
@@ -292,8 +315,8 @@ These variables worked initially, but they were too sky130 specific and will be 
 
 |Variable|Description|
 |-|-|
-| `LVS_INSERT_POWER_PINS` |  Enables power pins insertion before running lvs. 1 = Enabled, 0 = Disabled <br> (Default: `1` )|
-| `LVS_CONNECT_BY_LABEL` | Enables connections by label in LVS by skipping `extract unique` in magic extractions. <br> Default: `0` |
+| `LVS_INSERT_POWER_PINS` |  Enables power pins insertion before running lvs. 1 = Enabled, 0 = Disabled <br> (Default: `1`)|
+| `LVS_CONNECT_BY_LABEL` | Enables connections by label in LVS by skipping `extract unique` in magic extractions. <br> (Default: `0`) |
 | `YOSYS_REWRITE_VERILOG` | Enables yosys to rewrite the verilog before LVS producing a canonical verilog netlist with verbose wire declarations. 1 = Enabled, 0 = Disabled <br> (Default: `0` ) |
 
 ### Flow control
@@ -304,45 +327,45 @@ These variables worked initially, but they were too sky130 specific and will be 
 |-|-|
 | `RUN_DRT` | Enables detailed routing. 1 = Enabled, 0 = Disabled <br> (Default: `1`)|
 | `RUN_LVS` | Enables running LVS. 1 = Enabled, 0 = Disabled <br> (Default: `1`)|
-| `RUN_HEURISTIC_DIODE_INSERTION` | Enables running heuristic antenna insertion script. 1 = Enabled, 0 = Disabled <br> (Default: `0`)|
+| `RUN_HEURISTIC_DIODE_INSERTION` | Runs a script by [Sylvain Munaut](https://github.com/smunaut) that inserts diodes heuristically based on . 1 = Enabled, 0 = Disabled <br> (Default: `0`)|
 | `RUN_MAGIC` | Enables running magic and GDSII streaming. 1 = Enabled, 0 = Disabled <br> (Default: `1`)|
 | `RUN_MAGIC_DRC` | Enables running magic DRC on GDSII produced by magic. 1 = Enabled, 0 = Disabled <br> (Default: `1`)|
 | `RUN_KLAYOUT` | Enables running KLayout and GDSII streaming. 1 = Enabled, 0 = Disabled <br> (Default: `1`)|
 | `RUN_KLAYOUT_DRC` | Enables running KLayout DRC on GDSII produced by magic. 1 = Enabled, 0 = Disabled <br> (Default: `0`)|
 | `RUN_KLAYOUT_XOR` | Enables running KLayout XOR on 2 GDSIIs, the defaults are the one produced by magic vs the one produced by klayout. 1 = Enabled, 0 = Disabled <br> (Default: `1`)|
-| `RUN_SPEF_EXTRACTION` | Specifies whether or not to run SPEF extraction on the routed DEF. 1=enabled 0=disabled <br> Default: `1` |
-| `RUN_CVC` | Runs CVC on the output spice, which is a Circuit Validity Checker. Voltage aware ERC checker for CDL netlists. 1=Enabled, 0=Disabled. <br> Default: `1` |
-| `RUN_IRDROP_REPORT` | Creates an IR Drop report using OpenROAD PSM. 1=Enabled, 0=Disabled. <br> Default: `0` |
+| `RUN_SPEF_EXTRACTION` | Specifies whether or not to run SPEF extraction on the routed DEF. 1=enabled 0=disabled <br> (Default: `1`) |
+| `RUN_CVC` | Runs CVC on the output spice, which is a Circuit Validity Checker. Voltage aware ERC checker for CDL netlists. 1 = Enabled, 0 = Disabled. <br> (Default: `1`) |
+| `RUN_IRDROP_REPORT` | Creates an IR Drop report using OpenROAD PSM. 1 = Enabled, 0 = Disabled. <br> (Default: `0`) |
 | `RUN_TAP_DECAP_INSERTION` | Enables tap and decap cells insertion after floorplanning. 1 = Enabled, 0 = Disabled <br> (Default: `1`) |
 | `RUN_FILL_INSERTION` | Enables fill cells insertion after cts (if enabled). 1 = Enabled, 0 = Disabled <br> (Default: `1`)|
 | `KLAYOUT_DRC_KLAYOUT_GDS` | Enables running KLayout DRC on GDSII produced by KLayout. 1 = Enabled, 0 = Disabled <br> (Default: `0`)|
-| `GENERATE_FINAL_SUMMARY_REPORT` | Specifies whether or not to generate a final summary report after the run is completed. Check command `generate_final_summary_report`. 1=enabled 0=disabled <br> Default: `1` |
+| `GENERATE_FINAL_SUMMARY_REPORT` | Specifies whether or not to generate a final summary report after the run is completed. Check command `generate_final_summary_report`. 1 = Enabled, 0 = Disabled. <br> (Default: `1`) |
 | `LEC_ENABLE` | Enables logic verification using yosys, for comparing each netlist at each stage of the flow with the previous netlist and verifying that they are logically equivalent. Warning: this will increase the runtime significantly. 1 = Enabled, 0 = Disabled <br> (Default: `0`)|
-| `USE_GPIO_PADS` | Decides whether or not to use the gpio pads in routing by merging their LEF file set in `::env(USE_GPIO_ROUTING_LEF)` and blackboxing their verilog modules set in `::env(GPIO_PADS_VERILOG)`. 1=Enabled, 0=Disabled. <br> (Default: `0`) |
+| `USE_GPIO_PADS` | Decides whether or not to use the gpio pads in routing by merging their LEF file set in `::env(USE_GPIO_ROUTING_LEF)` and blackboxing their verilog modules set in `::env(GPIO_PADS_VERILOG)`. 1 = Enabled, 0 = Disabled. <br> (Default: `0`) |
 | `PRIMARY_SIGNOFF_TOOL` | Determines whether `magic` or `klayout` is the primary signoff tool. <br> (Default: `magic`) |
 | `KLAYOUT_XOR_GDS` | If `RUN_KLAYOUT_XOR` is enabled, this will enable producing a GDS output from the XOR along with it's PNG export. 1 = Enabled, 0 = Disabled <br> (Default: `1`)|
 | `KLAYOUT_XOR_XML` | If `RUN_KLAYOUT_XOR` is enabled, this will enable producing an XML output from the XOR. 1 = Enabled, 0 = Disabled <br> (Default: `1`)|
 | `TAKE_LAYOUT_SCROT` | Enables running KLayout to take a PNG screenshot of the produced layout (currently configured to run on the results of each stage).1 = Enabled, 0 = Disabled <br> (Default: `0`)|
 | `KLAYOUT_XOR_THREADS` | Specifies number of threads used in klayout xor check <br> (Default: `1`)|
-| `DIODE_INSERTION_STRATEGY` | **Deprecated** Specifies the insertion strategy of diodes to be used in the flow. |
-| | 0: No diode insertion. |
-| | 1: **removed** Spray diodes. |
-| | 2: **removed** Insert fake diodes and replace them with real diodes if needed. |
-| | (**Default**) 3: Use OpenROAD's Antenna Avoidance flow. |
-| | 4: Use Sylvain Minaut's custom script for diode insertion. |
-| | 5: **removed** A combination of strategies 2 and 4. |
-| | 6: A combination of strategies 3 and 4. | 
-| `DIODE_ON_PORTS` | Insert diodes on ports with the specified polarities. Available options are `none`, `in`, `out` and `both`. <br> (Default: NONE) |
+| `DIODE_ON_PORTS` | Insert diodes on ports with the specified polarities. Available options are `none`, `in`, `out` and `both`. <br> (Default: `none`) |
 | `HEURISTIC_ANTENNA_THRESHOLD` | Minimum manhattan distance of a net to insert a diode in microns. Only applicable for `RUN_HEURISTIC_DIODE_INSERTION` is enabled. <br> (Default: `90`)
 | `USE_ARC_ANTENNA_CHECK` | Specifies whether to use the openroad ARC antenna checker or magic antenna checker. 0=magic antenna checker, 1=ARC OR antenna checker <br> (Default: `1`)
 | `RUN_LINTER` | Enable linter (currently Verilator) <br> (Default: `1`)
-| `RUN_ROUTING_DETAILED` | **Deprecated: Use `RUN_DRT`** Enables detailed routing. 1 = Enabled, 0 = Disabled <br> (Default: `1`)|
-| `TAP_DECAP_INSERTION` | **Deprecated: Use `RUN_TAP_DECAP_INSERTION`** Enables tap and decap cells insertion after floorplanning (if enabled) .1 = Enabled, 0 = Disabled <br> (Default: `1`) |
-| `MAGIC_CONVERT_DRC_TO_RDB` | **Removed: Will always run** Specifies whether or not generate a Calibre RDB out of the magic.drc report. Result is saved in `<run_path>/results/magic/`. 1=enabled 0=disabled <br> Default: `1`|
-| `TEST_MISMATCHES` | **Removed: See `./flow.tcl -test_mismatches`** Test for mismatches between the OpenLane tool versions and the current environment. `all` tests all mismatches. `tools` tests all except the PDK. `pdk` only tests the PDK. `none` disables the check.<br> (Default: `all`) |
-| `QUIT_ON_MISMATCHES` | **Removed: See `./flow.tcl -ignore_mismatches`** Whether to halt the flow execution or not if mismatches are found. (Default: `1`) |
-| `KLAYOUT_XOR_GDS` | **Removed: XML always generated** If `RUN_KLAYOUT_XOR` is enabled, this will enable producing a GDS output from the XOR along with it's PNG export. 1 = Enabled, 0 = Disabled <br> (Default: `1`)|
-| `KLAYOUT_XOR_XML` | **Removed: XML always generated** If `RUN_KLAYOUT_XOR` is enabled, this will enable producing an XML output from the XOR. 1 = Enabled, 0 = Disabled <br> (Default: `1`)|
+| `TAP_DECAP_INSERTION` | **Deprecated: Use `RUN_TAP_DECAP_INSERTION`**: Enables tap and decap cells insertion after floorplanning. 1 = Enabled, 0 = Disabled. |
+| `RUN_ROUTING_DETAILED` | **Deprecated: Use `RUN_DRT`**: Enables detailed routing. 1 = Enabled, 0 = Disabled. <br> (Default: `1`)|
+| `DIODE_INSERTION_STRATEGY` | **Deprecated: Update replacement variables `GRT_REPAIR_ANTENNAS` and `RUN_HEURISTIC_DIODE_INSERTION` as per the instructions below**: Specifies the insertion strategy of diodes to be used in the flow. |
+| | 0: No diode insertion. Equivalent to replacement variables being set to `0`. |
+| | 1: **Removed**: Spray diodes. |
+| | 2: **Removed**: Insert fake diodes and replace them with real diodes if needed. |
+| | 3: Use OpenROAD's Antenna Avoidance flow. Equivalent to replacement variables being set to `1` and `0` respectively. |
+| | 4: Use Sylvain Minaut's custom script for diode insertion. Equivalent to replacement variables being set to `0` and `1` respectively. |
+| | 5: **Removed**: A combination of strategies 2 and 4. |
+| | 6: A combination of strategies 3 and 4. Equivalent to replacement variables being set to `1`. |
+| `MAGIC_CONVERT_DRC_TO_RDB` | **Removed: Will always run**: Specifies whether or not generate a Calibre RDB out of the magic.drc report. Result is saved in `<run_path>/results/magic/`. 1 = Enabled, 0 = Disabled. |
+| `TEST_MISMATCHES` | **Removed: See `./flow.tcl -test_mismatches`**: Test for mismatches between the OpenLane tool versions and the current environment. `all` tests all mismatches. `tools` tests all except the PDK. `pdk` only tests the PDK. `none` disables the check. |
+| `QUIT_ON_MISMATCHES` | **Removed: See `./flow.tcl -ignore_mismatches`**: Whether to halt the flow execution or not if `TEST_MISMATCHES` is enabled and any mismatches are found. |
+| `KLAYOUT_XOR_GDS` | **Removed: XML always generated**: If `RUN_KLAYOUT_XOR` is enabled, this will enable producing a GDS output from the XOR along with it's PNG export. 1 = Enabled, 0 = Disabled.|
+| `KLAYOUT_XOR_XML` | **Removed: XML always generated**: If `RUN_KLAYOUT_XOR` is enabled, this will enable producing an XML output from the XOR. 1 = Enabled, 0 = Disabled. |
 
 
 ### Checkers
@@ -363,12 +386,6 @@ These variables worked initially, but they were too sky130 specific and will be 
 | `QUIT_ON_TIMING_VIOLATIONS ` | Controls `QUIT_ON_HOLD_VIOLATIONS` and `QUIT_ON_SETUP_VIOLATIONS` <br> (Default: `1`)|
 | `QUIT_ON_LINTER_WARNINGS` | Quit on warnings generated by linter (currently Verilator) <br> (Default: `0`)|
 | `QUIT_ON_LINTER_ERRORS` | Quit on errors generated by linter (currently Verilator) <br> (Default: `1`)|
-| `LINTER_RELATIVE_INCLUDES` | When a file references an include file, resolve the filename relative to the path of the referencing file, instead of relative to the current directory. <br> (Default: `1`) |
-| `LINTER_INCLUDE_PDK_MODELS` | Enables including verilog models of the pdk with the linter. This is useful when the design has hand instantiated macros. This variable has no effect if the PDK/STD_CELL_LIBRARY aren't supported. Currently, sky130A/sky130_fd_sc_hd and sky130B/sky130_fd_sc_hd are the only ones supported <br> (Default: `1`) |
-| `LINTER_DEFINES` | A list of defines that are passed to the linter. The syntax for each item in the list is as follows `<define>(=<value>)`. `(=value)` is optional. Both `PnR=1` or `PnR` are accepted <br> (Default: `SYNTH_DEFINES`) |
-| `CHECK_ASSIGN_STATEMENTS` | **Deprecated: Use `QUIT_ON_ASSIGN_STATEMENTS`** Checks for assign statement in the generated gate level netlist and aborts of any was found.1 = Enabled, 0 = Disabled <br> (Default: `0`)|
-| `CHECK_UNMAPPED_CELLS` | **Deprecated: Use `QUIT_ON_UNMAPPED_CELLS`** Checks if there are unmapped cells after synthesis and aborts if any was found. 1 = Enabled, 0 = Disabled <br> (Default: `1`)|
-
 
 ### On comma-delimited variables
 :::{warning}

--- a/docs/source/reference/index.rst
+++ b/docs/source/reference/index.rst
@@ -6,6 +6,7 @@ Reference Manual
    cli
    configuration_files
    configuration
+   pdk_configuration
    openlane_commands
    interactive_mode
    datapoint_definitions

--- a/docs/source/reference/pdk_configuration.md
+++ b/docs/source/reference/pdk_configuration.md
@@ -1,0 +1,158 @@
+# PDK Configuration Variables
+
+These variables are defined by PDK configuration files to support the OpenLane
+flow and its steps.
+
+All these variables (unless marked optional) are defined by the PDK, but some may
+also be overriden by a user configuration.
+
+<!--
+    User configurations that should not be modified (unless you 100% know what
+    you're doing) are marked with a double dagger (‡).
+-->
+
+```{note}
+Any examples provided are for the `sky130A` PDK.
+```
+
+| Variable      | Description                                                   |
+|---------------|---------------------------------------------------------------|
+| `DEF_UNITS_PER_MICRON` | Defines the unit distance microns. Used during floorplanning for proper def file generation. |
+| `VDD_PIN` | Defines the power pin of the cells.  |
+| `GND_PIN` | Defines the ground pin of the cells. |
+| `TRACKS_INFO_FILE` | Points to the path of the tracks file. Used by the floorplanner to generate tracks |
+| `TECH_LEF_MIN` | Points to the path of the tech lef used for minimum corner extraction. (Optional) |
+| `TECH_LEF` | Points to the path of the tech lef used for nominal corner extraction. |
+| `TECH_LEF_MAX` | Points to the path of the tech lef used for maximum corner extraction. (Optional) |
+| `CELLS_LEF` | A list of paths to the cells lef views. Recommended to use wild card to catch all the files as follows: `[glob "$::env(PDK_ROOT)/sky130A/libs.ref/$::env(STD_CELL_LIBRARY)/lef/*.lef"]` |
+| `GDS_FILES` | A list of paths to the cells GDSII views. Recommended to use wild card to catch all the files as follows: `[glob "$::env(PDK_ROOT)/sky130A/libs.ref/$::env(STD_CELL_LIBRARY)/gds/*.gds"]` |
+| `MAGIC_TECH_FILE` | Points to the magic tech file which mainly has drc rules. |
+| `KLAYOUT_TECH` | Points to the klayout tech file (.lyt). |
+| `KLAYOUT_PROPERTIES` | Points to the klayout properties file (.lyp). |
+| `KLAYOUT_DEF_LAYER_MAP` | Points to klayout deflef layer map file (.map). |
+| `KLAYOUT_XOR_IGNORE_LAYERS` | A space separated layers list to ignore during klayout xor check. |
+| `MAGIC_MAGICRC` | Points to the magicrc file that is sourced while running magic in the flow. |
+| `GPIO_PADS_LEF` | A list of the pads lef views. For example:`[glob "$::env(PDK_ROOT)/sky130A/libs.ref/sky130_fd_io/lef/sky130_fd_io.lef"]` |
+| `GPIO_PADS_PREFIX` | A list of pad cells name prefixes. |
+| `NETGEN_SETUP_FILE` | Points to the setup file for netgen(lvs), that can exclude certain cells etc.. |
+| `FP_TAPCELL_DIST` | The distance between tapcell columns. Used in floorplanning in tapcell insertion. |
+| `DEFAULT_MAX_TRAN` | Defines the default maximum transition value, used in CTS & synthesis. |
+| `FP_PDN_RAIL_OFFSET` | Defines the rail offset for met1 used in PDN. <br> (Example: `0`) | |
+| `FP_PDN_HSPACING`  | The spacing between horizontal power/ground pair <br> (Default: `1.7`) |
+| `FP_PDN_VSPACING`  | The spacing between vertical power/ground pair <br> (Default: `1.7`) |
+| `FP_PDN_VOFFSET`  | The offset of the vertical power stripes on the metal layer 5 in the power distribution network <br> (Default: `16.32`) |
+| `FP_PDN_VPITCH`  | The pitch of the vertical power stripes on the metal layer 4 in the power distribution network <br> (Default: `153.6`) |
+| `FP_PDN_HOFFSET`  | The offset of the horizontal power stripes on the metal layer 5 in the power distribution network <br> (Default: `16.65`) |
+| `FP_PDN_HPITCH`  | The pitch of the horizontal power stripes on the metal layer 5 in the power distribution network <br> (Default: `153.18`) |
+| `FP_PDN_VWIDTH` | Defines the strap width for the vertical layer used in PDN. <br> (Example: `1.6`) | |
+| `FP_PDN_HWIDTH` | Defines the strap width for the horizontal layer used in PDN. <br> (Example: `1.6`) | |
+| `FP_PDN_CORE_RING_VWIDTH` | Defines the vertical width for the vertical layer used to create the core ring in the PDN. <br> (Example: `20`) | |
+| `FP_PDN_CORE_RING_HWIDTH` | Defines the horizontal width for the horizontal layer used to create the core ring in the PDN. <br> (Example: `20`) | |
+| `FP_PDN_CORE_RING_VSPACING` | Defines the spacing for the vertical layer used to create the core ring in the PDN. <br> (Example: `5`) | |
+| `FP_PDN_CORE_RING_HSPACING` | Defines the spacing for the horizontal layer used to create the core ring in the PDN. <br> (Example: `5`) | |
+| `FP_PDN_CORE_RING_VOFFSET` | Defines the offset for the vertical layer used to create the core ring in the PDN. <br> (Example: `20`) | |
+| `FP_PDN_CORE_RING_HOFFSET` | Defines the offset for the horizontal layer used to create the core ring in the PDN. <br> (Example: `20`) | |
+| `WIRE_RC_LAYER` | The metal layer used in estimate parastics `set_wire_rc`. <br> (Example: `met1`) ||
+| `GRT_LAYER_ADJUSTMENTS` | Layer-specific reductions in the routing capacity of the edges between the cells in the global routing graph, delimited by commas. Values range from 0 to 1. <br> (Example: `0.99,0,0,0,0,0`)
+| `FP_IO_HLAYER`  | The metal layer on which to place the io pins horizontally (top and bottom of the die). <br>(Example: `met3`)|
+| `FP_IO_VLAYER`  | The metal layer on which to place the io pins vertically (sides of the die) <br> (Example: `met2`)|
+| `FP_TAPCELL_DIST`  | The horizontal distance between two tapcell columns <br> (Default: `14`) |
+| `RT_MIN_LAYER`  | The lowest metal layer to route on. <br>(Example: `met1`)|
+| `RT_MAX_LAYER`  | The highest metal layer to route on. <br> (Example: `met5`)|
+| `RCX_RULES_MIN` | OpenRCX rules at the minimum corner. (Optional) |
+| `RCX_RULES` | OpenRCX rules at the nominal corner. |
+| `RCX_RULES_MAX` | OpenRCX rules at the maximum corner. (Optional) |
+| `WIRE_LENGTH_THRESHOLD` | A value in microns above which wire lengths generate warnings, and, if `QUIT_ON_LONG_WIRE` is set, the flow will error out. If a PDK does not set this value, the value is considered to be infinite. (Optional) |
+
+## SCL-specific variables
+
+This section defines the necessary variables to configure a standard cell library for use with OpenLane:
+
+| Variable      | Description                                                   |
+|---------------|---------------------------------------------------------------|
+| `LIB_SYNTH` | Points to the lib file used during synthesis. |
+| `LIB_SLOWEST` | Points to the lib file, corresponding to the slowest corner, for max delay calculation during STA. |
+| `LIB_FASTEST` | Points to the lib file, corresponding to the fastest corner, for min delay calculation during STA. |
+| `LIB_TYPICAL` | Points to the lib file for typical delay calculation during STA. |
+| `DFF_LIB_SYNTH` | Points to the lib file for used for dff mapping. If not specified, `LIB_SYNTH` is used. (Optional) |
+| `PLACE_SITE` | Defines the main site used by the cells. Used during floorplanning to generate the rows. |
+| `PLACE_SITE_WIDTH` | Defines the main site width. Used during floorplanning to generate the rows. |
+| `PLACE_SITE_HEIGHT` | Defines the main site height. Used during floorplanning to generate the rows. |
+| `FP_WELLTAP_CELL` | Defines the tapcell to be used in tapcell insertion. <br> If this is not defined then tapcell insertion will be skipped but the flow will resume normally |
+| `FP_ENDCAP_CELL` | Defines the decapcell. Inserted during floorplanning at the sides of the design. |
+| `SYNTH_DRIVING_CELL`  | The cell to drive the input ports, used in synthesis and static timing analysis. <br>(Example: `sky130_fd_sc_hd__inv_1`)|
+| `SYNTH_DRIVING_CELL_PIN`  | The name of the `SYNTH_DRIVING_CELL`'s output pin. <br>(Default: `Y`)|
+| `SYNTH_CLK_DRIVING_CELL`  | An alternative cell with which to drive clock inputs. Can be left empty, where the SDC script will use `SYNTH_DRIVING_CELL` for clock inputs as well. |
+| `SYNTH_CLK_DRIVING_CELL_PIN`  | The name of the SYNTH_CLK_DRIVING_CELL output pin. Can be left empty, where the SDC script will use `SYNTH_DRIVING_CELL_PIN`. |
+| `SYNTH_CAP_LOAD` | Defines the capacitive load on the output ports in femtofarads. Used in synthesis |
+| `SYNTH_MIN_BUF_PORT` | Defines the buffer, followed by its input port and output port to be used by `ins_buf` statements by yosys. It inserts buffer cells into the design for directly connected wires. <br> (Example: `sky130_fd_sc_hd__buf_2 A X`  )|
+| `SYNTH_TIEHI_PORT` | Defines the tie high cell followed by the port that implements the tie high functionality. Used in synthesis. <br> (Example: `sky130_fd_sc_hd__conb_1 HI`)|
+| `SYNTH_TIELO_PORT` | Defines the tie low cell followed by the port that implements the tie high functionality. Used in synthesis. <br> (Example: `sky130_fd_sc_hd__conb_1 LO`)|
+| `TRISTATE_CELL_PREFIX` | Prefix of tristate cells. Used with SYNTH_CHECKS_ALLOW_TRISTATE. <br> Example `sky130_fd_sc_hd__ebuf` |
+| `FILL_CELL` | Defines the fill cell. Used in fill insertion. Can use a wild card to define a class of cells. Example `sky130_fd_sc_hd__fill_*` |
+| `DECAP_CELL` | Defines the decap cell used for fill insertion. Can use a wild card to define a class of cells. Example `sky130_fd_sc_hd__fill_*` |
+| `DIODE_CELL_PIN` | Defines the `DIODE_CELL` pin. This is required if `DIODE_CELL` is defined |
+| `DIODE_CELL` | Defines the diode cell to be used during antenna violations fix step. <br> If this is not defined then the no antenna violations fixes will be attempted |
+| `GPL_CELL_PADDING` | Cell padding value (in sites) for global placement. <br> (Example: `2`) |
+| `DPL_CELL_PADDING` | Defines the number of sites to pad the cells with during detailed placement. This value should not be higher than `GPL_CELL_PADDING` unless you know what you're doing. <br> (Example: `2`) |
+| `CELL_PAD_EXCLUDE` | Defines the cells to exclude from padding for both detailed placement. |
+| `CTS_ROOT_BUFFER` | Defines the cell inserted at the root of the clock tree. Used in CTS. |
+| `CTS_CLK_BUFFER_LIST` | Defines the list of clock buffers to be used in CTS. |
+| `CTS_MAX_CAP` | Defines the maximum capacitance, used in CTS. |
+| `STD_CELL_POWER_PINS` | Defines power pins of stdcells. Used in PDN. |
+| `STD_CELL_GROUND_PINS` | Defines ground pins of stdcells. Used in PDN. |
+| `FP_PDN_HORIZONTAL_LAYER` | Defines the upper layer used in PDN. |
+| `FP_PDN_VERTICAL_LAYER` | Defines the lower layer used in PDN. |
+| `FP_PDN_RAIL_LAYER` | Defines the rail layer used in PDN. |
+| `FP_PDN_RAIL_WIDTH` | Defines the rail width for the rail layer used in PDN. |
+| `SYNTH_LATCH_MAP` | A pointer for the file containing the latch mapping for yosys. (Optional) |
+| `TRISTATE_BUFFER_MAP` | A pointer for the file containing the tri-state buffer mapping for yosys. (Optional) |
+| `CARRY_SELECT_ADDER_MAP` | A pointer for the file containing the carry-select adder mapping for Yosys. (Optional) |
+| `RIPPLE_CARRY_ADDER_MAP` | A pointer for the file containing the ripple-carry adder mapping for Yosys. (Optional) |
+| `FULL_ADDER_MAP` | A pointer for the file containing the full adder mapping for Yosys. (Optional) |
+| `NO_SYNTH_CELL_LIST` | Specifies the file that contains the don't-use-cell-list to be excluded from the liberty file during synthesis. See [this section](#no-synthesis-cells-file) for more information. |
+| `DRC_EXCLUDE_CELL_LIST` | Specifies the file that contains the don't-use-cell-list to be excluded from the liberty file during synthesis and timing optimizations. See [this section](#drc-exclude-cells-file) for more information. |
+| `CVC_SCRIPTS_DIR` | A directory of Circuit Validity Checker (CVC) scripts for the relevant PDK. Must contain the following set of files: `cvcrc`, an initialization file, `cdl.awk`, an awk script to remove black box definitions from SPICE files, `models`, cell models, and finally `power.awk`, an awk script that adds power information to the verilog netlists. |
+| `STD_CELL_LIBRARY_CDL` | A pointer for the cdl view of the SCL. |
+| `LAYERS_RC` | A comma separated list specifying capacitance and resistance per layer. Variable should be provided in the following format. `<layer_name> <capacitance> <resistance>, <layer_name> ...` ([warning](../configuration.md#on-comma-delimited-variables)) (Optional) |
+| `VIAS_RC` | A comma separated list specifying capacitance -only- of vias. Variable should be provided in the following format. `<layer_name> <capacitance> , <layer_name> ...` ([warning](../configuration.md#on-comma-delimited-variables)) (Optional) |
+
+## Tracks Info File
+
+The tracks files defines the metal layers pitches and offsets. This information
+should be extracted from the PDK's tech lef. The file should be an EOL-delimited
+set of lines formatted as follows:
+
+```
+<layer name> X|Y <offset> <pitch>
+```
+
+## DRC Exclude Cells File
+
+Some cells may be excluded from PnR entirely- due to hard-to-access pin shapes
+and/or the cells simply being invalid (DRC violations.)
+
+```{note}
+For sky130, the "lpflow" cells were also excluded because the flow is unable
+to handle them properly and create a keep-alive power (KAPWR) supply.
+```
+
+The file is formatted as an EOL-delimited list of cell names (wildcards and
+the like not supported.)
+
+## No Synthesis Cells File
+
+Some cells may be furtherexcluded from synthesis, for reasons including but not
+limited to the following:
+
+* Excluded from PnR, i.e., part of the DRC Exclude Cells.
+* Clock Buffers: They are balanced and may introduce too much of a delay when
+  not used for clock trees as part of CTS.
+* Cells without default mapping: Cannot be used by Yosys.
+* Smaller cell sizes: Prevents under-estimating the required floorplan.
+  The resizer may later choose to use them.
+
+The file is formatted as an EOL-delimited list of cell names (wildcards and
+the like not supported.)
+
+All cells excluded from PnR are also excluded from Synthesis.

--- a/scripts/generate_reports.py
+++ b/scripts/generate_reports.py
@@ -65,7 +65,7 @@ def cli(design, design_name, tag, run_path, output_file, man_report):
         os.path.join(run_path, "reports", "routing"), "antenna_violators.rpt"
     )
     _, arc_antenna_report = get_name(
-        os.path.join(run_path, "logs", "signoff"), "antenna.log"
+        os.path.join(run_path, "logs", "signoff"), "arc.log"
     )
     _, magic_drc_report = get_name(
         os.path.join(run_path, "reports", "signoff"), "drc.rpt"

--- a/scripts/report/report.py
+++ b/scripts/report/report.py
@@ -499,7 +499,7 @@ class Report(object):
                     klayout_violations += 1
 
         # Antenna Violations
-        arc_antenna_report = Artifact(rp, "logs", "signoff", "antenna.log")
+        arc_antenna_report = Artifact(rp, "logs", "signoff", "arc.log")
         aar_content = arc_antenna_report.get_content()
 
         pin_antenna_violations = -1

--- a/scripts/tcl_commands/all.tcl
+++ b/scripts/tcl_commands/all.tcl
@@ -617,48 +617,52 @@ proc prep {args} {
     set ::env(OPENLANE_VERBOSE) $arg_values(-verbose)
 
     # DEPRECATED CONFIGS
+    ## Flow
+    handle_diode_insertion_strategy
+
     handle_deprecated_config SYNTH_TOP_LEVEL SYNTH_ELABORATE_ONLY;
-    handle_deprecated_config LIB_MIN LIB_FASTEST;
-    handle_deprecated_config LIB_MAX LIB_SLOWEST;
+
+    handle_deprecated_config VERILATOR_RELATIVE_INCLUDES LINTER_RELATIVE_INCLUDES
 
     handle_deprecated_config FP_HORIZONTAL_HALO FP_PDN_HORIZONTAL_HALO;
     handle_deprecated_config FP_VERTICAL_HALO FP_PDN_VERTICAL_HALO;
 
-    handle_deprecated_config CELL_PAD_EXECLUDE CELL_PAD_EXCLUDE;
+    handle_deprecated_config LIB_RESIZER_OPT RSZ_LIB
+    handle_deprecated_config UNBUFFER_NETS RSZ_DONT_TOUCH_RX
 
-    handle_deprecated_config GLB_RT_ALLOW_CONGESTION GRT_ALLOW_CONGESTION;
-    handle_deprecated_config GLB_RT_OVERFLOW_ITERS GRT_OVERFLOW_ITERS;
-    handle_deprecated_config GLB_RT_ANT_ITERS GRT_ANT_ITERS;
-    handle_deprecated_config GLB_RT_ESTIMATE_PARASITICS GRT_ESTIMATE_PARASITICS;
-    handle_deprecated_config GLB_RT_MAX_DIODE_INS_ITERS GRT_MAX_DIODE_INS_ITERS;
-    handle_deprecated_config GLB_RT_OBS GRT_OBS;
-    handle_deprecated_config GLB_RT_ADJUSTMENT GRT_ADJUSTMENT;
-    handle_deprecated_config GLB_RT_MACRO_EXTENSION GRT_MACRO_EXTENSION;
-    handle_deprecated_config GLB_RT_LAYER_ADJUSTMENTS GRT_LAYER_ADJUSTMENTS;
-
-    handle_deprecated_config TAP_DECAP_INSERTION RUN_TAP_DECAP_INSERTION;
-    handle_deprecated_config RUN_ROUTING_DETAILED RUN_DRT; # Why the hell is this even an option?
-    handle_deprecated_config FILL_INSERTION RUN_FILL_INSERTION;
-
-    handle_deprecated_config SYNTH_CLOCK_UNCERTAINITY SYNTH_CLOCK_UNCERTAINTY;
-
-    handle_deprecated_config LIB_RESIZER_OPT RSZ_LIB;
-    handle_deprecated_config UNBUFFER_NETS RSZ_DONT_TOUCH_RX;
-
+    ### Checkers/Quitting
     handle_deprecated_config CHECK_ASSIGN_STATEMENTS QUIT_ON_ASSIGN_STATEMENTS
     handle_deprecated_config CHECK_UNMAPPED_CELLS QUIT_ON_UNMAPPED_CELLS
+    handle_deprecated_config QUIT_ON_VERILATOR_WARNINGS QUIT_ON_LINTER_WARNINGS
+    handle_deprecated_config QUIT_ON_VERILATOR_ERRORS QUIT_ON_LINTER_ERRORS
 
+    ### Flow Control
     handle_deprecated_config CLOCK_TREE_SYNTH RUN_CTS
+    handle_deprecated_config TAP_DECAP_INSERTION RUN_TAP_DECAP_INSERTION
+    handle_deprecated_config RUN_ROUTING_DETAILED RUN_DRT
+    handle_deprecated_config FILL_INSERTION RUN_FILL_INSERTION
+    handle_deprecated_config RUN_VERILATOR RUN_LINTER
+
+    ### PDN
     handle_deprecated_config FP_PDN_RAILS_LAYER FP_PDN_RAIL_LAYER
     handle_deprecated_config FP_PDN_UPPER_LAYER FP_PDN_HORIZONTAL_LAYER
     handle_deprecated_config FP_PDN_LOWER_LAYER FP_PDN_VERTICAL_LAYER
     handle_deprecated_config PDN_CFG FP_PDN_CFG
-    handle_deprecated_config QUIT_ON_VERILATOR_WARNINGS QUIT_ON_LINTER_WARNINGS
-    handle_deprecated_config QUIT_ON_VERILATOR_ERRORS QUIT_ON_LINTER_ERRORS
-    handle_deprecated_config RUN_VERILATOR RUN_LINTER
-    handle_deprecated_config VERILATOR_RELATIVE_INCLUDES LINTER_RELATIVE_INCLUDES
 
-    handle_diode_insertion_strategy
+    ### GLB_RT -> GRT (Document using ‡)
+    handle_deprecated_config GLB_RT_ALLOW_CONGESTION GRT_ALLOW_CONGESTION
+    handle_deprecated_config GLB_RT_OVERFLOW_ITERS GRT_OVERFLOW_ITERS
+    handle_deprecated_config GLB_RT_ANT_ITERS GRT_ANT_ITERS
+    handle_deprecated_config GLB_RT_ESTIMATE_PARASITICS GRT_ESTIMATE_PARASITICS
+    handle_deprecated_config GLB_RT_MAX_DIODE_INS_ITERS GRT_MAX_DIODE_INS_ITERS
+    handle_deprecated_config GLB_RT_OBS GRT_OBS
+    handle_deprecated_config GLB_RT_ADJUSTMENT GRT_ADJUSTMENT
+    handle_deprecated_config GLB_RT_MACRO_EXTENSION GRT_MACRO_EXTENSION
+    handle_deprecated_config GLB_RT_LAYER_ADJUSTMENTS GRT_LAYER_ADJUSTMENTS
+
+    ### Spelling (No need to document)
+    handle_deprecated_config CELL_PAD_EXECLUDE CELL_PAD_EXCLUDE
+    handle_deprecated_config SYNTH_CLOCK_UNCERTAINITY SYNTH_CLOCK_UNCERTAINTY
 
     #
     ############################
@@ -1189,7 +1193,7 @@ proc write_verilog {args} {
 proc run_or_antenna_check {args} {
     increment_index
     TIMER::timer_start
-    set log [index_file $::env(signoff_logs)/antenna.log]
+    set log [index_file $::env(signoff_logs)/arc.log]
 
     puts_info "Running OpenROAD Antenna Rule Checker (log: [relpath . $log])..."
 

--- a/scripts/tcl_commands/magic.tcl
+++ b/scripts/tcl_commands/magic.tcl
@@ -210,7 +210,7 @@ proc export_magic_view {args} {
 proc run_magic_antenna_check {args} {
     increment_index
     TIMER::timer_start
-    set log [index_file $::env(signoff_logs)/antenna.log]
+    set log [index_file $::env(signoff_logs)/magic_antenna.log]
     puts_info "Running Magic Antenna Checks (log: [relpath . $log])..."
 
     set feedback_file [index_file $::env(signoff_reports)/antenna.feedback.txt]


### PR DESCRIPTION
```
~ Rename `antenna.log` to `arc.log` and `magic_antenna.log` to avoid confusion
~ Separate PDK porting instructions and PDK variables
~ Add deprecated variables to documentation
~ Make existing deprecated variable documentation formatting-consistent and with replacement instructions
- Remove defaults from deprecated variables (they don't have any)
- Remove `LIB_MIN`/`LIB_MAX`: enough time has passed and PDK variables are annoying to deprecate
```