### PR TITLE
fix synthesis `chparam` issue

### DIFF
--- a/scripts/yosys/elaborate.tcl
+++ b/scripts/yosys/elaborate.tcl
@@ -73,6 +73,7 @@ show -format dot -prefix $::env(synthesis_tmpfiles)/hierarchy
 select -clear
 
 hierarchy -check -top $vtop
+yosys rename -top $vtop
 if { $::env(SYNTH_FLAT_TOP) } {
 	flatten
 }

--- a/scripts/yosys/synth.tcl
+++ b/scripts/yosys/synth.tcl
@@ -225,11 +225,13 @@ if { [info exists ::env(SYNTH_PARAMETERS) ] } {
     }
 }
 
+
 select -module $vtop
 show -format dot -prefix $::env(synthesis_tmpfiles)/hierarchy
 select -clear
 
 hierarchy -check -top $vtop
+yosys rename -top $vtop
 
 # Infer tri-state buffers.
 set tbuf_map false


### PR DESCRIPTION
~ Rename top level module to retain the name after synth params applied