### PR TITLE
OpenROAD python `read_def` api updates

### DIFF
--- a/dependencies/tool_metadata.yml
+++ b/dependencies/tool_metadata.yml
@@ -65,7 +65,7 @@
   in_install: false
 - name: openroad_app
   repo: https://github.com/The-OpenROAD-Project/OpenROAD
-  commit: 41a51eaf4ca2171c92ff38afb91eb37bbd3f36da
+  commit: 0cfb9a45bfb256c9af1a0500d4c97da0f145f54f
   in_install: false
 - name: git
   repo: https://github.com/git/git

--- a/scripts/odbpy/defutil.py
+++ b/scripts/odbpy/defutil.py
@@ -90,7 +90,7 @@ def move_diearea(target_db, input_lef, template_def):
     source_db = odb.dbDatabase.create()
 
     odb.read_lef(source_db, input_lef)
-    odb.read_def(source_db, template_def)
+    odb.read_def(source_db.getTech(), template_def)
 
     assert (
         source_db.getTech().getManufacturingGrid()
@@ -166,7 +166,7 @@ def relocate_pins(db, input_lef, template_def):
     # --------------------------------
     template_db = odb.dbDatabase.create()
     odb.read_lef(template_db, input_lef)
-    odb.read_def(template_db, template_def)
+    odb.read_def(template_db.getTech(), template_def)
     template_bterms = template_db.getChip().getBlock().getBTerms()
 
     assert (

--- a/scripts/odbpy/reader.py
+++ b/scripts/odbpy/reader.py
@@ -34,7 +34,7 @@ class OdbReader(object):
             for lef in lef_in:
                 odb.read_lef(self.db, lef)
             if def_in is not None:
-                odb.read_def(self.db, def_in)
+                odb.read_def(self.db.getTech(), def_in)
 
         self.tech = self.db.getTech()
         self.chip = self.db.getChip()


### PR DESCRIPTION
bump openroad version
update openroad python odb read_def api usage to pass tech instead of odb object based on https://github.com/The-OpenROAD-Project/OpenLane/issues/1925

---
Fixes https://github.com/The-OpenROAD-Project/OpenLane/issues/1925