### PR TITLE
Rename `mca` folders

### DIFF
--- a/scripts/report/report.py
+++ b/scripts/report/report.py
@@ -241,9 +241,18 @@ class Report(object):
             ("rsz_timing", Artifact(rp, "logs", "routing", "rsz_timing_sta.log")),
             ("grt", Artifact(rp, "logs", "routing", "grt_sta.log")),
             ("rcx", Artifact(rp, "logs", "signoff", "rcx_sta.log")),
-            ("sta-rcx_nom/signoff", Artifact(rp, "logs", "signoff", "rcx_mcsta.nom.log")),
-            ("sta-rcx_min/signoff", Artifact(rp, "logs", "signoff", "rcx_mcsta.min.log")),
-            ("sta-rcx_max/signoff", Artifact(rp, "logs", "signoff", "rcx_mcsta.max.log")),
+            (
+                "sta-rcx_nom/multi_corner",
+                Artifact(rp, "logs", "signoff", "rcx_mcsta.nom.log"),
+            ),
+            (
+                "sta-rcx_min/multi_corner",
+                Artifact(rp, "logs", "signoff", "rcx_mcsta.min.log"),
+            ),
+            (
+                "sta-rcx_max/multi_corner",
+                Artifact(rp, "logs", "signoff", "rcx_mcsta.max.log"),
+            ),
         ]:
             generate_report_args = [
                 (name + report_postfix, report_locus)

--- a/scripts/report/report.py
+++ b/scripts/report/report.py
@@ -98,7 +98,6 @@ class Artifact(object):
             self.index = "X"
         for report in args:
             filename = f"{self.index}-{report[0]}"
-            print(filename, report)
             locus = report[1]
             self.log_to_report(filename, locus)
 

--- a/scripts/report/report.py
+++ b/scripts/report/report.py
@@ -98,6 +98,7 @@ class Artifact(object):
             self.index = "X"
         for report in args:
             filename = f"{self.index}-{report[0]}"
+            print(filename, report)
             locus = report[1]
             self.log_to_report(filename, locus)
 
@@ -240,9 +241,9 @@ class Report(object):
             ("rsz_timing", Artifact(rp, "logs", "routing", "rsz_timing_sta.log")),
             ("grt", Artifact(rp, "logs", "routing", "grt_sta.log")),
             ("rcx", Artifact(rp, "logs", "signoff", "rcx_sta.log")),
-            ("mca/rcx_nom", Artifact(rp, "logs", "signoff", "rcx_mcsta.nom.log")),
-            ("mca/rcx_min", Artifact(rp, "logs", "signoff", "rcx_mcsta.min.log")),
-            ("mca/rcx_max", Artifact(rp, "logs", "signoff", "rcx_mcsta.max.log")),
+            ("sta-rcx_nom/signoff", Artifact(rp, "logs", "signoff", "rcx_mcsta.nom.log")),
+            ("sta-rcx_min/signoff", Artifact(rp, "logs", "signoff", "rcx_mcsta.min.log")),
+            ("sta-rcx_max/signoff", Artifact(rp, "logs", "signoff", "rcx_mcsta.max.log")),
         ]:
             generate_report_args = [
                 (name + report_postfix, report_locus)


### PR DESCRIPTION
```
~ rename mca folders from `mca` to `sta-<corner>`.
~ rename sta files prefix from `<corner>` to `multi_corner`.
```
Proposed tree:
```
├── 26-sta-rcx_min/
│  ├── multi_corner_sta.checks.rpt
│  ├── multi_corner_sta.max.rpt
│  ├── multi_corner_sta.min.rpt
│  ├── multi_corner_sta.power.rpt
│  ├── multi_corner_sta.skew.rpt
│  └── multi_corner_sta.summary.rpt
├── 28-sta-rcx_max/
│  ├── multi_corner_sta.checks.rpt
│  ├── multi_corner_sta.max.rpt
│  ├── multi_corner_sta.min.rpt
│  ├── multi_corner_sta.power.rpt
│  ├── multi_corner_sta.skew.rpt
│  └── multi_corner_sta.summary.rpt
├── 30-sta-rcx_nom/
│  ├── multi_corner_sta.checks.rpt
│  ├── multi_corner_sta.max.rpt
│  ├── multi_corner_sta.min.rpt
│  ├── multi_corner_sta.power.rpt
│  ├── multi_corner_sta.skew.rpt
│  └── multi_corner_sta.summary.rpt
```
Previous tree:
```
├── 26-mca/
│  ├── rcx_min_sta.checks.rpt
│  ├── rcx_min_sta.max.rpt
│  ├── rcx_min_sta.min.rpt
│  ├── rcx_min_sta.power.rpt
│  ├── rcx_min_sta.skew.rpt
│  └── rcx_min_sta.summary.rpt
├── 28-mca/
│  ├── rcx_max_sta.checks.rpt
│  ├── rcx_max_sta.max.rpt
│  ├── rcx_max_sta.min.rpt
│  ├── rcx_max_sta.power.rpt
│  ├── rcx_max_sta.skew.rpt
│  └── rcx_max_sta.summary.rpt
├── 30-mca/
│  ├── rcx_nom_sta.checks.rpt
│  ├── rcx_nom_sta.max.rpt
│  ├── rcx_nom_sta.min.rpt
│  ├── rcx_nom_sta.power.rpt
│  ├── rcx_nom_sta.skew.rpt
│  └── rcx_nom_sta.summary.rpt
```
---
Fixes https://github.com/The-OpenROAD-Project/OpenLane/issues/1921