### PR TITLE
bugfix: Replaced inappropriate `is` comparison with `==`

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -66,7 +66,7 @@ def gui(viewer, format, run_dir, stage):
         extra_config = {}
         if stage is not None:
             matches = glob.glob(os.path.join(run_dir, "results", stage, f"*.{format}"))
-            if matches is []:
+            if matches == []:
                 err(f"No {format} found for stage {stage}")
             else:
                 extra_config[f"CURRENT_{format.upper()}"] = matches[0]


### PR DESCRIPTION
## Introduction
This PR fixes a logical bug in your codebase


## Description
In file [gui.py](https://github.com/The-OpenROAD-Project/OpenLane/blob/master/gui.py#L69), there's a comparison that compares an empty list to an object using `is` operator. This is not the correct way to compare objects with empty list or dict.

For example, running the code below will give the output:
```
x = []
print(x is [])
```
```
False
```

As a result, it's better to perform comparison using `==` operator than `is`.


## Contribution
All contributions made in this PR follows [Developer Certificate of Origin](https://developercertificate.org)


## Comments
If you think such fixes aren't necessary for your project, and you'd like me to find some better bugs / code-to-fix, then please let me know. I'll be happy to contribute.
