### PR TITLE
Adding the option the use welltap-less PDK

### DIFF
--- a/scripts/openroad/tapcell.tcl
+++ b/scripts/openroad/tapcell.tcl
@@ -14,11 +14,22 @@
 source $::env(SCRIPTS_DIR)/openroad/common/io.tcl
 read
 
-tapcell\
-    -distance $::env(FP_TAPCELL_DIST)\
-    -tapcell_master "$::env(FP_WELLTAP_CELL)"\
-    -endcap_master "$::env(FP_ENDCAP_CELL)"\
-    -halo_width_x $::env(FP_TAP_HORIZONTAL_HALO)\
-    -halo_width_y $::env(FP_TAP_VERTICAL_HALO)
+if { ![info exists  ::env(FP_WELLTAP_CELL)] || $::env(FP_WELLTAP_CELL) eq ""} {
+    place_endcaps\
+        -left_edge "$::env(FP_ENDCAP_CELL)"\
+        -right_edge "$::env(FP_ENDCAP_CELL)"
+
+    cut_rows\
+        -endcap_master "$::env(FP_ENDCAP_CELL)"\
+        -halo_width_x $::env(FP_TAP_HORIZONTAL_HALO)\
+        -halo_width_y $::env(FP_TAP_VERTICAL_HALO)
+} else {
+    tapcell\
+        -distance $::env(FP_TAPCELL_DIST)\
+        -tapcell_master "$::env(FP_WELLTAP_CELL)"\
+        -endcap_master "$::env(FP_ENDCAP_CELL)"\
+        -halo_width_x $::env(FP_TAP_HORIZONTAL_HALO)\
+        -halo_width_y $::env(FP_TAP_VERTICAL_HALO)
+}
 
 write

--- a/scripts/tcl_commands/floorplan.tcl
+++ b/scripts/tcl_commands/floorplan.tcl
@@ -247,8 +247,7 @@ proc place_contextualized_io {args} {
 
 proc tap_decap_or {args} {
     if { ![info exists  ::env(FP_WELLTAP_CELL)] || $::env(FP_WELLTAP_CELL) eq ""} {
-        puts_warn "No tap cells found for this standard cell library. Skipping Tap/Decap insertion."
-        return
+        puts_info "No tap cells found for this standard cell library. Decap insertion only."
     }
 
     increment_index


### PR DESCRIPTION
Some PDKs don't have welltaps as dedicated cells, typically high voltage technologies with isolation wells. I have slightly modified the scripts such that if no tapcells are defined, it still inserts the decap cells instead of skipping the step altogether.

I am not certain if the `place_endcaps` commands should be placed before or after the `cut_rows` command, but it appears to work for me as it is.