### PR TITLE
Purge`odb.dbDatabase.create`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -142,16 +142,16 @@
         "volare": "volare"
       },
       "locked": {
-        "lastModified": 1719911213,
-        "narHash": "sha256-rd4nqjpwNwqcpKGMx6QN6cX/2MjVt24I5CL9/QE45iM=",
+        "lastModified": 1722786339,
+        "narHash": "sha256-eU9EXz2QaLegqwp1NUod7eyOLoA8nry+2h69avqd5TU=",
         "owner": "efabless",
         "repo": "openlane2",
-        "rev": "315e8a220fc7327c4d146b9101b5dc5325862d58",
+        "rev": "129fc2211fd6e51d6a6e899ff010d6ae675739ee",
         "type": "github"
       },
       "original": {
         "owner": "efabless",
-        "ref": "dev",
+        "ref": "2.1.1",
         "repo": "openlane2",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -22,7 +22,7 @@
   };
 
   inputs = {
-    openlane2.url = github:efabless/openlane2/dev;
+    openlane2.url = github:efabless/openlane2/2.1.1;
   };
 
   outputs = {
@@ -50,8 +50,14 @@
               };
               openroad = pkgs.openroad.override {
                 # openroad-rev-sha
+                # https://github.com/The-OpenROAD-Project/OpenROAD/discussions/4743
                 openroad-abc = self.openroad-abc;
                 opensta = self.opensta;
+              };
+              magic = pkgs.magic.override {
+                # https://github.com/RTimothyEdwards/magic/issues/317
+                rev = "8.3.478";
+                sha256 = "sha256-aFFKbSqIgpkYjFZfpW3C52N1yQc5+KiLyf5jC16K5UU=";
               };
               openlane1 = callPythonPackage ./default.nix {};
               default = self.openlane1;
@@ -63,13 +69,5 @@
             });
         in
           self);
-
-    # devShells = self.forAllSystems (
-    #   pkgs: let
-    #     callPackage = pkgs.lib.callPackageWith (pkgs // self.packages.${pkgs.system});
-    #     callPythonPackage = pkgs.lib.callPackageWith (pkgs // pkgs.python3.pkgs // self.packages.${pkgs.system});
-    #   in rec {
-    #   }
-    # );
   };
 }

--- a/scripts/odbpy/defutil.py
+++ b/scripts/odbpy/defutil.py
@@ -87,10 +87,7 @@ cli.add_command(merge_components)
 
 
 def move_diearea(target_db, input_lef, template_def):
-    source_db = odb.dbDatabase.create()
-
-    odb.read_lef(source_db, input_lef)
-    odb.read_def(source_db.getTech(), template_def)
+    source_db = OdbReader(input_lef, template_def).db
 
     assert (
         source_db.getTech().getManufacturingGrid()
@@ -164,9 +161,7 @@ def relocate_pins(db, input_lef, template_def):
     # --------------------------------
     # 2. Read the donor def
     # --------------------------------
-    template_db = odb.dbDatabase.create()
-    odb.read_lef(template_db, input_lef)
-    odb.read_def(template_db.getTech(), template_def)
+    template_db = OdbReader(input_lef, template_def).db
     template_bterms = template_db.getChip().getBlock().getBTerms()
 
     assert (

--- a/scripts/odbpy/reader.py
+++ b/scripts/odbpy/reader.py
@@ -28,8 +28,7 @@ class OdbReader(object):
 
     def __init__(self, *args):
         if primary := OdbReader.primary_reader:
-            self.db = odb.dbDatabase.create()
-            self.db.setLogger(primary.design.getLogger())
+            self.db = primary.design.createDetachedDb()
         else:
             self.ord_tech = Tech()
             self.design = Design(self.ord_tech)

--- a/tests/1007-buffer_insertion/hooks/post_run.py
+++ b/tests/1007-buffer_insertion/hooks/post_run.py
@@ -14,7 +14,6 @@
 
 import os
 import odb
-import odb
 from openroad import Tech, Design
 
 ord_tech = Tech()

--- a/tests/1007-buffer_insertion/hooks/post_run.py
+++ b/tests/1007-buffer_insertion/hooks/post_run.py
@@ -14,8 +14,12 @@
 
 import os
 import odb
+import odb
+from openroad import Tech, Design
 
-db = odb.dbDatabase.create()
+ord_tech = Tech()
+design = Design(ord_tech)
+db = ord_tech.getDB()
 odb.read_db(db, os.getenv("CURRENT_ODB"))
 instances = db.getChip().getBlock().getInsts()
 buffers = [

--- a/tests/1413-odb_remover/hooks/post_run.py
+++ b/tests/1413-odb_remover/hooks/post_run.py
@@ -14,8 +14,11 @@
 
 import os
 import odb
+from openroad import Tech, Design
 
-db = odb.dbDatabase.create()
+ord_tech = Tech()
+design = Design(ord_tech)
+db = ord_tech.getDB()
 odb.read_db(db, os.getenv("CURRENT_ODB"))
 nets = db.getChip().getBlock().getNets()
 pins = db.getChip().getBlock().getBTerms()

--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -124,7 +124,7 @@ def run_test_case(test_case):
 
         result = subprocess.Popen(
             [
-                "flow.tcl",
+                os.path.join(openlane_root, "flow.tcl"),
                 "-design",
                 test_case,
                 "-verbose",


### PR DESCRIPTION
~ Synchronize tool versions with OpenLane 2.1.1.
~ Downgrade Magic to 8.3.478: See https://github.com/RTimothyEdwards/magic/issues/317
~ Purge `odb.dbDatabase.create` from the codebase: See https://github.com/The-OpenROAD-Project/OpenROAD/discussions/4743