### PR TITLE
Create directory store_dir regardless of enable_timestamp value

### DIFF
--- a/run_designs.py
+++ b/run_designs.py
@@ -196,7 +196,7 @@ def cli(
         store_dir = f"./regression_results/{tag}"
         report_file_name = f"{store_dir}/{tag}"
 
-        utils.mkdirp(store_dir)
+    utils.mkdirp(store_dir)
 
     log = logging.getLogger("log")
     log_formatter = logging.Formatter("%(asctime)s | %(message)s", "%Y-%m-%d %H:%M")


### PR DESCRIPTION
By default, enable_timestamp is True.
Logger handler1 will blame for opening file report_file_name 
 since store_dir is not created priorly.
Adjust the indent of the line of mkdirp to solve the logic error.