### PR TITLE
Support VERILOG_INCLUDE_DIRS in linter

### DIFF
--- a/scripts/tcl_commands/synthesis.tcl
+++ b/scripts/tcl_commands/synthesis.tcl
@@ -308,6 +308,15 @@ proc run_verilator {} {
         lappend arg_list {*}$output_file
     }
     lappend arg_list {*}$::env(VERILOG_FILES)
+    
+    set incdirs ""
+    if { [info exists ::env(VERILOG_INCLUDE_DIRS)] } {
+        foreach incdir $::env(VERILOG_INCLUDE_DIRS) {
+            set incdirs "$incdirs +incdir+$incdir"
+        }
+    }
+    lappend arg_list {*}$incdirs
+
     lappend arg_list -Wno-fatal
     if { $::env(LINTER_RELATIVE_INCLUDES) } {
         lappend arg_list "--relative-includes"


### PR DESCRIPTION
Adds support for `VERILOG_INCLUDE_DIRS` option to Verilator linter (in `synthesis.tcl` command `run_verilator`)

This option is already supported in synthesis by yosys, so it would be nice if it would also work with linter. Without it, some designs that are synthesized fine, cannot pass the linter.

If preferred, this option could be renamed to `LINTER_INCLUDE_DIRS`, as a independent option from yosys one. I'm not sure which one would fit better.