### PR TITLE
Defer compilation of AST of verilog files read in by Yosys till all the files are read

### DIFF
--- a/scripts/yosys/elaborate.tcl
+++ b/scripts/yosys/elaborate.tcl
@@ -68,11 +68,11 @@ if { [info exists ::env(SYNTH_PARAMETERS) ] } {
 	}
 }
 
+hierarchy -check -top $vtop
 select -module $vtop
 show -format dot -prefix $::env(synthesis_tmpfiles)/hierarchy
 select -clear
 
-hierarchy -check -top $vtop
 yosys rename -top $vtop
 if { $::env(SYNTH_FLAT_TOP) } {
 	flatten

--- a/scripts/yosys/elaborate.tcl
+++ b/scripts/yosys/elaborate.tcl
@@ -57,7 +57,7 @@ if { [info exists ::env(VERILOG_FILES_BLACKBOX)] } {
 
 
 for { set i 0 } { $i < [llength $::env(VERILOG_FILES)] } { incr i } {
-	read_verilog {*}$vIdirsArgs [lindex $::env(VERILOG_FILES) $i]
+	read_verilog -defer {*}$vIdirsArgs [lindex $::env(VERILOG_FILES) $i]
 }
 
 if { [info exists ::env(SYNTH_PARAMETERS) ] } {

--- a/scripts/yosys/synth.tcl
+++ b/scripts/yosys/synth.tcl
@@ -223,7 +223,7 @@ if { !($adder_type in [list "YOSYS" "FA" "RCA" "CSA"]) } {
 
 # Start Synthesis
 for { set i 0 } { $i < [llength $::env(VERILOG_FILES)] } { incr i } {
-    read_verilog -sv {*}$vIdirsArgs [lindex $::env(VERILOG_FILES) $i]
+    read_verilog -defer -sv {*}$vIdirsArgs [lindex $::env(VERILOG_FILES) $i]
 }
 
 if { [info exists ::env(SYNTH_PARAMETERS) ] } {
@@ -235,11 +235,11 @@ if { [info exists ::env(SYNTH_PARAMETERS) ] } {
 }
 
 
+hierarchy -check -top $vtop
 select -module $vtop
 show -format dot -prefix $::env(synthesis_tmpfiles)/hierarchy
 select -clear
 
-hierarchy -check -top $vtop
 yosys rename -top $vtop
 
 # Infer tri-state buffers.


### PR DESCRIPTION
Add `-defer` to read_verilog and run `hierarchy -check -top $vtop` after all the Verilog files are read 

---

Fixes #2094