### PR TITLE
superstable: Support latest PDK for September shuttle 

### DIFF
--- a/.github/test_sets/test_sets.yml
+++ b/.github/test_sets/test_sets.yml
@@ -25,18 +25,18 @@
     - ./designs/ci/PPU
     - ./designs/ci/y_huff
     - ./designs/ci/aes
-- scl: gf180mcuC/gf180mcu_fd_sc_mcu7t5v0
-  name: fastest_test_set
-  designs:
-    - spm
-    - ./designs/ci/APU
-    - ./designs/ci/usb
-    # - usb_cdc_core
-    # - zipdiv
-    # - wbqspiflash
-- scl: gf180mcuC/gf180mcu_fd_sc_mcu7t5v0
-  name: extended_test_set
-  designs:
-    - ./designs/ci/picorv32a
-    - ./designs/ci/PPU
-    - ./designs/ci/y_huff
+# - scl: gf180mcuC/gf180mcu_fd_sc_mcu7t5v0
+#   name: fastest_test_set
+#   designs:
+#     - spm
+#     - ./designs/ci/APU
+#     - ./designs/ci/usb
+#     # - usb_cdc_core
+#     # - zipdiv
+#     # - wbqspiflash
+# - scl: gf180mcuC/gf180mcu_fd_sc_mcu7t5v0
+#   name: extended_test_set
+#   designs:
+#     - ./designs/ci/picorv32a
+#     - ./designs/ci/PPU
+#     - ./designs/ci/y_huff

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The short version is, to install the OpenLane environment...
 
 1. [Get Docker](https://docs.docker.com/get-docker/) (or a compatible container engine)
     * On Ubuntu, follow the [Docker post install instructions](https://docs.docker.com/engine/install/linux-postinstall/) after you install Docker.
-2. Get Python 3.6 or higher ([macOS](https://formulae.brew.sh/formula/python3) | [Ubuntu](https://packages.ubuntu.com/focal/python3))
+2. Get a version between Python 3.6 and Python 3.10: ([macOS](https://formulae.brew.sh/formula/python3) | [Ubuntu](https://packages.ubuntu.com/focal/python3))
     * On Ubuntu, you may also need to install venv: `apt-get install python3-venv`, and pip: `apt-get install python3-pip`.
 3. Get git ([macOS](https://formulae.brew.sh/formula/git) | [Ubuntu](https://packages.ubuntu.com/focal/git))
 4. Get GNU Make ([macOS](https://formulae.brew.sh/formula/make) | [Ubuntu](https://packages.ubuntu.com/focal/make))

--- a/dependencies/tool_metadata.yml
+++ b/dependencies/tool_metadata.yml
@@ -73,6 +73,6 @@
   in_install: false
 - name: open_pdks
   repo: https://github.com/RTimothyEdwards/open_pdks
-  commit: 78b7bc32ddb4b6f14f76883c2e2dc5b5de9d1cbc
+  commit: 0fe599b2afb6708d281543108caf8310912f54af
   in_install: false
   pdk: true

--- a/docs/source/reference/pdk_configuration.md
+++ b/docs/source/reference/pdk_configuration.md
@@ -63,13 +63,15 @@ you're doing.
 | `GPIO_PADS_PREFIX` | A list of pad cells name prefixes. |
 | `NETGEN_SETUP_FILE` | Points to the setup file for netgen(lvs), that can exclude certain cells etc.. |
 | `FP_TAPCELL_DIST` | The distance between tapcell columns. Used in floorplanning in tapcell insertion. |
-| `WIRE_RC_LAYER` | The metal layer used in estimate parastics `set_wire_rc`. <br> (Example: `met1`) |
+| `DATA_WIRE_RC_LAYER` | The metal layer used in estimate parastics `set_wire_rc`. <br> (Example: `met2`) |
+| `CLOCK_WIRE_RC_LAYER` | The metal layer used in estimate parastics `set_wire_rc`. <br> (Example: `met5`) |
 | `FP_IO_HLAYER`  | The metal layer on which to place the io pins horizontally (top and bottom of the die). <br>(Example: `met3`)|
 | `FP_IO_VLAYER`  | The metal layer on which to place the io pins vertically (sides of the die) <br> (Example: `met2`)|
 | `FP_TAPCELL_DIST`  | The horizontal distance between two tapcell columns <br> (Default: `14`) |
 | `RCX_RULES_MIN` | OpenRCX rules at the minimum corner. (Optional) |
 | `RCX_RULES` | OpenRCX rules at the nominal corner. |
 | `RCX_RULES_MAX` | OpenRCX rules at the maximum corner. (Optional) |
+| `WIRE_RC_LAYER` | **Deprecated: Use `DATA_WIRE_RC_LAYER` and `CLOCK_WIRE_RC_LAYER`** The metal layer used in estimate parastics `set_wire_rc`. |
 
 ## SCL-specific variables
 

--- a/scripts/openroad/common/set_rc.tcl
+++ b/scripts/openroad/common/set_rc.tcl
@@ -35,7 +35,9 @@ if { [info exist ::env(LAYERS_RC)] } {
     }
 }
 
-if { [info exist ::env(WIRE_RC_LAYER)] } {
-    set_wire_rc -signal -layer $::env(WIRE_RC_LAYER)
-    set_wire_rc -clock -layer $::env(WIRE_RC_LAYER)
+if { [info exist ::env(DATA_WIRE_RC_LAYER)] } {
+    set_wire_rc -signal -layer $::env(DATA_WIRE_RC_LAYER)
+}
+if { [info exist ::env(CLOCK_WIRE_RC_LAYER)] } {
+    set_wire_rc -clock -layer $::env(CLOCK_WIRE_RC_LAYER)
 }

--- a/scripts/tcl_commands/all.tcl
+++ b/scripts/tcl_commands/all.tcl
@@ -621,6 +621,7 @@ proc prep {args} {
     handle_deprecated_pdk_config SYNTH_MAX_TRAN MAX_TRANSITION_CONSTRAINT
     handle_deprecated_pdk_config SYNTH_MAX_FANOUT MAX_FANOUT_CONSTRAINT
     handle_deprecated_pdk_config SYNTH_CAP_LOAD OUTPUT_CAP_LOAD
+    handle_deprecated_pdk_config WIRE_RC_LAYER DATA_WIRE_RC_LAYER
 
     ## Flow
     handle_diode_insertion_strategy


### PR DESCRIPTION
~ backported `wire rc` changes to superstable version so it can work with later PDKs

---

Upon merge, the tag `2023.07.19-2` will be created.