### PR TITLE
Updated link to newer version of spanish docs

### DIFF
--- a/docs/source/additional_material.md
+++ b/docs/source/additional_material.md
@@ -22,7 +22,7 @@ Additionally, we are also going to link to academic publications about OpenLane 
 - [RgGen ✕ OpenMPWでLSIを焼こう！](https://vlsi.jp/RgGenxOpenMPW.html)
 
 #### Español
-- [Tutoriales de OpenLane/OpenROAD](https://erickcb.github.io/)
+- [Tutoriales de OpenLane/OpenROAD](https://lima-ucr.github.io/)
 
 ## Videos
 - [Aboard Caravel, Ahmed Ghazy](https://www.youtube.com/watch?v=9QV8SDelURk)


### PR DESCRIPTION
I worked on adding documentation to OpenLane in Spanish using a more visually appealing website, and providing a translation of the openlane configuration parameters.  I only updating the link, the website used to come from "erickcb", my personal github account, but it is now from "lima-ucr", the account for the laboratory I run at Universidad de Costa Rica