### PR TITLE
Syntax Validation for IO and Macro Placement

### DIFF
--- a/scripts/odbpy/manual_macro_place.py
+++ b/scripts/odbpy/manual_macro_place.py
@@ -94,7 +94,9 @@ def manual_macro_place(reader, config, fixed):
             line_number += 1
             if not line:
                 continue
-            validate_syntax(line, f"[ERROR]: MACRO_PLACEMENT_CFG file line {line_number}: ")
+            validate_syntax(
+                line, f"[ERROR]: MACRO_PLACEMENT_CFG file line {line_number}: "
+            )
             line = line.split()
             macros[line[0]] = [
                 str(int(float(line[1]) * db_units_per_micron)),

--- a/scripts/odbpy/manual_macro_place.py
+++ b/scripts/odbpy/manual_macro_place.py
@@ -12,6 +12,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import sys
+
 import click
 
 from reader import click_odb
@@ -43,6 +45,28 @@ def gridify(n, f):
     return round(n / f) * f
 
 
+def validate_syntax(line, error_prefix):
+    line = line.split()
+    error = ""
+
+    if len(line) != 4:
+        error = f"{error_prefix}Expected 4 elements found {len(line)}"
+    try:
+        float(line[1])
+    except ValueError:
+        error = print(f"{error_prefix}Expected an x coordinate found '{line[1]}'")
+    try:
+        float(line[2])
+    except ValueError:
+        error = print(f"{error_prefix}Expected a y coordinate found '{line[2]}'")
+    if line[3] not in list(LEF2OA_MAP.keys()) + list(LEF2OA_MAP.values()):
+        error = f"{error_prefix}Expected an orientation found '{line[3]}'"
+
+    if error != "":
+        print(error)
+        sys.exit(-1)
+
+
 @click.command()
 @click.option("-c", "--config", required=True, help="Configuration file")
 @click.option(
@@ -62,12 +86,15 @@ def manual_macro_place(reader, config, fixed):
 
     # read config
     macros = {}
+    line_number = 0
     with open(config, "r") as config_file:
         for line in config_file:
             # Discard comments and empty lines
             line = line.split("#")[0].strip()
+            line_number += 1
             if not line:
                 continue
+            validate_syntax(line, f"[ERROR]: MACRO_PLACEMENT_CFG file line {line_number}: ")
             line = line.split()
             macros[line[0]] = [
                 str(int(float(line[1]) * db_units_per_micron)),

--- a/scripts/odbpy/manual_macro_place.py
+++ b/scripts/odbpy/manual_macro_place.py
@@ -50,17 +50,17 @@ def validate_syntax(line, error_prefix):
     error = ""
 
     if len(line) != 4:
-        error = f"{error_prefix}Expected 4 elements found {len(line)}"
+        error = f"{error_prefix}Expected 4 elements. Found {len(line)}"
     try:
         float(line[1])
     except ValueError:
-        error = print(f"{error_prefix}Expected an x coordinate found '{line[1]}'")
+        error = print(f"{error_prefix}Expected an x coordinate. Found '{line[1]}'")
     try:
         float(line[2])
     except ValueError:
-        error = print(f"{error_prefix}Expected a y coordinate found '{line[2]}'")
+        error = print(f"{error_prefix}Expected a y coordinate. Found '{line[2]}'")
     if line[3] not in list(LEF2OA_MAP.keys()) + list(LEF2OA_MAP.values()):
-        error = f"{error_prefix}Expected an orientation found '{line[3]}'"
+        error = f"{error_prefix}Expected an orientation. Found '{line[3]}'"
 
     if error != "":
         print(error)
@@ -128,7 +128,7 @@ def manual_macro_place(reader, config, fixed):
                 inst.setPlacementStatus("PLACED")
             del macros[inst_name]
 
-    assert not macros, ("Macros not found:", macros)
+    assert not macros, ("[ERROR]: Macros not found:", macros)
 
     print(f"Successfully placed {macros_cnt} instances.")
 


### PR DESCRIPTION
+ Add validation for `@min_distance` in `io_place.py`
+ Validate the following syntax for macro placement configuration files
    `<non_whitespace> <float> <float> <ORIENTATION>`
~ Make error and warning messages format of `io_place.py` consistent with the rest of OpenLane scripts