### PR TITLE
Remove SYNTH_READ_BLACKBOX_LIB

### DIFF
--- a/configuration/synthesis.tcl
+++ b/configuration/synthesis.tcl
@@ -27,7 +27,6 @@ set ::env(SYNTH_SIZING) 0
 set ::env(SYNTH_STRATEGY) "AREA 0"
 set ::env(SYNTH_ADDER_TYPE) "YOSYS"
 set ::env(CLOCK_BUFFER_FANOUT) 16
-set ::env(SYNTH_READ_BLACKBOX_LIB) 0
 set ::env(SYNTH_FLAT_TOP) 0
 set ::env(IO_PCT) 0.2
 set ::env(SYNTH_EXTRA_MAPPING_FILE) ""

--- a/docs/source/reference/configuration.md
+++ b/docs/source/reference/configuration.md
@@ -85,7 +85,6 @@ files you may be depending on, including headers, in `VERILOG_FILES`.
 | `SYNTH_STRATEGY` <a id="SYNTH_STRATEGY"></a> | Strategies for abc logic synthesis and technology mapping <br> Possible values are `DELAY/AREA 0-4/0-3`; the first part refers to the optimization target of the synthesis strategy (area vs. delay) and the second one is an index. <br> (Default: `AREA 0`)|
 | `SYNTH_BUFFERING` <a id="SYNTH_BUFFERING"></a> | Enables abc cell buffering <br> Enabled = 1, Disabled = 0 <br> (Default: `1`)|
 | `SYNTH_SIZING` <a id="SYNTH_SIZING"></a> | Enables abc cell sizing (instead of buffering) <br> Enabled = 1, Disabled = 0 <br> (Default: `0`)|
-| `SYNTH_READ_BLACKBOX_LIB` <a id="SYNTH_READ_BLACKBOX_LIB"></a> | A flag that enable reading the full(untrimmed) liberty file as a blackbox for synthesis. Please note that this is not used in technology mapping. This should only be used when trying to preserve gate instances in the rtl of the design.  <br> Enabled = 1, Disabled = 0 <br> (Default: `0`)|
 | `SYNTH_NO_FLAT` <a id="SYNTH_NO_FLAT"></a> | A flag that disables flattening the hierarchy during synthesis, only flattening it after synthesis, mapping and optimizations. <br> Enabled = 1, Disabled = 0 <br> (Default: `0`)|
 | `SYNTH_SHARE_RESOURCES` <a id="SYNTH_SHARE_RESOURCES"></a> | A flag that enables yosys to reduce the number of cells by determining shareable resources and merging them. <br> Enabled = 1, Disabled = 0 <br> (Default: `1`)|
 | `SYNTH_ABC_LEGACY_REFACTOR` <a id="SYNTH_ABC_LEGACY_REFACTOR"></a> | Replaces the ABC command `drf -l` with `refactor` which matches older versions of OpenLane but is more unstable.  <br> Enabled = 1, Disabled = 0 <br> (Default: `0`) |
@@ -102,6 +101,7 @@ files you may be depending on, including headers, in `VERILOG_FILES`.
 | `SYNTH_TOP_LEVEL` <a id="SYNTH_TOP_LEVEL"></a> | **Deprecated: Use `SYNTH_ELABORATE_ONLY`**: "Elaborate" the design only without attempting any logic mapping. Useful when dealing with structural Verilog netlists. |
 | `SYNTH_MAX_FANOUT` <a id="SYNTH_MAX_FANOUT"></a>  | **Deprecated: Use the PDK's `MAX_FANOUT_CONSTRAINT` value**: The max load that the output ports can drive. |
 | `SYNTH_MAX_TRAN` <a id="SYNTH_MAX_TRAN"></a> |  **Deprecated: Use the PDK's `MAX_TRANSITION_CONSTRAINT` value**: The max transition time (slew) from high to low or low to high on cell inputs in ns. If unset, the library's default maximum transition time will be used. |
+| `SYNTH_READ_BLACKBOX_LIB` <a id="SYNTH_READ_BLACKBOX_LIB"></a> | **Removed: The liberty file is always read now. A flag that enable reading the full(untrimmed) liberty file as a blackbox for synthesis. Please note that this is not used in technology mapping. This should only be used when trying to preserve gate instances in the rtl of the design.  <br> Enabled = 1, Disabled = 0 <br> (Default: `0`)|
 ## Static Timing Analysis (STA)
 
 | Variable | Description |

--- a/docs/source/usage/chip_integration.md
+++ b/docs/source/usage/chip_integration.md
@@ -36,7 +36,6 @@ You need to set the following environment variables in your configuration file f
 | `EXTRA_LEFS` | LEF files for pre-hardened macros you incorporate into your design. |
 | `EXTRA_LIBS` | Specifies LIB files of pre-hardened macros used in the current design, used to improve timing analysis. (Optional) |
 | `EXTRA_GDS_FILES` | GDS files for pre-hardened macros you incorporate into your design. |
-| `SYNTH_READ_BLACKBOX_LIB` | `1/0` (Tcl), `true/false` (JSON): Should be set to true if you are using any standard cells directly in your design, i.e., your design does not function purely at the register transfer level. |
 | `MACRO_PLACEMENT_CFG` | A path to a file containing a line-break delimited list of instances and positions if you want to manually place the macros in specific locations, in the format `instance_name X_pos Y_pos Orientation`. The [`manual_macro_placement_test` example][9] under designs should be a good example. |
 > \* The ``` `include ``` directive is not supported.
 

--- a/scripts/tcl_commands/synthesis.tcl
+++ b/scripts/tcl_commands/synthesis.tcl
@@ -35,10 +35,6 @@ proc run_yosys {args} {
     set_if_unset arg_values(-output) $::env(synthesis_results)/$::env(DESIGN_NAME).v
     set_if_unset arg_values(-indexed_log) /dev/null
 
-    if { [ info exists ::env(SYNTH_ADDER_TYPE)] && ($::env(SYNTH_ADDER_TYPE) in [list "RCA" "CSA"]) } {
-        set ::env(SYNTH_READ_BLACKBOX_LIB) 1
-    }
-
     set ::env(synth_report_prefix) [index_file $::env(synthesis_reports)/synthesis]
 
     set ::env(LIB_SYNTH_COMPLETE_NO_PG) [list]

--- a/scripts/yosys/elaborate.tcl
+++ b/scripts/yosys/elaborate.tcl
@@ -22,10 +22,8 @@ set gl_ext      ".gl.v"
 set timing_ext  ".timing.txt"
 set abc_ext     ".abc"
 
-if { $::env(SYNTH_READ_BLACKBOX_LIB) } {
-	foreach lib $::env(LIB_SYNTH_COMPLETE_NO_PG) {
-		read_liberty -lib -ignore_miss_dir -setattr blackbox $lib
-	}
+foreach lib $::env(LIB_SYNTH) {
+    read_liberty -lib -ignore_miss_dir -setattr blackbox $lib
 }
 
 if { [info exists ::env(EXTRA_LIBS) ] } {

--- a/scripts/yosys/elaborate.tcl
+++ b/scripts/yosys/elaborate.tcl
@@ -22,7 +22,7 @@ set gl_ext      ".gl.v"
 set timing_ext  ".timing.txt"
 set abc_ext     ".abc"
 
-foreach lib $::env(LIB_SYNTH) {
+foreach lib $::env(LIB_SYNTH_COMPLETE) {
     read_liberty -lib -ignore_miss_dir -setattr blackbox $lib
 }
 

--- a/scripts/yosys/synth.tcl
+++ b/scripts/yosys/synth.tcl
@@ -40,11 +40,8 @@ if {[info exist ::env(VERILOG_INCLUDE_DIRS)]} {
     set vIdirsArgs [join $vIdirsArgs]
 }
 
-if { $::env(SYNTH_READ_BLACKBOX_LIB) } {
-    log "Reading $::env(LIB_SYNTH_COMPLETE_NO_PG) as a blackbox"
-    foreach lib $::env(LIB_SYNTH_COMPLETE_NO_PG) {
-        read_liberty -lib -ignore_miss_dir -setattr blackbox $lib
-    }
+foreach lib $::env(LIB_SYNTH) {
+    read_liberty -lib -ignore_miss_dir -setattr blackbox $lib
 }
 
 if { [info exists ::env(EXTRA_LIBS) ] } {

--- a/scripts/yosys/synth.tcl
+++ b/scripts/yosys/synth.tcl
@@ -40,7 +40,7 @@ if {[info exist ::env(VERILOG_INCLUDE_DIRS)]} {
     set vIdirsArgs [join $vIdirsArgs]
 }
 
-foreach lib $::env(LIB_SYNTH) {
+foreach lib $::env(LIB_SYNTH_COMPLETE) {
     read_liberty -lib -ignore_miss_dir -setattr blackbox $lib
 }
 


### PR DESCRIPTION
Always read `LIB_SYNTH_COMPLETE` in Yosys scripts

---

Fixes https://github.com/The-OpenROAD-Project/OpenLane/issues/2098