### PR TITLE
add -skip_io and iterate io and global placement

### DIFF
--- a/configuration/floorplan.tcl
+++ b/configuration/floorplan.tcl
@@ -30,7 +30,7 @@ set ::env(FP_PDN_ENABLE_RAILS) 1
 set ::env(FP_PDN_CHECK_NODES) 1
 set ::env(FP_PDN_IRDROP) 1
 
-set ::env(FP_IO_MODE) 1; # 0 matching mode - 1 random equidistant mode
+set ::env(FP_IO_MODE) 0; # 0 matching mode - 1 random equidistant mode
 set ::env(FP_IO_HLENGTH) 4
 set ::env(FP_IO_VLENGTH) 4
 set ::env(FP_IO_VEXTEND) 0

--- a/docs/source/reference/configuration.md
+++ b/docs/source/reference/configuration.md
@@ -119,7 +119,7 @@ files you may be depending on, including headers, in `VERILOG_FILES`.
 | `FP_SIZING` <a id="FP_SIZING"></a>  | Whether to use relative sizing by making use of `FP_CORE_UTIL` or absolute one using `DIE_AREA`. <br> (Default: `"relative"` - accepts `"absolute"` as well)|
 | `DIE_AREA` <a id="DIE_AREA"></a>  | Specific die area to be used in floorplanning when `FP_SIZING` is set to `absolute`. Specified as a 4-corner rectangle "x0 y0 x1 y1". Units in μm <br> (Default: unset)|
 | `CORE_AREA` <a id="CORE_AREA"></a> | Specific core area (i.e. die area minus margins) to be used in floorplanning when `FP_SIZING` is set to `absolute`. Specified as a 4-corner rectangle "x0 y0 x1 y1". Units in μm <br> (Default: unset)|
-| `FP_IO_MODE` <a id="FP_IO_MODE"></a>  | Decides the mode of the random IO placement option. 0=matching mode, 1=random equidistant mode <br> (Default: `1`)|
+| `FP_IO_MODE` <a id="FP_IO_MODE"></a>  | Decides the mode of the random IO placement option. 0=matching mode, 1=random equidistant mode. Matching mode attempts to optimize pin and cell placement. Random equidistant mode places equidistant pins with a random order <br> (Default: `0`)|
 | `FP_WELLTAP_CELL` <a id="FP_WELLTAP_CELL"></a>  | The name of the welltap cell during welltap insertion. |
 | `FP_ENDCAP_CELL` <a id="FP_ENDCAP_CELL"></a>  | The name of the endcap cell during endcap insertion. |
 | `FP_PDN_CFG` <a id="FP_PDN_CFG"></a> | Points to a PDN configuration file that describes how to construct the PDN in detail. <br> (Default: `scripts/openroad/common/pdn_cfg.tcl`) |

--- a/scripts/openroad/gpl.tcl
+++ b/scripts/openroad/gpl.tcl
@@ -61,6 +61,10 @@ if { $::env(PL_SKIP_INITIAL_PLACEMENT) && !$::env(PL_BASIC_PLACEMENT) } {
 	lappend arg_list -skip_initial_place
 }
 
+if { [info exists ::env(__PL_SKIP_IO)] } {
+    lappend arg_list -skip_io
+}
+
 set cell_pad_side [expr $::env(GPL_CELL_PADDING) / 2]
 
 lappend arg_list -pad_right $cell_pad_side

--- a/scripts/or_issue.py
+++ b/scripts/or_issue.py
@@ -249,10 +249,8 @@ def issue(
 
                     value_substituted = full.replace(accessor, value)
 
-                    if (
-                        value_substituted.endswith(".tcl")
-                        or value_substituted.endswith(".sdc")
-                        or value_substituted.endswith(".py")
+                    if value_substituted.endswith(".tcl") or value_substituted.endswith(
+                        ".sdc"
                     ):
                         if value_substituted not in tcls:
                             tcls.add(value_substituted)

--- a/scripts/or_issue.py
+++ b/scripts/or_issue.py
@@ -249,8 +249,10 @@ def issue(
 
                     value_substituted = full.replace(accessor, value)
 
-                    if value_substituted.endswith(".tcl") or value_substituted.endswith(
-                        ".sdc"
+                    if (
+                        value_substituted.endswith(".tcl")
+                        or value_substituted.endswith(".sdc")
+                        or value_substituted.endswith(".py")
                     ):
                         if value_substituted not in tcls:
                             tcls.add(value_substituted)

--- a/scripts/tcl_commands/floorplan.tcl
+++ b/scripts/tcl_commands/floorplan.tcl
@@ -181,14 +181,26 @@ proc place_io_ol {args} {
 }
 
 proc place_io {args} {
+    set options {
+        {-log optional}
+        {-outdir optional}
+        {-name optional}
+    }
+    set flags {}
+    parse_key_args "place-io" args arg_values $options flags_map $flags
+
+    set_if_unset arg_values(-name) io
+    set_if_unset arg_values(-log) $::env(floorplan_logs)/io.log
+    set_if_unset arg_values(-outdir) $::env(floorplan_tmpfiles)
+
     increment_index
     TIMER::timer_start
-    set log [index_file $::env(floorplan_logs)/io.log]
-    puts_info "Running IO Placement..."
+    set log [index_file $arg_values(-log)]
+    puts_info "Running IO Placement (log: [relpath . $log])..."
 
     run_openroad_script $::env(SCRIPTS_DIR)/openroad/ioplacer.tcl\
-        -indexed_log [index_file $::env(floorplan_logs)/io.log]\
-        -save "to=$::env(floorplan_tmpfiles),name=io,def,odb"
+        -indexed_log $log\
+        -save "to=$arg_values(-outdir),name=$arg_values(-name),def,odb"
 
     TIMER::timer_stop
     exec echo "[TIMER::get_runtime]" | python3 $::env(SCRIPTS_DIR)/write_runtime.py "ioplace - openroad"

--- a/scripts/tcl_commands/placement.tcl
+++ b/scripts/tcl_commands/placement.tcl
@@ -190,7 +190,7 @@ proc run_placement {args} {
             global_placement_or -skip_io -name global_skip_io -log $::env(placement_logs)/global_skip_io.log
             place_io -outdir $::env(placement_tmpfiles) -log $::env(placement_logs)/io.log
         }
-        global_placement
+        global_placement_or
     }
 
     run_resizer_design


### PR DESCRIPTION
~ Set default `FP_IO_MODE` to 0.
~ Better `FP_IO_MODE` documentation.
~ Change the behavior of `FP_IO_MODE` 0:
1. Run global placement with `-skip_io` flag. 
2. Run io placement (again).
3. Run global placement.

If `FP_IO_MODE` is 1, steps 1 and 2 are skipped. 

~ Change tcl functions `global_placement_or` and `place_io` to allow for the changes mentioned above.