### PR TITLE
Enhance antenna violations report

### DIFF
--- a/scripts/extract_antenna_violators.py
+++ b/scripts/extract_antenna_violators.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 import re
 import click
 
@@ -33,10 +32,29 @@ class AntennaViolation:
 
 
 @click.command()
-@click.option("-o", "--output", required=True, help="Output file to store results.")
-@click.option("--plain-out", default=False, help="Only outputs a list of violating pins")
+@click.option(
+    "-o",
+    "--output",
+    required=True,
+    type=click.Path(
+        exists=False,
+        dir_okay=False,
+        writable=True,
+    ),
+    help="Output file to store results.",
+)
+@click.option(
+    "--plain-out",
+    type=click.Path(
+        exists=False,
+        dir_okay=False,
+        writable=True,
+    ),
+    default=None,
+    help="If provided, outputs violator pins in a plain, EOL-delimited format to the path specified.",
+)
 @click.argument("report", nargs=1)
-def extract_antenna_violators(output, report, plain_out):
+def extract_antenna_violators(output, plain_out, report):
     """
     Usage: extract_antenna_violators.py -o <output text file> <input ARC report>
     Extracts the list of violating nets from an ARC report file"
@@ -91,12 +109,13 @@ def extract_antenna_violators(output, report, plain_out):
     violations.sort(reverse=True)
     with open(output, "w") as f:
         for violation in violations:
-            if plain_out:
-                print(violation.pin)
+            print(violation)
+            f.write(f"{violation}\n")
+
+    if plain_out is not None:
+        with open(plain_out, "w") as f:
+            for violation in violations:
                 f.write(f"{violation.pin}\n")
-            else:
-                print(violation)
-                f.write(f"{violation}\n")
 
 
 if __name__ == "__main__":

--- a/scripts/extract_antenna_violators.py
+++ b/scripts/extract_antenna_violators.py
@@ -34,8 +34,9 @@ class AntennaViolation:
 
 @click.command()
 @click.option("-o", "--output", required=True, help="Output file to store results.")
+@click.option("--plain-out", default=False, help="Only outputs a list of violating pins")
 @click.argument("report", nargs=1)
-def extract_antenna_violators(output, report):
+def extract_antenna_violators(output, report, plain_out):
     """
     Usage: extract_antenna_violators.py -o <output text file> <input ARC report>
     Extracts the list of violating nets from an ARC report file"
@@ -90,8 +91,12 @@ def extract_antenna_violators(output, report):
     violations.sort(reverse=True)
     with open(output, "w") as f:
         for violation in violations:
-            print(f"{violation}")
-            f.write(f"{violation}\n")
+            if plain_out:
+                print(violation.pin)
+                f.write(f"{violation.pin}\n")
+            else:
+                print(violation)
+                f.write(f"{violation}\n")
 
 
 if __name__ == "__main__":

--- a/scripts/tcl_commands/all.tcl
+++ b/scripts/tcl_commands/all.tcl
@@ -1200,8 +1200,11 @@ proc run_or_antenna_check {args} {
     run_openroad_script $::env(SCRIPTS_DIR)/openroad/antenna_check.tcl -indexed_log $log
 
     set antenna_violators_rpt [index_file $::env(signoff_reports)/antenna_violators.rpt]
+    set antenna_violators_plain [index_file $::env(signoff_reports)/antenna_violators.txt]
+
     try_exec python3 $::env(SCRIPTS_DIR)/extract_antenna_violators.py\
         --output $antenna_violators_rpt\
+        --plain-out $antenna_violators_plain\
         $log
 
     set ::env(ANTENNA_VIOLATOR_LIST) $antenna_violators_rpt

--- a/scripts/tcl_commands/all.tcl
+++ b/scripts/tcl_commands/all.tcl
@@ -1200,7 +1200,7 @@ proc run_or_antenna_check {args} {
     run_openroad_script $::env(SCRIPTS_DIR)/openroad/antenna_check.tcl -indexed_log $log
 
     set antenna_violators_rpt [index_file $::env(signoff_reports)/antenna_violators.rpt]
-    set antenna_violators_plain [index_file $::env(signoff_reports)/antenna_violators.txt]
+    set antenna_violators_plain [index_file $::env(signoff_reports)/antenna_violators_pins.txt]
 
     try_exec python3 $::env(SCRIPTS_DIR)/extract_antenna_violators.py\
         --output $antenna_violators_rpt\


### PR DESCRIPTION
Include the following information:
```
+ required ratio
+ partial ratio
+ violating pin
+ violating net
+ metal layer
```
Old behavior of printing only a list of violating pins is kept with a CLI flag `--plain-out`. However it prints a list of violating pins instead of a list of violating nets because violating pins is more accurate as a net can have one or more violating pins.