### PR TITLE
remove `unset_propagated_clock` 

### DIFF
--- a/scripts/openroad/floorplan.tcl
+++ b/scripts/openroad/floorplan.tcl
@@ -16,8 +16,6 @@ read_libs -typical "$::env(LIB_SYNTH_COMPLETE)"
 read_lef $::env(MERGED_LEF)
 read_netlist
 
-unset_propagated_clock [all_clocks]
-
 set bottom_margin  [expr $::env(PLACE_SITE_HEIGHT) * $::env(BOTTOM_MARGIN_MULT)]
 set top_margin  [expr $::env(PLACE_SITE_HEIGHT) * $::env(TOP_MARGIN_MULT)]
 set left_margin [expr $::env(PLACE_SITE_WIDTH) * $::env(LEFT_MARGIN_MULT)]

--- a/scripts/openroad/resizer.tcl
+++ b/scripts/openroad/resizer.tcl
@@ -20,8 +20,6 @@ if { $::env(RSZ_MULTICORNER_LIB) } {
 lappend read_args -lib_typical $::env(RSZ_LIB)
 read {*}$read_args
 
-unset_propagated_clock [all_clocks]
-
 # set rc values
 source $::env(SCRIPTS_DIR)/openroad/common/set_rc.tcl
 

--- a/scripts/openroad/sta/multi_corner.tcl
+++ b/scripts/openroad/sta/multi_corner.tcl
@@ -54,13 +54,6 @@ if { [info exists ::env(ESTIMATE_PARASITICS)]} {
     estimate_parasitics {*}$::env(ESTIMATE_PARASITICS)
 }
 
-if { $::env(STA_PRE_CTS) } {
-    if { [info exists ::env(DEBUG)] && $::env(DEBUG) } {
-        puts "sta pre cts"
-    }
-    unset_propagated_clock [all_clocks]
-}
-
 puts "min_report"
 puts "\n==========================================================================="
 puts "report_checks -path_delay min (Hold)"


### PR DESCRIPTION
removed `unset_propagated_clock` from:
1- `/scripts/openroad/floorplan.tcl`
2- `/scripts/openroad/resizer.tcl`
3- `/scripts/openroad/sta/multi_corner.tcl`

To avoid using a generated SDC that doesn't include `set_propagated_clock` in signoff STA. Further review is in the works to determine if the removed commands are required.
