### PR TITLE
Fix missing ReadTheDocs content

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,6 +10,7 @@ build:
   tools:
     python: "3.10"
   commands:
+    - git submodule update --init
     - pip3 install -r ./docs/requirements.txt
     - cd docs && python3 -m sphinx.cmd.build -M html "source" "_build"
     - mv docs/_build _readthedocs


### PR DESCRIPTION
~ Add submodules to ReadTheDocs builds, as there are references to files in submodules (CI configurations, netlists, etc)